### PR TITLE
fix: renew session cookie so active users stay logged in

### DIFF
--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -5,7 +5,7 @@ const { JWT } = require("jose")
 const cookie = require("cookie")
 
 const NETLIFY_JWT_EXPIRATION_SECONDS = 14 * 24 * 3600
-// cookie's maxAge is in seconds, not milliseconds
+// cookie's maxAge is in seconds
 const LOGIN_COOKIE_MAX_AGE = 30 * 60
 const AUTH0_LOGIN_COOKIE_NAME = "auth0_login_cookie"
 const NETLIFY_COOKIE_NAME = "nf_jwt"

--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -5,7 +5,8 @@ const { JWT } = require("jose")
 const cookie = require("cookie")
 
 const NETLIFY_JWT_EXPIRATION_SECONDS = 14 * 24 * 3600
-const LOGIN_COOKIE_MAX_AGE = 30 * 60 * 1000
+// cookie's maxAge is in seconds, not milliseconds
+const LOGIN_COOKIE_MAX_AGE = 30 * 60
 const AUTH0_LOGIN_COOKIE_NAME = "auth0_login_cookie"
 const NETLIFY_COOKIE_NAME = "nf_jwt"
 const isRunningLocally = process.env.NETLIFY_DEV === "true"
@@ -19,21 +20,18 @@ const getOpenIDClient = async () => {
   })
 }
 
-const generateNetlifyJWT = async (tokenData) => {
+//Refer to Netlify Documentation for token formatting - https://docs.netlify.com/visitor-access/role-based-access-control/#external-providers
+const signNetlifyJWT = async ({ aud, sub, roles }) => {
   const iat = Math.floor(Date.now() / 1000)
   const exp = Math.floor(iat + NETLIFY_JWT_EXPIRATION_SECONDS)
-  //copy over appropriate properties from the original token data
-  //Refer to Netlify Documentation for token formatting - https://docs.netlify.com/visitor-access/role-based-access-control/#external-providers
   const tokenPayload = {
     exp,
     iat,
     updated_at: iat,
-    aud: tokenData.aud,
-    sub: tokenData.sub,
+    aud,
+    sub,
     app_metadata: {
-      authorization: {
-        roles: tokenData[`${process.env.AUTH0_TOKEN_NAMESPACE}/roles`],
-      },
+      authorization: { roles },
     },
   }
   return await JWT.sign(tokenPayload, process.env.TOKEN_SECRET, {
@@ -44,6 +42,14 @@ const generateNetlifyJWT = async (tokenData) => {
   })
 }
 
+//copy over appropriate properties from the original token data
+const generateNetlifyJWT = (tokenData) =>
+  signNetlifyJWT({
+    aud: tokenData.aud,
+    sub: tokenData.sub,
+    roles: tokenData[`${process.env.AUTH0_TOKEN_NAMESPACE}/roles`],
+  })
+
 const generateAuth0LoginCookie = (nonce, encodedStateStr) => {
   const cookieData = { nonce, state: encodedStateStr }
   return cookie.serialize(AUTH0_LOGIN_COOKIE_NAME, JSON.stringify(cookieData), {
@@ -51,6 +57,10 @@ const generateAuth0LoginCookie = (nonce, encodedStateStr) => {
     path: "/",
     maxAge: LOGIN_COOKIE_MAX_AGE,
     httpOnly: true,
+    // Auth0 posts the callback back to us cross-site (response_mode: form_post),
+    // so the browser only sends this cookie along if it is SameSite=None.
+    // That requires Secure, hence the fallback for plain http local dev.
+    sameSite: isRunningLocally ? "lax" : "none",
   })
 }
 
@@ -78,13 +88,25 @@ const generateLogoutCookie = () => {
   })
 }
 
-const generateNetlifyCookieFromAuth0Token = async (tokenData) => {
-  const netlifyToken = await generateNetlifyJWT(tokenData)
-  return cookie.serialize(NETLIFY_COOKIE_NAME, netlifyToken, {
+const generateNetlifyCookie = (netlifyToken) =>
+  cookie.serialize(NETLIFY_COOKIE_NAME, netlifyToken, {
     secure: !isRunningLocally,
     path: "/",
     maxAge: NETLIFY_JWT_EXPIRATION_SECONDS,
   })
+
+const generateNetlifyCookieFromAuth0Token = async (tokenData) =>
+  generateNetlifyCookie(await generateNetlifyJWT(tokenData))
+
+const getNetlifyJWTFromEvent = (event) => {
+  const authHeader = event.headers?.authorization
+  if (authHeader) {
+    return authHeader.replace("Bearer ", "")
+  }
+  const cookieHeader = event.headers?.cookie
+  return cookieHeader
+    ? cookie.parse(cookieHeader)[NETLIFY_COOKIE_NAME]
+    : undefined
 }
 
 const generateAuth0LogoutUrl = () => {
@@ -173,6 +195,53 @@ const handleCallback = async (event) => {
   }
 }
 
+/* Re-issues the nf_jwt cookie with a fresh expiry so that an active session
+   slides forward instead of hard-expiring NETLIFY_JWT_EXPIRATION_SECONDS after
+   login. The frontend calls this once the current token is past halfway
+   through its lifetime. */
+const handleRenew = async (event) => {
+  const currentToken = getNetlifyJWTFromEvent(event)
+  if (!currentToken) {
+    return {
+      statusCode: 401,
+      headers: { "Cache-Control": "no-store" },
+      body: JSON.stringify({ error: "Not logged in" }),
+    }
+  }
+
+  let claims
+  try {
+    /* A token still inside its renewal window verifies fine, so a failure here
+       means the session is genuinely over and the user has to log in again. */
+    claims = JWT.verify(currentToken, process.env.TOKEN_SECRET)
+  } catch (err) {
+    return {
+      statusCode: 401,
+      headers: {
+        "Cache-Control": "no-store",
+        "Set-Cookie": generateLogoutCookie(),
+      },
+      body: JSON.stringify({ error: "Session expired" }),
+    }
+  }
+
+  const renewedToken = await signNetlifyJWT({
+    aud: claims.aud,
+    sub: claims.sub,
+    roles: claims.app_metadata?.authorization?.roles,
+  })
+
+  return {
+    statusCode: 200,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json",
+      "Set-Cookie": generateNetlifyCookie(renewedToken),
+    },
+    body: JSON.stringify({ token: renewedToken }),
+  }
+}
+
 const handleLogout = async () => {
   return {
     statusCode: 302,
@@ -188,4 +257,5 @@ module.exports = {
   handleLogin,
   handleCallback,
   handleLogout,
+  handleRenew,
 }

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -2,7 +2,7 @@
 const responses = require('../utils/responses')
 const { matchVerbAndNumberOfUrlSegments, } = require('../router')
 const { getUrlSegments } = require('../controllers/utils')
-const { handleLogout, handleLogin, handleCallback } = require('../controllers/auth')
+const { handleLogout, handleLogin, handleCallback, handleRenew } = require('../controllers/auth')
 const { match } = require('ts-pattern')
 
 /** @type Handler */
@@ -11,11 +11,12 @@ exports.handler = async (event, context) => {
   console.log(getUrlSegments(event)[0])
   return matchVerbAndNumberOfUrlSegments(event)
 
-    // GET /api/auth/{logout | login}
+    // GET /api/auth/{logout | login | renew}
     .with(['GET', 1], () =>
       match(getUrlSegments(event)[0])
         .with('logout', () => handleLogout())
         .with('login', () => handleLogin(event))
+        .with('renew', () => handleRenew(event))
         .otherwise(responses.notFound)
     )
 

--- a/src/frontend/_includes/js/utils/http.js
+++ b/src/frontend/_includes/js/utils/http.js
@@ -75,6 +75,47 @@ const cookies = () =>
   )
 
 
+/* The nf_jwt cookie is minted with a fixed lifetime, so without renewal it just
+   expires and silently logs the user out. Renewing once it is past halfway
+   through that lifetime keeps an active session sliding forward. */
+const RENEWAL_THRESHOLD_SECONDS = 7 * 24 * 3600
+const RENEWAL_URL = '/.netlify/functions/auth/renew'
+
+let pendingRenewal = null
+
+const base64UrlDecode = (segment) => {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = (4 - base64.length % 4) % 4
+  return atob(base64.padEnd(base64.length + padding, '='))
+}
+
+const secondsUntilExpiry = (jwt) => {
+  try {
+    const { exp } = JSON.parse(base64UrlDecode(jwt.split('.')[1]))
+    return exp - Math.floor(Date.now() / 1000)
+  } catch (e) {
+    return undefined
+  }
+}
+
+/* Falls back to the current token: it is still valid for a while, so a failed
+   renewal should not break the request that triggered it. */
+const renewToken = (token) =>
+  axios.get(RENEWAL_URL, { headers: toAuthHeader(token) })
+    .then(({ data }) => data.token)
+    .catch(() => token)
+    .finally(() => { pendingRenewal = null })
+
 const refreshTokenIfNecessary = async () => {
-  return cookies().nf_jwt
+  const token = cookies().nf_jwt
+  if (!token) {
+    return undefined
+  }
+  const remaining = secondsUntilExpiry(token)
+  if (remaining > RENEWAL_THRESHOLD_SECONDS) {
+    return token
+  }
+  // in-flight renewal is shared so concurrent requests only renew once
+  pendingRenewal = pendingRenewal ?? renewToken(token)
+  return pendingRenewal
 }


### PR DESCRIPTION
Fixes #81.

## The cause

`nf_jwt` is minted once in `handleCallback` with a fixed 14-day lifetime and never re-issued:

```js
const NETLIFY_JWT_EXPIRATION_SECONDS = 14 * 24 * 3600
```

Nothing renews it, so the session ends abruptly 14 days after each login regardless of activity — `isLoggedIn()` is just `!isNil(cookies().nf_jwt)`, so the moment the cookie expires you're signed out.

The hook for fixing this already existed, wired into every API request via `makeRequest`, but was a stub:

```js
const refreshTokenIfNecessary = async () => {
  return cookies().nf_jwt
}
```

Why re-login prompts for credentials instead of bouncing through silently is a separate matter. Auth0's **inactivity** timeout is capped at 3 days on self-service plans (the absolute "require login after" cap is 30 days), and the idle timer only resets when the browser actually reaches Auth0 — SSO, silent auth, or `/authorize`. This app touches Auth0 only during an explicit login, so the SSO session always dies 3 days after login and stays dead.

That has no bearing on whether you stay signed in — the app session is `nf_jwt` alone. It only decides whether a *future* login is a silent redirect or a credential prompt. Raising the Auth0 dashboard limits would not change it, so this PR is entirely app-side.

## The fix

**`GET /.netlify/functions/auth/renew`** verifies the current `nf_jwt` and re-signs it with a fresh expiry, preserving `sub`, `aud`, and roles. The signing core is extracted into `signNetlifyJWT` so the callback and renew paths share it. An invalid or genuinely expired token gets a 401 plus a cookie-clearing header.

**`refreshTokenIfNecessary`** now decodes `exp` and calls that endpoint once the token is past halfway through its lifetime (7 days left). Concurrent requests share one in-flight renewal, and a failed renewal falls back to the current token so it can't break the request that triggered it.

Net effect: visiting at least once every 14 days keeps you logged in indefinitely.

## Two adjacent bugs in the same login path

- `LOGIN_COOKIE_MAX_AGE` was `30 * 60 * 1000`, but `cookie`'s `maxAge` is in **seconds** — the nonce/state cookie was living ~20 days instead of 30 minutes.
- The login cookie had no `SameSite`. With `response_mode: "form_post"` Auth0 POSTs the callback cross-site, and a default-`Lax` cookie isn't sent on that; it worked only via Chrome's 2-minute Lax+POST grace period, so any login spending longer than that on the Auth0 screen would fail. Now `SameSite=None` in production, `lax` on local http.

Happy to split these out if you'd rather keep the PR to the one fix.

## Testing

The repo has no test setup and no installed `node_modules`, so I exercised the real controller against `jose`/`cookie`/`openid-client` installed out-of-tree, and loaded `http.js` in a `vm` sandbox with stubbed `document`/`axios`.

Server `handleRenew`: valid token via `Authorization` header → 200 with `sub`/`aud`/roles preserved and expiry reset to a full 14 days; valid token via cookie header → 200; no token → 401; expired token → 401 + clears cookie; token forged with a different secret → 401.

Frontend, 17 assertions over 6 cases: no cookie; fresh token (no request issued); past-halfway token (one request, correct URL and Bearer header); renewal failure; 4 concurrent calls collapsing to a single request; undecodable token. All pass.

## Judgment calls worth a look

- **No absolute session cap.** An active user now stays logged in indefinitely. That seemed right for this app, but a hard ceiling is easy to add.
- **Still logs out after 14 days away**, since nothing can renew a cookie in a closed browser. Bump `NETLIFY_JWT_EXPIRATION_SECONDS` if that window is too short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
