### PR TITLE
docs: describe the actual deploy workflow, single `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,7 @@ GET http://localhost:8888/.netlify/functions/<function_file_name_without_extensi
 
 **2. Deploying.** `main` is the only long-lived branch. Netlify publishes nil.moe from `main`
 automatically on every push, so there is no separate staging or production branch and no manual
-promotion step. Pull requests aren't really necessary due to the small team size, but if you'd
-like code review send a PR to merge to `main`.
-
-Because there is no buffer, merging to `main` goes straight to the live site. Netlify does build a
-deploy preview for every PR, but Auth0's `redirect_uri` is derived from Netlify's `URL` variable,
-which always points at production — so logging in from a preview bounces you to nil.moe. Anything
-touching the login flow can only be exercised for real after it ships.
+promotion step.
 
 ## Web Development Stack
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ If you use `npx netlify dev` your serverless functions will also be available at
 GET http://localhost:8888/.netlify/functions/<function_file_name_without_extension>
 ```
 
-**2. Staging branch.** Generally you should push commits directly to staging. Pull requests aren't really necessary
-due to the small team size, but if you'd like code review send a PR to merge to staging.
+**2. Deploying.** `main` is the only long-lived branch. Netlify publishes nil.moe from `main`
+automatically on every push, so there is no separate staging or production branch and no manual
+promotion step. Pull requests aren't really necessary due to the small team size, but if you'd
+like code review send a PR to merge to `main`.
 
-**3. Production branch.** Merge staging to production whenever you think the changes are ready. Deploys to
-the website from production are automatic.
+Because there is no buffer, merging to `main` goes straight to the live site. Netlify does build a
+deploy preview for every PR, but Auth0's `redirect_uri` is derived from Netlify's `URL` variable,
+which always points at production — so logging in from a preview bounces you to nil.moe. Anything
+touching the login flow can only be exercised for real after it ships.
 
 ## Web Development Stack
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,12 +16,6 @@
 NODE_VERSION = "18"
 AWS_LAMBDA_JS_RUNTIME = "nodejs18.x"
 
-[context.staging.environment]
-# https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
-# https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-NODE_VERSION = "18"
-AWS_LAMBDA_JS_RUNTIME = "nodejs18.x"
-
 [context.deploy-preview.environment]
 NODE_VERSION = "18"
 AWS_LAMBDA_JS_RUNTIME = "nodejs18.x"


### PR DESCRIPTION
The README's workflow section has been wrong for a while, in a way that matters: it tells you to merge `staging` into `production` and says the site deploys from `production`. Neither is true.

## What's actually true

Netlify's production branch is `staging`, and auto-publishing is on — nil.moe deploys on every push to it. The dashboard confirms it: *"Deploys from staging are published automatically,"* with the current published deploy showing as `staging@7be8098`.

The `production` branch, meanwhile, is dead:

```
in production but NOT in staging:   (nothing)
in staging but NOT in production:   7be8098  fix: don't wipe review text (#77)
```

It's strictly one commit behind and holds nothing unique. Its last update was `ea6da57`; the newest deploy from it in Netlify's history is from Jan 2022. Following the README as written would be a no-op that promotes nothing.

## What this PR does

Replaces the two-branch promotion instructions with a single sentence naming `main` as the only long-lived branch and stating that Netlify publishes from it automatically.

Also drops `[context.staging.environment]` from `netlify.toml`. Deploys from the production branch use the `production` context regardless of what the branch is named, so that block never applied — it was already dead config, and renaming the branch makes that permanent.

## This PR is only correct once two settings change

The README now says `main`, so **merge this after** doing both of these, in this order:

1. Rename `staging` → `main` on GitHub (Settings → Branches). Open PRs retarget automatically.
2. Update Netlify's production branch to `main`: Project configuration → Build & deploy → Branches and deploy contexts.

**Doing step 1 without step 2 silently stops all deploys** — Netlify keeps looking for a branch that no longer exists, and nothing about the repo will look wrong. Push a trivial commit afterwards and confirm a deploy fires.

Then `production` can be deleted. Nothing is lost — `ea6da57` is in `main`'s history either way:

```bash
git push upstream --delete production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
