### PR TITLE
Fix playtime links and duplicate books, and add work-collection maintenance tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # The unit-tested modules are deliberately dependency-free, so the
+      # suite runs without an install. Nothing here needs a database or an
+      # API key.
+      - name: Unit tests
+        run: npm test
+
+      # Cheap guard against a typo in the files the tests don't reach —
+      # the Netlify functions and the frontend globals.
+      - name: Syntax check every JS file
+        run: git ls-files '*.js' | xargs -n1 node --check

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /dist
 /src/site/_includes/css
 
+# db_maintenance backups and reports
+/src/db_maintenance/backups
+/mongobackup
+
 # secrets and errors
 .env
 /yarn-error.log

--- a/docs/API_choices.md
+++ b/docs/API_choices.md
@@ -36,261 +36,128 @@ Let's reduce the risk of hitting rate limits and avoid as much as possible block
 
 ## Game API
 
-### howlongtobeat
+Split into two questions, because one source no longer answers both:
+**metadata** (title, year, cover, genres, platforms, studio, publisher) and
+**playtime**.
 
-https://www.npmjs.com/package/howlongtobeat
-
-<details>
-<summary>Research</summary>
-  
-- Scraper
-- Testing indicates no rate limits
-- Might have the most accurate game playtime data
-- Preferably should not rely on it for anything else
-- Can consider writing own scraper
-
-```js
-HowLongToBeatEntry {
-  id: '43344',
-  name: 'Yu-Gi-Oh! Duel Links',
-  description: ' Step into a world that crosses dimensions and connects all Duelists. Here, any location transforms into a Duel Field where heated Duels unfold!\n' +
-    '\t\t\t',
-  platforms: [ 'Mobile', 'PC' ],
-  imageUrl: '/games/43344_Yu-Gi-Oh_Duel_Links.jpg',
-  timeLabels: [
-    [ 'gameplayMain', 'Single-Player' ],
-    [ 'gameplayMainExtra', 'Co-Op' ],
-    [ 'gameplayComplete', 'Vs.' ]
-  ],
-  gameplayMain: 559,
-  gameplayMainExtra: 0,
-  gameplayCompletionist: 170,
-  similarity: 1,
-  searchTerm: 'Yu-Gi-Oh! Duel Links',
-  playableOn: [ 'Mobile', 'PC' ]
-}
-```
-
-Missing (\* = can be implemented):
-
-- Original title
-- Release year\*
-- Genres\*
-- Platforms\*
-- Studio\*
-- Developer\*
-</details>
-
-Relying solely on HLTB would get us all the data except original title. However
-it would mean being at the mercy of HTML changes. My hacky sh scraper from 1 year ago has already stopped working.
-
-We should only use HLTB to get playtime data, and gracefully fail or fallback.
-
-### IGDB
+### Metadata: IGDB
 
 https://www.npmjs.com/package/igdb-api-node
-https://api-docs.igdb.com#franchise
-[Setting up an authorization credentials (pita)](https://api-docs.igdb.com#account-creation)
+https://api-docs.igdb.com
+
+- 4 requests per second, free, authenticated with Twitch client credentials
+- The [Expander](https://api-docs.igdb.com/?shell#expander) feature gets
+  expanded data in one request, one level deep — company names still need a
+  second request
+- Everything we need except original title and playtime
+
+Still the right choice. Note that `external_games.category` has been replaced
+by `external_games.external_game_source` (`1` = Steam); a query filtering on
+the old field silently returns nothing rather than erroring.
+
+### Playtime: the situation as of 2026-08-11
+
+| source | reachable | coverage of our library | metric | verdict |
+| --- | --- | --- | --- | --- |
+| `howlongtobeat` npm 1.8.0 | no — 404 on every search | — | time to beat | dead |
+| `howlongtobeat-core` npm 1.1.1 | no — "Failed to fetch auth token: 404" | — | time to beat | dead |
+| howlongtobeat.com directly | no — 401 | — | time to beat | behind auth |
+| **IGDB `/game_time_to_beats`** | **yes, with credentials we already hold** | **63%** | **time to beat** | **best available** |
+| SteamSpy | yes, but playtime fields are `0` | 56% have a Steam appid | total time played | unusable |
+| RAWG | needs an account we don't have | unmeasured | average total playtime | wrong metric |
 
 <details>
-<summary>Research</summary>
+<summary>Evidence</summary>
 
-- 4 requests per second
-- [Link to list of returned fields](https://api-docs.igdb.com#game)
-- Must programmatically regenerate auth token every so often... should be no problem to refresh it for every request for simplicity (due to being serverless)
-- **At first it looked like it would take many requests to get one game's data (see code below), but after digging a little I happily found the [Expander](https://api-docs.igdb.com/?shell#expander) feature which lets us get expanded data in one request.**
-  - This only works one level deep, so additional requests are still necessary
-    - **1 request** for company names
+**`howlongtobeat` npm.** 1.8.0 is the latest release, published 2023.
+`hltb.search()` throws `Request failed with status code 404` for every title
+tested. The games adapter wraps it in `.catch(() => undefined)`, so the
+failure is silent: games simply get no duration and no HowLongToBeat link.
 
-```js
-  // Without expander settings
-  {
-    id: 27093,
-    alternative_names: [ 13594 ],
-    artworks: [ 33661 ],
-    cover: 86245,
-    genres: [ 15, 16, 26, 35 ],
-    involved_companies: [ 62226, 62227 ],
-    name: 'Yu-Gi-Oh! Duel Links',
-    platforms: [ 6, 34, 39 ],
-    release_dates: [ 65212, 146989, 146990, 150165, 158774, 254407 ]
-  }
+**`howlongtobeat-core` npm.** 1.1.1, the actively maintained alternative.
+`new HowLongToBeat().search("Hollow Knight")` logs
+`Failed to fetch auth token: 404` and returns 0 results.
 
-  // With expander
-  [
-    {
-      "id": 27093,
-      "alternative_names": [
-        {
-          "id": 13594,
-          "comment": "Other",
-          "game": 27093,
-          "name": "Yu-Gi-Oh! Dungeondice Monsters",
-          "checksum": "eee0a878-6b28-0ab5-7808-7799bd13c86f"
-        }
-      ],
-      "cover": {
-        "id": 86245,
-        "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1ujp.jpg"
-      },
-      "genres": [
-        {
-          "id": 15,
-          "name": "Strategy"
-        },
-        {
-          "id": 16,
-          "name": "Turn-based strategy (TBS)"
-        },
-        {
-          "id": 26,
-          "name": "Quiz/Trivia"
-        },
-        {
-          "id": 35,
-          "name": "Card & Board Game"
-        }
-      ],
-      "involved_companies": [
-        {
-          "id": 62226,
-          "company": 129,
-          "created_at": 1518480000,
-          "developer": true,
-          "game": 27093,
-          "porting": false,
-          "publisher": false,
-          "supporting": false,
-          "updated_at": 1518480000,
-          "checksum": "dbb971a3-0fa6-a22c-b98b-39b20bcfd465"
-        },
-        {
-          "id": 62227,
-          "company": 161,
-          "created_at": 1518480000,
-          "developer": false,
-          "game": 27093,
-          "porting": false,
-          "publisher": true,
-          "supporting": false,
-          "updated_at": 1518480000,
-          "checksum": "32eaf131-aa94-06fb-f648-6ba8108bdd7d"
-        }
-      ],
-      "name": "Yu-Gi-Oh! Duel Links",
-      "platforms": [
-        {
-          "id": 6,
-          "abbreviation": "PC"
-        },
-        {
-          "id": 34,
-          "abbreviation": "Android"
-        },
-        {
-          "id": 39,
-          "abbreviation": "iOS"
-        }
-      ],
-      "release_dates": [
-        {
-          "id": 65212,
-          "category": 0,
-          "created_at": 1486662608,
-          "date": 1484870400,
-          "game": 27093,
-          "human": "Jan 20, 2017",
-          "m": 1,
-          "platform": 34,
-          "region": 8,
-          "updated_at": 1486662608,
-          "y": 2017,
-          "checksum": "0a7d44a5-76fe-6e70-e440-0927059f2854"
-        },
-        {
-          "id": 146989,
-          "category": 0,
-          "created_at": 1518484178,
-          "date": 1479340800,
-          "game": 27093,
-          "human": "Nov 17, 2016",
-          "m": 11,
-          "platform": 34,
-          "region": 5,
-          "updated_at": 1518497293,
-          "y": 2016,
-          "checksum": "256f8f50-d924-3cbb-6f9e-31f35b89184b"
-        },
-        {
-          "id": 146990,
-          "category": 0,
-          "created_at": 1518484178,
-          "date": 1479340800,
-          "game": 27093,
-          "human": "Nov 17, 2016",
-          "m": 11,
-          "platform": 39,
-          "region": 5,
-          "updated_at": 1518497293,
-          "y": 2016,
-          "checksum": "ee913588-f9e5-7615-be51-3484ec601dc3"
-        },
-        {
-          "id": 150165,
-          "category": 0,
-          "created_at": 1522159932,
-          "date": 1484092800,
-          "game": 27093,
-          "human": "Jan 11, 2017",
-          "m": 1,
-          "platform": 39,
-          "region": 8,
-          "updated_at": 1522160325,
-          "y": 2017,
-          "checksum": "11364ef8-3771-888d-6ea5-5bcba7de6bbd"
-        },
-        {
-          "id": 158774,
-          "category": 0,
-          "created_at": 1537038892,
-          "date": 1510790400,
-          "game": 27093,
-          "human": "Nov 16, 2017",
-          "m": 11,
-          "platform": 6,
-          "region": 8,
-          "updated_at": 1537095764,
-          "y": 2017,
-          "checksum": "6fde44cd-8428-174d-3428-bcef8f8b77ee"
-        },
-        {
-          "id": 254407,
-          "category": 0,
-          "created_at": 1623552795,
-          "date": 1510790400,
-          "game": 27093,
-          "human": "Nov 16, 2017",
-          "m": 11,
-          "platform": 6,
-          "region": 2,
-          "updated_at": 1623759663,
-          "y": 2017,
-          "checksum": "40a7d49d-4186-fe24-d3bf-aa6f40333d5d"
-        }
-      ]
-    }
-  ]
+**howlongtobeat.com directly.** The homepage still serves 200 and a Next.js
+bundle, but no longer ships the `_next/static/chunks/pages/_app-*.js` file
+that the community libraries extract a key from. The API is now versioned and
+authenticated:
+
+```
+POST /api/v1/games     401
+POST /api/v0/games     401
+POST /api/search       404
+POST /api/stats/games  503
 ```
 
-Missing:
+401 rather than 404 means the endpoints exist and require credentials. No
+token is discoverable in the client bundles by the pattern those libraries
+use. Getting past that would mean defeating an access control on someone
+else's service, which we are not going to do, and their terms prohibit
+scraping in any case. **Treat HowLongToBeat as unavailable, not as broken.**
 
-- Playtime
-- Original title
+**IGDB `/game_time_to_beats`.** Note the plural — `game_time_to_beat` and
+`time_to_beat` both 404, which makes this easy to conclude doesn't exist.
+
+```
+POST https://api.igdb.com/v4/game_time_to_beats
+fields game_id,hastily,normally,completely,count; where game_id = (3042);
+
+{ "game_id": 3042, "hastily": 45000, "normally": 102780,
+  "completely": 165270, "count": 13 }
+```
+
+Values are seconds. `hastily` / `normally` / `completely` line up with
+HowLongToBeat's Main / Main+Extra / Completionist.
+
+Measured against our 1,145 games:
+
+- 1,105 have an `igdb__` ref; IGDB has a time for 698 of them (63%)
+- of the 167 games with no duration at all, IGDB can supply 69
+- of the 215 games holding a duration with no HowLongToBeat link, IGDB has a
+  time for 104
+
+Quality is the caveat. Comparing 620 games that have both a stored
+(HowLongToBeat-derived) duration and IGDB times, agreement within ±20% is
+`hastily` 31%, `normally` 30%, `completely` 6% — no field is a drop-in
+substitute, and adopting one visibly changes playtimes. The sample sizes
+behind IGDB's numbers are small: **median 3 submissions per game**, and
+393 of 620 games have fewer than 5.
+
+**SteamSpy.** Free, no key, `?request=appdetails&appid=N`. But
+`average_forever` and `median_forever` return `0` for every game sampled — the
+free endpoint no longer populates them. Even working, it measures total hours
+played, which for anything with multiplayer or NG+ is not time to beat. 614
+of our 1,105 games have a Steam appid, so it is PC-only anyway.
+
+**RAWG.** https://rawg.io/apidocs — 350k+ games, free tier 20,000
+requests/month, requires an API key from a signed-up account. Its `playtime`
+field is average total playtime in hours, sourced from Steam, so it has
+SteamSpy's semantic problem: not a time to beat. Unmeasured, because getting
+a key means creating an account.
 
 </details>
 
-Great high quality API containing everything we need except original title and
-playtime, will use in conjunction with HLTB.
+### Recommendation
+
+1. **Adopt IGDB `/game_time_to_beats` as the playtime source.** It needs no
+   new credentials, no new account, no scraping, and it is the only reachable
+   source that measures the right thing. Map `normally` to `duration`.
+2. **Record where a duration came from.** Store the source alongside it, so a
+   later switch can tell an IGDB figure from a HowLongToBeat one and from a
+   user override, instead of guessing as we now have to.
+3. **Don't overwrite existing HowLongToBeat-derived durations.** They come
+   from far larger samples than IGDB's median of 3 submissions. Fill gaps
+   only, or the numbers people already see will shift for no visible reason.
+4. **Keep the stored `hltb__` refs and HowLongToBeat links.** 775 games have
+   them, the pages still exist and are worth linking to; only the API is gone.
+5. **Revisit if HowLongToBeat opens up.** The 401 suggests a credentialed API
+   rather than a permanent closure. If they publish terms we can meet, it
+   remains the best data.
+
+The original criteria still apply: real APIs over scrapers, lenient rate
+limits, a JS wrapper if possible. IGDB satisfies all three; every remaining
+HowLongToBeat route satisfies none.
 
 ## Film / TV API
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "cross-env ELEVENTY_ENV=dev eleventy --serve",
-    "build": "cross-env ELEVENTY_ENV=prod eleventy"
+    "build": "cross-env ELEVENTY_ENV=prod eleventy",
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/src/api/controllers/works.js
+++ b/src/api/controllers/works.js
@@ -21,10 +21,8 @@ const retrieveWork = (event) => {
   const apiRefId = getUrlSegments(event)[2]
 
   // Hardcoded for now, but ideally shouldnt be.
-  // Books are cached under `ISBN__` by the Google Books adapter; looking them
-  // up as `google__` never hit the cache, so every retrieve created another
-  // duplicate book. `google__` stays as a fallback for anything already
-  // stored under the old name.
+  // The Google Books adapter caches books under `ISBN__`; `google__` is also
+  // accepted because some book documents are stored under that name.
   const apiNames = {
     films: ['tmdb'],
     books: ['ISBN', 'google'],

--- a/src/api/controllers/works.js
+++ b/src/api/controllers/works.js
@@ -20,19 +20,22 @@ const retrieveWork = (event) => {
   const type = getUrlSegments(event)[1]
   const apiRefId = getUrlSegments(event)[2]
 
-  // Hardcoded for now, but ideally shouldnt be
-  const apiName = {
-    films: 'tmdb',
-    books: 'google',
-    tv: 'tmdb',
-    games: 'igdb',
+  // Hardcoded for now, but ideally shouldnt be.
+  // Books are cached under `ISBN__` by the Google Books adapter; looking them
+  // up as `google__` never hit the cache, so every retrieve created another
+  // duplicate book. `google__` stays as a fallback for anything already
+  // stored under the old name.
+  const apiNames = {
+    films: ['tmdb'],
+    books: ['ISBN', 'google'],
+    tv: ['tmdb'],
+    games: ['igdb'],
   }[type]
 
-  if (!apiName) return Promise.resolve(responses.notFound())
-  const apiRef = `${apiName}__${apiRefId}`
+  if (!apiNames) return Promise.resolve(responses.notFound())
 
   return toPromise(
-    db.findOneByField_(typeToCollection(type), 'apiRefs', apiRef)
+    findCachedWork(typeToCollection(type), apiNames.map((name) => `${name}__${apiRefId}`))
       .andThen(({ data, ref }) => data
         ? okAsync(({
           ...data,
@@ -59,6 +62,20 @@ const typeToCollection = (type) => ({
   tv: 'tvShows',
   games: 'games',
 }[type])
+
+/**
+ * Tries each apiRef in turn and stops at the first cached work.
+ * @type {(collection: any, apiRefs: string[]) => ResultAsync<any, Error>}
+ */
+const findCachedWork = (collection, apiRefs) =>
+  apiRefs.reduce(
+    (found, apiRef) => found.andThen((result) =>
+      result?.data
+        ? okAsync(result)
+        : db.findOneByField_(collection, 'apiRefs', apiRef)
+    ),
+    okAsync({})
+  )
 
 
 /** @type {(action: keyof Adapter, event: Event) => Promise<Response>} */

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -6,12 +6,106 @@ In order to use the scripts in this folder, you need
 to create a `.env` file in this folder containing
 `MONGODB_URL=...`
 
-## Upcoming
+Scripts that talk to the external metadata APIs also need
+the same keys the deployed API uses:
+`TMDB_API_KEY` (films and TV), `TWITCH_CLIENT_ID` +
+`TWITCH_CLIENT_SECRET` (games, via IGDB) and, optionally but
+recommended, `GOOGLE_API_KEY` (books).
 
-We migrated from FaunaDB to MongoDB Atlas on 2022-10-10
+Run the scripts from this folder, so that `dotenv` picks up the `.env`.
 
-One script has been written to add missing duration data to DB entries:
-./mongodb_add_missing_durations.js
+## Auditing and backfilling metadata
+
+`audit_database.js` is read-only, needs no API keys, and reports every
+inconsistency it can find: works that can't be refreshed because they
+have no usable apiRef, missing or corrupt metadata fields, games that
+have a duration but no HowLongToBeat link, duplicate works sharing an
+apiRef, orphaned works, and entries with a missing or dangling `workRef`.
+
+```
+node audit_database.js
+node audit_database.js --only=games,books --json=./audit.json
+```
+
+`backfill_work_metadata.js` re-runs the API adapters for cached works and
+fills in what's missing / refreshes what's stale. It is a **dry run unless
+you pass `--apply`**, and it takes a JSON backup of each collection before
+writing to it.
+
+```
+node backfill_work_metadata.js --only=games --missing-only
+node backfill_work_metadata.js --only=games --missing-only --apply
+```
+
+Useful flags: `--only=films,tv,games,books`, `--missing-only` (only touch
+works with gaps, instead of refreshing everything older than
+`--max-age-days`, default 180), `--force`, `--limit=N`, `--delay-ms=N`,
+`--json=path`, `--backup-dir=path`.
+
+Notes on its behaviour:
+
+- It only ever writes to the **work** collections. User overrides live on
+  the entry documents (`entry.overrides`) and are never touched, so a
+  refresh cannot clobber a value the user set by hand.
+- A field the API returns nothing for is never cleared.
+- `apiRefs` and `externalUrls` are merged, so a ref we already know about
+  survives even if the API stops reporting it.
+- Each refreshed work gets a `metadataUpdatedDate`, so an interrupted run
+  can be resumed cheaply and periodic refreshes skip recent work.
+- Duplicate works are reported, never merged — that's `dedupe_works.js`.
+
+## Collapsing duplicate works
+
+`populate_work_collections.js` created one work document per *entry*, so the
+same film cached for two users became two documents; books were worse,
+because the works controller looked them up under a different apiRef prefix
+than the one they were stored under, so every retrieve made another copy.
+
+`dedupe_works.js` merges each group of duplicates into the most complete
+document, repoints the entries' `workRef` at it, and deletes the leftovers.
+It only groups works that share an API identifier — never by title — and it
+is a **dry run unless you pass `--apply`**. Read the dry run before applying:
+it prints the survivor, what gets filled in, and a warning when duplicates
+disagree about the title.
+
+```
+node dedupe_works.js --only=books
+node dedupe_works.js --only=books --apply
+```
+
+Useful flags: `--only=...`, `--keep-duplicates` (merge and repoint but delete
+nothing), `--json=path`, `--backup-dir=path`. Both the work and the entry
+collection are backed up before anything is written.
+
+Run it before a full `backfill_work_metadata.js`, so you aren't paying for an
+API call per duplicate.
+
+## Tests
+
+The parts that decide what to write (`work_metadata_merge.js`) and what to
+delete (`work_dedupe_plan.js`) are pure and dependency-free, and are covered
+by `node --test`:
+
+```
+npm test
+```
+
+Keep it that way: the scripts should hold the I/O, and the rules should stay
+in a module that can be tested without a database or an API key.
+
+## History
+
+We migrated from FaunaDB to MongoDB Atlas on 2022-10-10. The scripts that
+use `faunadb` / `./utils.js` predate that migration and no longer run.
+
+Two one-off scripts left the database in a state the backfill now repairs:
+
+- `mongodb_add_missing_durations.js` set `duration` only, and not the
+  `hltb__` apiRef or the HowLongToBeat `externalUrls` entry that should
+  accompany it — which is why playtimes stopped linking out.
+- `mongodb_add_missing_book_publishers.js` stored an un-awaited Promise,
+  which Mongo wrote as an empty object, so those books have a `publishers`
+  field that isn't a list of strings. The script itself is fixed now.
 
 ## Backing up the production DB
 

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -56,17 +56,20 @@ Notes on its behaviour:
 
 ## Collapsing duplicate works
 
-`populate_work_collections.js` created one work document per *entry*, so the
-same film cached for two users became two documents; books were worse,
-because the works controller looked them up under a different apiRef prefix
-than the one they were stored under, so every retrieve made another copy.
+The work collections hold multiple documents describing the same work — in
+some cases one per entry that referenced it.
 
 `dedupe_works.js` merges each group of duplicates into the most complete
 document, repoints the entries' `workRef` at it, and deletes the leftovers.
-It only groups works that share an API identifier — never by title — and it
-is a **dry run unless you pass `--apply`**. Read the dry run before applying:
-it prints the survivor, what gets filled in, and a warning when duplicates
-disagree about the title.
+It is a **dry run unless you pass `--apply`**.
+
+A group is only merged when its documents share an API identifier **and**
+agree about the title. Sharing an apiRef does not mean being the same work:
+"Fargo - Season 1" and "Fargo - Season 2" sit under one show id, five Haruhi
+Suzumiya volumes share one ISBN, and "Demons" is filed under The Da Vinci
+Code’s. Groups that disagree are printed and skipped —
+`--merge-title-mismatches` forces them through, and you should read every one
+of them first.
 
 ```
 node dedupe_works.js --only=books
@@ -74,8 +77,8 @@ node dedupe_works.js --only=books --apply
 ```
 
 Useful flags: `--only=...`, `--keep-duplicates` (merge and repoint but delete
-nothing), `--json=path`, `--backup-dir=path`. Both the work and the entry
-collection are backed up before anything is written.
+nothing), `--merge-title-mismatches`, `--json=path`, `--backup-dir=path`. Both
+the work and the entry collection are backed up before anything is written.
 
 Run it before a full `backfill_work_metadata.js`, so you aren't paying for an
 API call per duplicate.
@@ -98,14 +101,11 @@ in a module that can be tested without a database or an API key.
 We migrated from FaunaDB to MongoDB Atlas on 2022-10-10. The scripts that
 use `faunadb` / `./utils.js` predate that migration and no longer run.
 
-Two one-off scripts left the database in a state the backfill now repairs:
+Two conditions in the data that `backfill_work_metadata.js` repairs:
 
-- `mongodb_add_missing_durations.js` set `duration` only, and not the
-  `hltb__` apiRef or the HowLongToBeat `externalUrls` entry that should
-  accompany it — which is why playtimes stopped linking out.
-- `mongodb_add_missing_book_publishers.js` stored an un-awaited Promise,
-  which Mongo wrote as an empty object, so those books have a `publishers`
-  field that isn't a list of strings. The script itself is fixed now.
+- Games carrying a `duration` with no `hltb__` apiRef and no HowLongToBeat
+  `externalUrls` entry, so the playtime has nothing to link to.
+- Books whose `publishers` is an empty object rather than a list of strings.
 
 ## Backing up the production DB
 

--- a/src/db_maintenance/audit_database.js
+++ b/src/db_maintenance/audit_database.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * @file Read-only audit of the production database.
+ *
+ * Reports every inconsistency backfill_work_metadata.js and dedupe_works.js
+ * can act on, plus the ones that need a human decision. It never writes, and
+ * it needs no external API keys — only MONGODB_URL.
+ *
+ * Usage:
+ *   node audit_database.js
+ *   node audit_database.js --only=games,books
+ *   node audit_database.js --json=./audit.json
+ */
+require("dotenv").config();
+const fs = require("fs");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const {
+  COLLECTIONS,
+  parseApiRef,
+  isEmptyValue,
+  selectCollections,
+  parseArgs,
+} = require("./work_collections");
+const {
+  expectedFields,
+  corruptFieldsOf,
+  isMissingHltbLink,
+} = require("./work_metadata_merge");
+const { groupWorksByApiRef } = require("./work_dedupe_plan");
+
+const args = parseArgs(process.argv);
+
+let client;
+
+const main = async () => {
+  const selected = selectCollections(args.only);
+  if (selected.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Valid types: ${COLLECTIONS.map(
+        (c) => c.type
+      ).join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const report = {};
+  for (const collection of selected) {
+    report[collection.type] = await auditCollection(db, collection);
+  }
+
+  if (args.json) {
+    fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
+    console.log(`\nFull report written to ${args.json}`);
+  }
+
+  await client.close();
+};
+
+const auditCollection = async (db, collection) => {
+  const works = await db.collection(collection.works).find().toArray();
+  const entries = await db.collection(collection.entries).find().toArray();
+
+  const workIds = new Set(works.map((w) => w._id));
+  const referencedWorkIds = new Set(
+    entries.map((e) => e.workRef).filter((ref) => ref)
+  );
+
+  const noApiRef = [];
+  const legacyObjectApiRefs = [];
+  const missingFields = [];
+  const corruptFields = [];
+  const gamesMissingHltbLink = [];
+  const orphanWorks = [];
+
+  for (const work of works) {
+    if (!hasRetrieveRef(collection, work)) noApiRef.push(describe(work));
+
+    if (
+      Array.isArray(work.apiRefs) &&
+      work.apiRefs.some((ref) => parseApiRef(ref)?.flat === false)
+    ) {
+      legacyObjectApiRefs.push(describe(work));
+    }
+
+    const missing = expectedFields(collection).filter((field) =>
+      isEmptyValue(work[field])
+    );
+    if (missing.length > 0) {
+      missingFields.push({ ...describe(work), fields: missing });
+    }
+
+    const corrupt = corruptFieldsOf(collection, work);
+    if (corrupt.length > 0) {
+      corruptFields.push({ ...describe(work), fields: corrupt });
+    }
+
+    if (isMissingHltbLink(collection, work)) {
+      gamesMissingHltbLink.push(describe(work));
+    }
+
+    if (!referencedWorkIds.has(work._id)) orphanWorks.push(describe(work));
+  }
+
+  const duplicateWorks = [...groupWorksByApiRef(collection, works).entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([apiRef, group]) => ({
+      apiRef,
+      count: group.length,
+      works: group.map(describe),
+    }));
+
+  const entriesWithoutWorkRef = entries
+    .filter((e) => !e.workRef)
+    .map((e) => ({ id: e._id, userId: e.userId, status: e.status }));
+
+  const entriesWithDanglingWorkRef = entries
+    .filter((e) => e.workRef && !workIds.has(e.workRef))
+    .map((e) => ({ id: e._id, userId: e.userId, workRef: e.workRef }));
+
+  const result = {
+    works: works.length,
+    entries: entries.length,
+    noApiRef,
+    legacyObjectApiRefs,
+    missingFields,
+    corruptFields,
+    gamesMissingHltbLink,
+    duplicateWorks,
+    orphanWorks,
+    entriesWithoutWorkRef,
+    entriesWithDanglingWorkRef,
+  };
+
+  printSummary(collection, result);
+  return result;
+};
+
+const hasRetrieveRef = (collection, work) =>
+  Array.isArray(work.apiRefs) &&
+  work.apiRefs.some(
+    (ref) => parseApiRef(ref)?.name === collection.retrievePrefix
+  );
+
+const describe = (work) => ({
+  id: work._id,
+  title: work.englishTranslatedTitle ?? work.originalTitle ?? "(untitled)",
+  apiRefs: work.apiRefs,
+});
+
+const printSummary = (collection, r) => {
+  console.log(`\n=== ${collection.works} ===`);
+  console.log(`  works: ${r.works}, entries: ${r.entries}`);
+  const lines = [
+    [`no ${collection.retrievePrefix}__ ref (cannot be refreshed)`, r.noApiRef],
+    ["apiRefs still stored as objects", r.legacyObjectApiRefs],
+    ["missing metadata fields", r.missingFields],
+    ["corrupt field values", r.corruptFields],
+    ...(collection.type === "games"
+      ? [["duration but no HowLongToBeat link", r.gamesMissingHltbLink]]
+      : []),
+    ["duplicate works sharing an apiRef", r.duplicateWorks],
+    ["works no entry points at", r.orphanWorks],
+    ["entries with no workRef", r.entriesWithoutWorkRef],
+    ["entries with a dangling workRef", r.entriesWithDanglingWorkRef],
+  ];
+  for (const [label, items] of lines) {
+    console.log(`  ${String(items.length).padStart(5)}  ${label}`);
+  }
+
+  const examples = r.missingFields.slice(0, 5);
+  if (examples.length > 0) {
+    console.log("  e.g. missing:");
+    for (const e of examples) {
+      console.log(`    - ${e.title}: ${e.fields.join(", ")}`);
+    }
+  }
+};
+
+main().catch(async (e) => {
+  console.error(e);
+  process.exitCode = 1;
+  await client?.close();
+});

--- a/src/db_maintenance/backfill_work_metadata.js
+++ b/src/db_maintenance/backfill_work_metadata.js
@@ -4,10 +4,7 @@
  *
  * For every document in films/tvShows/games/books it re-runs the same
  * adapter the API uses, then fills in what is missing and refreshes what is
- * stale. Notably it repairs games that got a `duration` from
- * mongodb_add_missing_durations.js but never got the matching `hltb__` apiRef
- * or HowLongToBeat externalUrl, which is why the playtime column had nothing
- * to link to.
+ * stale.
  *
  * User overrides are never touched: they live on the *entry* documents
  * (`entry.overrides`), and this script only ever writes to work documents.

--- a/src/db_maintenance/backfill_work_metadata.js
+++ b/src/db_maintenance/backfill_work_metadata.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * @file Backfills and refreshes the cached work metadata (issue #83).
+ *
+ * For every document in films/tvShows/games/books it re-runs the same
+ * adapter the API uses, then fills in what is missing and refreshes what is
+ * stale. Notably it repairs games that got a `duration` from
+ * mongodb_add_missing_durations.js but never got the matching `hltb__` apiRef
+ * or HowLongToBeat externalUrl, which is why the playtime column had nothing
+ * to link to.
+ *
+ * User overrides are never touched: they live on the *entry* documents
+ * (`entry.overrides`), and this script only ever writes to work documents.
+ *
+ * It is a dry run unless you pass --apply, and it takes a JSON backup of every
+ * collection it is about to write to.
+ *
+ * The decisions it makes live in ./work_metadata_merge.js and are unit tested.
+ *
+ * Environment (.env in this folder): MONGODB_URL, plus the keys the adapters
+ * need for the types you are refreshing — TMDB_API_KEY (films, tv),
+ * TWITCH_CLIENT_ID + TWITCH_CLIENT_SECRET (games), GOOGLE_API_KEY (books,
+ * optional but strongly recommended for rate limits).
+ *
+ * Usage:
+ *   node backfill_work_metadata.js --only=games --missing-only
+ *   node backfill_work_metadata.js --only=games --missing-only --apply
+ *   node backfill_work_metadata.js --max-age-days=365 --limit=50
+ *
+ * Flags:
+ *   --apply             actually write (default: dry run)
+ *   --only=a,b          restrict to these types (films, tv, games, books)
+ *   --missing-only      only touch works with missing/corrupt metadata
+ *   --max-age-days=N    in full-refresh mode, skip works refreshed within N
+ *                       days (default 180)
+ *   --force             ignore --max-age-days
+ *   --limit=N           stop after N works per collection
+ *   --delay-ms=N        override the per-type pause between API calls
+ *   --json=path         write a machine-readable report
+ *   --backup-dir=path   where to put backups (default ./backups)
+ */
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const {
+  COLLECTIONS,
+  findApiRef,
+  isEmptyValue,
+  sleep,
+  parseArgs,
+  selectCollections,
+} = require("./work_collections");
+const { hasGaps, mergeWork } = require("./work_metadata_merge");
+
+const args = parseArgs(process.argv);
+
+const options = {
+  apply: args.apply === true,
+  missingOnly: args["missing-only"] === true,
+  force: args.force === true,
+  maxAgeMs: (parseInt(args["max-age-days"]) || 180) * 24 * 60 * 60 * 1000,
+  limit: parseInt(args.limit) || Infinity,
+  delayMs:
+    args["delay-ms"] === undefined ? undefined : parseInt(args["delay-ms"]),
+  backupDir: String(args["backup-dir"] ?? path.join(__dirname, "backups")),
+};
+
+/** Built inside main() so the module can be required without MONGODB_URL. */
+let client;
+
+const main = async () => {
+  const selected = selectCollections(args.only);
+  if (selected.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Valid types: ${COLLECTIONS.map(
+        (c) => c.type
+      ).join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    options.apply
+      ? "APPLY MODE: the database will be modified."
+      : "DRY RUN: nothing will be written. Re-run with --apply to commit."
+  );
+
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const report = {};
+  for (const collection of selected) {
+    report[collection.type] = await backfillCollection(db, collection);
+  }
+
+  if (args.json) {
+    fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
+    console.log(`\nFull report written to ${args.json}`);
+  }
+
+  await client.close();
+};
+
+const backfillCollection = async (db, collection) => {
+  console.log(`\n=== ${collection.works} ===`);
+
+  const adapter = loadAdapter(collection);
+  if (!adapter) return { skipped: "adapter could not be loaded" };
+
+  const works = await db.collection(collection.works).find().toArray();
+  const candidates = works.filter((work) => needsRefresh(collection, work));
+  const selected = candidates.slice(0, options.limit);
+
+  console.log(
+    `  ${works.length} works, ${candidates.length} need attention, ` +
+      `processing ${selected.length}`
+  );
+
+  if (selected.length === 0) return { works: works.length, processed: 0 };
+
+  if (options.apply) backup(collection.works, works);
+
+  const delayMs = options.delayMs ?? collection.defaultDelayMs;
+  const changes = [];
+  const failures = [];
+  const unrefreshable = [];
+  let unchanged = 0;
+
+  for (const [index, work] of selected.entries()) {
+    const apiRef = findApiRef(work.apiRefs, collection.retrievePrefix);
+    if (!apiRef) {
+      unrefreshable.push(describe(work));
+      continue;
+    }
+
+    if (index > 0) await sleep(delayMs);
+
+    const result = await adapter.retrieve(apiRef);
+    if (result.isErr()) {
+      const error = describeError(result.error);
+      console.log(`  ! ${title(work)} (${apiRef}): ${error}`);
+      failures.push({ ...describe(work), error });
+      continue;
+    }
+
+    const { updates, notes } = mergeWork(collection, work, result.value, options);
+
+    if (Object.keys(updates).length === 0) {
+      unchanged += 1;
+      if (options.apply) await touch(db, collection, work);
+      continue;
+    }
+
+    console.log(`  ~ ${title(work)}: ${summarizeUpdates(work, updates)}`);
+    for (const note of notes) console.log(`      note: ${note}`);
+
+    if (options.apply) {
+      await db
+        .collection(collection.works)
+        .updateOne(
+          { _id: work._id },
+          { $set: { ...updates, metadataUpdatedDate: Date.now() } }
+        );
+    }
+
+    changes.push({ ...describe(work), updates, notes });
+  }
+
+  console.log(
+    `  ${changes.length} ${options.apply ? "updated" : "would be updated"}, ` +
+      `${unchanged} already current, ${failures.length} failed, ` +
+      `${unrefreshable.length} without a ${collection.retrievePrefix}__ ref`
+  );
+
+  return {
+    works: works.length,
+    processed: selected.length,
+    changes,
+    failures,
+    unrefreshable,
+    unchanged,
+  };
+};
+
+/**
+ * Lazily required: each adapter reads (and the games one throws on) its own
+ * env vars at load time, so requiring all four would make a films-only run
+ * depend on Twitch credentials.
+ */
+const loadAdapter = (collection) => {
+  try {
+    return require(collection.adapterModule);
+  } catch (e) {
+    console.log(
+      `  skipping ${collection.works}: could not load adapter (${
+        e?.message ?? e
+      })`
+    );
+    return undefined;
+  }
+};
+
+const needsRefresh = (collection, work) => {
+  if (options.missingOnly) return hasGaps(collection, work);
+  if (options.force) return true;
+  const refreshedAt = work.metadataUpdatedDate;
+  return (
+    typeof refreshedAt !== "number" ||
+    Date.now() - refreshedAt > options.maxAgeMs
+  );
+};
+
+/** Marks a work as checked so an interrupted run can be resumed cheaply. */
+const touch = (db, collection, work) =>
+  db
+    .collection(collection.works)
+    .updateOne({ _id: work._id }, { $set: { metadataUpdatedDate: Date.now() } });
+
+const backup = (collectionName, documents) => {
+  fs.mkdirSync(options.backupDir, { recursive: true });
+  const file = path.join(
+    options.backupDir,
+    `${collectionName}_${new Date().toISOString().replace(/:/g, "-")}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(documents, null, 2));
+  console.log(`  backed up ${documents.length} documents to ${file}`);
+};
+
+const title = (work) =>
+  work.englishTranslatedTitle ?? work.originalTitle ?? work._id;
+
+const describe = (work) => ({
+  id: work._id,
+  title: title(work),
+  apiRefs: work.apiRefs,
+});
+
+const describeError = (error) =>
+  typeof error === "string" ? error : error?.message ?? JSON.stringify(error);
+
+const summarizeUpdates = (work, updates) =>
+  Object.entries(updates)
+    .map(([field, value]) =>
+      isEmptyValue(work[field])
+        ? `+${field}=${preview(value)}`
+        : `${field}: ${preview(work[field])} -> ${preview(value)}`
+    )
+    .join(", ");
+
+const preview = (value) => {
+  const text = Array.isArray(value)
+    ? value.map(preview).join("|")
+    : String(value && typeof value === "object" ? JSON.stringify(value) : value);
+  return text.length > 40 ? `${text.slice(0, 39)}…` : text;
+};
+
+main().catch(async (e) => {
+  console.error(e);
+  process.exitCode = 1;
+  await client?.close();
+});

--- a/src/db_maintenance/dedupe_works.js
+++ b/src/db_maintenance/dedupe_works.js
@@ -6,8 +6,15 @@
  * This is the destructive half of the cleanup: it deletes documents. It is a
  * dry run unless you pass --apply, it backs up both the work and the entry
  * collection first, and it only ever groups works that share an API
- * identifier — never by title. Which document survives and what gets merged
- * into it is decided by ./work_dedupe_plan.js, which is unit tested.
+ * identifier AND agree about the title. Which document survives and what gets
+ * merged into it is decided by ./work_dedupe_plan.js, which is unit tested.
+ *
+ * The title check is not paranoia. Sharing an apiRef does not mean being the
+ * same work in this database: "Fargo - Season 1" and "Fargo - Season 2" sit
+ * under one show id, five Haruhi Suzumiya volumes share one ISBN, and
+ * "Demons" is filed under The Da Vinci Code's. Those groups are reported and
+ * skipped; --merge-title-mismatches forces them through, and you should read
+ * every one of them first.
  *
  * Order of operations per group: update the survivor, repoint the entries,
  * then delete the duplicates. If the run dies half way, re-running converges
@@ -24,6 +31,8 @@
  *   --apply             actually write (default: dry run)
  *   --only=a,b          restrict to these types (films, tv, games, books)
  *   --keep-duplicates   merge and repoint, but don't delete the leftovers
+ *   --merge-title-mismatches
+ *                       also merge groups whose titles disagree (dangerous)
  *   --json=path         write a machine-readable report
  *   --backup-dir=path   where to put backups (default ./backups)
  */
@@ -43,6 +52,7 @@ const args = parseArgs(process.argv);
 const options = {
   apply: args.apply === true,
   keepDuplicates: args["keep-duplicates"] === true,
+  mergeTitleMismatches: args["merge-title-mismatches"] === true,
   backupDir: String(args["backup-dir"] ?? path.join(__dirname, "backups")),
 };
 
@@ -90,7 +100,14 @@ const dedupeCollection = async (db, collection) => {
 
   const works = await db.collection(collection.works).find().toArray();
   const entries = await db.collection(collection.entries).find().toArray();
-  const plans = planDedupe(collection, works, entries);
+
+  const allGroups = planDedupe(collection, works, entries, {
+    includeTitleMismatches: true,
+  });
+  const plans = options.mergeTitleMismatches
+    ? allGroups
+    : allGroups.filter((p) => p.titlesAgree);
+  const skipped = allGroups.filter((p) => !plans.includes(p));
 
   const duplicateCount = plans.reduce((n, p) => n + p.duplicateIds.length, 0);
   const repointCount = plans.reduce((n, p) => n + p.entriesToRepoint.length, 0);
@@ -100,7 +117,17 @@ const dedupeCollection = async (db, collection) => {
       `${duplicateCount} documents to remove, ${repointCount} entries to repoint`
   );
 
-  if (plans.length === 0) return { works: works.length, groups: 0 };
+  if (skipped.length > 0) {
+    console.log(
+      `  ${skipped.length} group(s) skipped: the works share an apiRef but not ` +
+        `a title, so they are probably distinct works filed under one id`
+    );
+    for (const group of skipped) {
+      console.log(`      ${group.key}: ${JSON.stringify(group.titles)}`);
+    }
+  }
+
+  if (plans.length === 0) return { works: works.length, groups: 0, skipped };
 
   for (const plan of plans) {
     console.log(
@@ -128,7 +155,7 @@ const dedupeCollection = async (db, collection) => {
   }
 
   if (!options.apply) {
-    return { works: works.length, groups: plans.length, plans };
+    return { works: works.length, groups: plans.length, plans, skipped };
   }
 
   backup(collection.works, works);
@@ -162,7 +189,7 @@ const dedupeCollection = async (db, collection) => {
       `${options.keepDuplicates ? "kept" : "deleted"} ${duplicateCount} duplicates`
   );
 
-  return { works: works.length, groups: plans.length, plans };
+  return { works: works.length, groups: plans.length, plans, skipped };
 };
 
 const backup = (collectionName, documents) => {

--- a/src/db_maintenance/dedupe_works.js
+++ b/src/db_maintenance/dedupe_works.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * @file Collapses duplicate cached works and repoints the entries that refer
+ * to them (issue #83).
+ *
+ * This is the destructive half of the cleanup: it deletes documents. It is a
+ * dry run unless you pass --apply, it backs up both the work and the entry
+ * collection first, and it only ever groups works that share an API
+ * identifier — never by title. Which document survives and what gets merged
+ * into it is decided by ./work_dedupe_plan.js, which is unit tested.
+ *
+ * Order of operations per group: update the survivor, repoint the entries,
+ * then delete the duplicates. If the run dies half way, re-running converges
+ * on the same survivor.
+ *
+ * Environment (.env in this folder): MONGODB_URL. No API keys needed.
+ *
+ * Usage:
+ *   node dedupe_works.js
+ *   node dedupe_works.js --only=books
+ *   node dedupe_works.js --only=books --apply
+ *
+ * Flags:
+ *   --apply             actually write (default: dry run)
+ *   --only=a,b          restrict to these types (films, tv, games, books)
+ *   --keep-duplicates   merge and repoint, but don't delete the leftovers
+ *   --json=path         write a machine-readable report
+ *   --backup-dir=path   where to put backups (default ./backups)
+ */
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const {
+  COLLECTIONS,
+  selectCollections,
+  parseArgs,
+} = require("./work_collections");
+const { planDedupe } = require("./work_dedupe_plan");
+
+const args = parseArgs(process.argv);
+
+const options = {
+  apply: args.apply === true,
+  keepDuplicates: args["keep-duplicates"] === true,
+  backupDir: String(args["backup-dir"] ?? path.join(__dirname, "backups")),
+};
+
+let client;
+
+const main = async () => {
+  const selected = selectCollections(args.only);
+  if (selected.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Valid types: ${COLLECTIONS.map(
+        (c) => c.type
+      ).join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    options.apply
+      ? "APPLY MODE: works will be merged and duplicates deleted."
+      : "DRY RUN: nothing will be written. Re-run with --apply to commit."
+  );
+
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const report = {};
+  for (const collection of selected) {
+    report[collection.type] = await dedupeCollection(db, collection);
+  }
+
+  if (args.json) {
+    fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
+    console.log(`\nFull report written to ${args.json}`);
+  }
+
+  await client.close();
+};
+
+const dedupeCollection = async (db, collection) => {
+  console.log(`\n=== ${collection.works} ===`);
+
+  const works = await db.collection(collection.works).find().toArray();
+  const entries = await db.collection(collection.entries).find().toArray();
+  const plans = planDedupe(collection, works, entries);
+
+  const duplicateCount = plans.reduce((n, p) => n + p.duplicateIds.length, 0);
+  const repointCount = plans.reduce((n, p) => n + p.entriesToRepoint.length, 0);
+
+  console.log(
+    `  ${works.length} works, ${plans.length} duplicate groups, ` +
+      `${duplicateCount} documents to remove, ${repointCount} entries to repoint`
+  );
+
+  if (plans.length === 0) return { works: works.length, groups: 0 };
+
+  for (const plan of plans) {
+    console.log(
+      `  * ${plan.key}: keeping ${plan.survivorId} (${plan.titles[0]}), ` +
+        `merging ${plan.duplicateIds.length} duplicate(s)` +
+        `${
+          Object.keys(plan.updates).length > 0
+            ? `, filling ${Object.keys(plan.updates).join(", ")}`
+            : ""
+        }` +
+        `${
+          plan.entriesToRepoint.length > 0
+            ? `, repointing ${plan.entriesToRepoint.length} entry(s)`
+            : ""
+        }`
+    );
+    const otherTitles = [...new Set(plan.titles.slice(1))].filter(
+      (t) => t !== plan.titles[0]
+    );
+    if (otherTitles.length > 0) {
+      console.log(
+        `      note: duplicates have different titles: ${otherTitles.join(", ")}`
+      );
+    }
+  }
+
+  if (!options.apply) {
+    return { works: works.length, groups: plans.length, plans };
+  }
+
+  backup(collection.works, works);
+  backup(collection.entries, entries);
+
+  for (const plan of plans) {
+    if (Object.keys(plan.updates).length > 0) {
+      await db
+        .collection(collection.works)
+        .updateOne({ _id: plan.survivorId }, { $set: plan.updates });
+    }
+
+    if (plan.entriesToRepoint.length > 0) {
+      await db
+        .collection(collection.entries)
+        .updateMany(
+          { _id: { $in: plan.entriesToRepoint } },
+          { $set: { workRef: plan.survivorId } }
+        );
+    }
+
+    if (!options.keepDuplicates) {
+      await db
+        .collection(collection.works)
+        .deleteMany({ _id: { $in: plan.duplicateIds } });
+    }
+  }
+
+  console.log(
+    `  merged ${plans.length} groups, repointed ${repointCount} entries, ` +
+      `${options.keepDuplicates ? "kept" : "deleted"} ${duplicateCount} duplicates`
+  );
+
+  return { works: works.length, groups: plans.length, plans };
+};
+
+const backup = (collectionName, documents) => {
+  fs.mkdirSync(options.backupDir, { recursive: true });
+  const file = path.join(
+    options.backupDir,
+    `${collectionName}_${new Date().toISOString().replace(/:/g, "-")}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(documents, null, 2));
+  console.log(`  backed up ${documents.length} documents to ${file}`);
+};
+
+main().catch(async (e) => {
+  console.error(e);
+  process.exitCode = 1;
+  await client?.close();
+});

--- a/src/db_maintenance/dedupe_works.js
+++ b/src/db_maintenance/dedupe_works.js
@@ -9,12 +9,12 @@
  * identifier AND agree about the title. Which document survives and what gets
  * merged into it is decided by ./work_dedupe_plan.js, which is unit tested.
  *
- * The title check is not paranoia. Sharing an apiRef does not mean being the
- * same work in this database: "Fargo - Season 1" and "Fargo - Season 2" sit
- * under one show id, five Haruhi Suzumiya volumes share one ISBN, and
- * "Demons" is filed under The Da Vinci Code's. Those groups are reported and
- * skipped; --merge-title-mismatches forces them through, and you should read
- * every one of them first.
+ * The title check matters: sharing an apiRef does not mean being the same
+ * work. "Fargo - Season 1" and "Fargo - Season 2" sit under one show id, five
+ * Haruhi Suzumiya volumes share one ISBN, and "Demons" is filed under The Da
+ * Vinci Code's. Those groups are reported and skipped;
+ * --merge-title-mismatches forces them through, and you should read every one
+ * of them first.
  *
  * Order of operations per group: update the survivor, repoint the entries,
  * then delete the duplicates. If the run dies half way, re-running converges

--- a/src/db_maintenance/mongodb_add_missing_book_publishers.js
+++ b/src/db_maintenance/mongodb_add_missing_book_publishers.js
@@ -44,14 +44,18 @@ const updateAllCachedGameEntriesWithoutPublishers = async (books) => {
     const isbn = book.apiRefs
       .find((ref) => ref.startsWith("ISBN"))
       .replace("ISBN__", "");
-    const publishers = axios({
+    // This used to store the un-awaited Promise itself, which Mongo wrote as
+    // an empty object, and it mapped over every result instead of taking the
+    // first, producing an array of arrays. `publishers` must be a flat array
+    // of strings — see the bookParser in ../api/utils/parsers/books.js.
+    const publisher = await axios({
       method: "get",
       url: `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`,
-    }).then(({ data }) =>
-      data.items?.map(({ volumeInfo }) =>
-        volumeInfo.publisher ? [volumeInfo.publisher] : undefined
-      )
-    );
+    })
+      .then(({ data }) => data.items?.[0]?.volumeInfo?.publisher)
+      .catch(() => undefined);
+
+    const publishers = publisher ? [publisher] : undefined;
 
     if (publishers) {
       console.log("Adding missing publisher for ", book.englishTranslatedTitle);

--- a/src/db_maintenance/mongodb_add_missing_book_publishers.js
+++ b/src/db_maintenance/mongodb_add_missing_book_publishers.js
@@ -44,10 +44,10 @@ const updateAllCachedGameEntriesWithoutPublishers = async (books) => {
     const isbn = book.apiRefs
       .find((ref) => ref.startsWith("ISBN"))
       .replace("ISBN__", "");
-    // This used to store the un-awaited Promise itself, which Mongo wrote as
-    // an empty object, and it mapped over every result instead of taking the
-    // first, producing an array of arrays. `publishers` must be a flat array
-    // of strings — see the bookParser in ../api/utils/parsers/books.js.
+    // `publishers` must end up a flat array of strings — see the bookParser
+    // in ../api/utils/parsers/books.js. Await the response and take the first
+    // result: an un-awaited Promise is stored by Mongo as an empty object,
+    // and mapping over every result gives an array of arrays.
     const publisher = await axios({
       method: "get",
       url: `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`,

--- a/src/db_maintenance/work_collections.js
+++ b/src/db_maintenance/work_collections.js
@@ -1,0 +1,168 @@
+/**
+ * @file Shared description of the work/entry collections, used by the
+ * audit and backfill scripts. Keep this in sync with
+ * ../api/utils/parsers/ and ../api/utils/external_api_adapters/.
+ */
+
+/**
+ * `apiRefPrefixes` lists every prefix a cached work may legitimately carry.
+ * `retrievePrefix` is the one the adapter's `retrieve(ref)` expects.
+ * `stringArrayFields` / `numberFields` are the metadata fields we expect the
+ * adapter to fill, and that the audit checks for corruption.
+ */
+const COLLECTIONS = [
+  {
+    type: "films",
+    works: "films",
+    entries: "filmEntries",
+    entryType: "Film",
+    adapterModule: "../api/utils/external_api_adapters/films/tmdb",
+    apiRefPrefixes: ["tmdb"],
+    retrievePrefix: "tmdb",
+    stringArrayFields: ["genres", "directors", "actors"],
+    numberFields: ["releaseYear", "duration"],
+    defaultDelayMs: 300,
+  },
+  {
+    type: "tv",
+    works: "tvShows",
+    entries: "tvShowEntries",
+    entryType: "TVShow",
+    adapterModule: "../api/utils/external_api_adapters/tv_shows/tmdb",
+    apiRefPrefixes: ["tmdb"],
+    retrievePrefix: "tmdb",
+    stringArrayFields: ["genres", "directors", "actors"],
+    numberFields: ["releaseYear", "duration", "episodes"],
+    defaultDelayMs: 300,
+  },
+  {
+    type: "games",
+    works: "games",
+    entries: "gameEntries",
+    entryType: "Game",
+    adapterModule: "../api/utils/external_api_adapters/games/igdb_and_hltb",
+    // `hltb` is a secondary ref: it is added by the adapter alongside `igdb`,
+    // but only `igdb` can be used to re-retrieve the work.
+    apiRefPrefixes: ["igdb", "hltb"],
+    retrievePrefix: "igdb",
+    stringArrayFields: ["genres", "platforms", "studios", "publishers"],
+    numberFields: ["releaseYear", "duration"],
+    // IGDB caps at 4 req/s and the HLTB lookup scrapes the site, so go slow.
+    defaultDelayMs: 1500,
+  },
+  {
+    type: "books",
+    works: "books",
+    entries: "bookEntries",
+    entryType: "Book",
+    adapterModule: "../api/utils/external_api_adapters/books/google",
+    // Books were cached under `ISBN__` by the adapter, but the works
+    // controller used to look them up as `google__`, so both may exist.
+    apiRefPrefixes: ["ISBN", "google"],
+    retrievePrefix: "ISBN",
+    stringArrayFields: ["genres", "authors", "publishers"],
+    numberFields: ["releaseYear", "duration"],
+    // The unauthenticated Google Books API rate limits aggressively.
+    defaultDelayMs: 1000,
+  },
+];
+
+/** Fields every work is expected to carry, whatever its type. */
+const COMMON_FIELDS = [
+  "englishTranslatedTitle",
+  "imageUrl",
+  "releaseYear",
+  "duration",
+  "genres",
+];
+
+/**
+ * apiRefs are flat strings (`igdb__1234`) since
+ * flatten_api_refs_in_work_collections.js ran, but a few documents may still
+ * hold the original `{ name, ref }` objects.
+ * @type {(apiRef: unknown) => { name: string, ref: string, flat: boolean } | undefined}
+ */
+const parseApiRef = (apiRef) => {
+  if (typeof apiRef === "string") {
+    const separatorAt = apiRef.indexOf("__");
+    if (separatorAt <= 0) return undefined;
+    return {
+      name: apiRef.slice(0, separatorAt),
+      ref: apiRef.slice(separatorAt + 2),
+      flat: true,
+    };
+  }
+  if (apiRef && typeof apiRef === "object" && apiRef.name && apiRef.ref) {
+    return { name: String(apiRef.name), ref: String(apiRef.ref), flat: false };
+  }
+  return undefined;
+};
+
+/** @type {(apiRefs: unknown, name: string) => string | undefined} */
+const findApiRef = (apiRefs, name) => {
+  if (!Array.isArray(apiRefs)) return undefined;
+  return apiRefs
+    .map(parseApiRef)
+    .find((parsed) => parsed?.name === name)?.ref;
+};
+
+/** Empty means "there is nothing usable here", so it's safe to overwrite. */
+const isEmptyValue = (value) =>
+  value === undefined ||
+  value === null ||
+  value === "" ||
+  (Array.isArray(value) && value.length === 0);
+
+/**
+ * mongodb_add_missing_book_publishers.js stored an unawaited Promise, which
+ * lands in Mongo as `{}`. More generally, anything that isn't an array of
+ * non-empty strings is unusable for a string array field.
+ */
+const isCorruptStringArray = (value) =>
+  !isEmptyValue(value) &&
+  (!Array.isArray(value) ||
+    value.some((item) => typeof item !== "string" || item === ""));
+
+const isCorruptNumber = (value) =>
+  !isEmptyValue(value) && (typeof value !== "number" || Number.isNaN(value));
+
+const isCorruptExternalUrls = (value) =>
+  !isEmptyValue(value) &&
+  (!Array.isArray(value) ||
+    value.some(
+      (url) =>
+        !url ||
+        typeof url !== "object" ||
+        typeof url.name !== "string" ||
+        typeof url.url !== "string"
+    ));
+
+/** Resolves a `--only=games,books` value to collection descriptors. */
+const selectCollections = (only) =>
+  only === undefined || only === true
+    ? COLLECTIONS
+    : COLLECTIONS.filter((c) => String(only).split(",").includes(c.type));
+
+const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
+
+/** Minimal `--flag` / `--flag=value` parser for these scripts. */
+const parseArgs = (argv) =>
+  argv.slice(2).reduce((args, arg) => {
+    if (!arg.startsWith("--")) return args;
+    const [name, ...rest] = arg.slice(2).split("=");
+    return { ...args, [name]: rest.length === 0 ? true : rest.join("=") };
+  }, {});
+
+module.exports = {
+  COLLECTIONS,
+  COMMON_FIELDS,
+  parseApiRef,
+  findApiRef,
+  isEmptyValue,
+  isCorruptStringArray,
+  isCorruptNumber,
+  isCorruptExternalUrls,
+  selectCollections,
+  sleep,
+  parseArgs,
+};

--- a/src/db_maintenance/work_collections.js
+++ b/src/db_maintenance/work_collections.js
@@ -18,6 +18,7 @@ const COLLECTIONS = [
     entryType: "Film",
     adapterModule: "../api/utils/external_api_adapters/films/tmdb",
     apiRefPrefixes: ["tmdb"],
+    identityPrefixes: ["tmdb"],
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration"],
@@ -30,6 +31,7 @@ const COLLECTIONS = [
     entryType: "TVShow",
     adapterModule: "../api/utils/external_api_adapters/tv_shows/tmdb",
     apiRefPrefixes: ["tmdb"],
+    identityPrefixes: ["tmdb"],
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration", "episodes"],
@@ -44,6 +46,9 @@ const COLLECTIONS = [
     // `hltb` is a secondary ref: it is added by the adapter alongside `igdb`,
     // but only `igdb` can be used to re-retrieve the work.
     apiRefPrefixes: ["igdb", "hltb"],
+    // An hltb id identifies a HowLongToBeat page, not the game, and plenty of
+    // games share the placeholder `hltb__N/A`. Only igdb establishes identity.
+    identityPrefixes: ["igdb"],
     retrievePrefix: "igdb",
     stringArrayFields: ["genres", "platforms", "studios", "publishers"],
     numberFields: ["releaseYear", "duration"],
@@ -59,6 +64,8 @@ const COLLECTIONS = [
     // Books were cached under `ISBN__` by the adapter, but the works
     // controller used to look them up as `google__`, so both may exist.
     apiRefPrefixes: ["ISBN", "google"],
+    // Both name the same ISBN, so either establishes identity.
+    identityPrefixes: ["ISBN", "google"],
     retrievePrefix: "ISBN",
     stringArrayFields: ["genres", "authors", "publishers"],
     numberFields: ["releaseYear", "duration"],
@@ -77,12 +84,43 @@ const COMMON_FIELDS = [
 ];
 
 /**
+ * Values that were stored where an identifier should have been. The database
+ * really contains 27 games with `hltb__N/A` and 14 films with
+ * `undefined__undefined`; treating those as identifiers would make every one
+ * of them look like the same work.
+ */
+const PLACEHOLDER_REF_VALUES = new Set([
+  "",
+  "0",
+  "n/a",
+  "na",
+  "null",
+  "undefined",
+  "nan",
+  "none",
+  "false",
+]);
+
+const isPlaceholder = (value) =>
+  PLACEHOLDER_REF_VALUES.has(String(value).trim().toLowerCase());
+
+/**
  * apiRefs are flat strings (`igdb__1234`) since
  * flatten_api_refs_in_work_collections.js ran, but a few documents may still
  * hold the original `{ name, ref }` objects.
+ *
+ * Returns undefined for anything that isn't a usable identifier, so a
+ * placeholder can never be mistaken for one.
  * @type {(apiRef: unknown) => { name: string, ref: string, flat: boolean } | undefined}
  */
 const parseApiRef = (apiRef) => {
+  const parsed = parseApiRefShape(apiRef);
+  if (!parsed) return undefined;
+  if (isPlaceholder(parsed.name) || isPlaceholder(parsed.ref)) return undefined;
+  return parsed;
+};
+
+const parseApiRefShape = (apiRef) => {
   if (typeof apiRef === "string") {
     const separatorAt = apiRef.indexOf("__");
     if (separatorAt <= 0) return undefined;
@@ -156,6 +194,8 @@ const parseArgs = (argv) =>
 module.exports = {
   COLLECTIONS,
   COMMON_FIELDS,
+  PLACEHOLDER_REF_VALUES,
+  isPlaceholder,
   parseApiRef,
   findApiRef,
   isEmptyValue,

--- a/src/db_maintenance/work_collections.js
+++ b/src/db_maintenance/work_collections.js
@@ -61,8 +61,8 @@ const COLLECTIONS = [
     entries: "bookEntries",
     entryType: "Book",
     adapterModule: "../api/utils/external_api_adapters/books/google",
-    // Books were cached under `ISBN__` by the adapter, but the works
-    // controller used to look them up as `google__`, so both may exist.
+    // The adapter caches books under `ISBN__`; some documents carry
+    // `google__` instead, naming the same ISBN.
     apiRefPrefixes: ["ISBN", "google"],
     // Both name the same ISBN, so either establishes identity.
     identityPrefixes: ["ISBN", "google"],

--- a/src/db_maintenance/work_dedupe_plan.js
+++ b/src/db_maintenance/work_dedupe_plan.js
@@ -1,0 +1,168 @@
+/**
+ * @file Works out which duplicate works to collapse and into what.
+ *
+ * populate_work_collections.js created one work document per *entry*, so the
+ * same film cached for two users became two documents. The books path made it
+ * worse: the works controller looked books up as `google__<isbn>` while the
+ * adapter cached them as `ISBN__<isbn>`, so every retrieve missed the cache
+ * and created another copy.
+ *
+ * Pure and dependency-free: dedupe_works.js deletes documents based on what
+ * this returns, so the decisions are unit tested
+ * (./work_dedupe_plan.test.js) rather than discovered in production.
+ */
+const { parseApiRef, isEmptyValue } = require("./work_collections");
+const {
+  expectedFields,
+  isCorruptField,
+  mergeApiRefs,
+  mergeExternalUrls,
+  completeness,
+} = require("./work_metadata_merge");
+
+/**
+ * Groups works by every apiRef they carry that the type can be retrieved by.
+ * A work is only ever placed in one group, so two duplicates that overlap on
+ * one ref but not another are still collapsed together.
+ * @type {(collection: any, works: any[]) => Map<string, any[]>}
+ */
+const groupWorksByApiRef = (collection, works) => {
+  const groups = new Map();
+  for (const work of works) {
+    const key = groupKey(collection, work);
+    if (!key) continue;
+    groups.set(key, [...(groups.get(key) ?? []), work]);
+  }
+  return groups;
+};
+
+/**
+ * The first prefix the work has a ref for, in `apiRefPrefixes` order, so a
+ * book stored as `ISBN__x` and a book stored as `google__x` land in the same
+ * group when they share the identifier.
+ */
+const groupKey = (collection, work) => {
+  const refs = (Array.isArray(work.apiRefs) ? work.apiRefs : [])
+    .map(parseApiRef)
+    .filter((ref) => ref);
+
+  for (const prefix of collection.apiRefPrefixes) {
+    const match = refs.find((ref) => ref.name === prefix);
+    // Books are keyed on the bare identifier: ISBN__x and google__x are the
+    // same book. Everything else keeps its prefix, since an igdb id and an
+    // hltb id are different numbering schemes.
+    if (match) {
+      return collection.type === "books" ? match.ref : `${prefix}__${match.ref}`;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * One plan per group that has more than one work in it.
+ *
+ * The survivor is the most complete document, tie-broken by how many entries
+ * already point at it and then by id, so the plan is deterministic and
+ * re-running after a partial failure converges.
+ *
+ * @type {(collection: any, works: any[], entries: any[]) => Array<{
+ *   key: string,
+ *   survivorId: string,
+ *   duplicateIds: string[],
+ *   updates: object,
+ *   entriesToRepoint: string[],
+ *   titles: string[],
+ * }>}
+ */
+const planDedupe = (collection, works, entries) => {
+  const entriesByWorkRef = new Map();
+  for (const entry of entries) {
+    if (!entry.workRef) continue;
+    entriesByWorkRef.set(entry.workRef, [
+      ...(entriesByWorkRef.get(entry.workRef) ?? []),
+      entry,
+    ]);
+  }
+
+  const entryCount = (work) => (entriesByWorkRef.get(work._id) ?? []).length;
+
+  const plans = [];
+  for (const [key, group] of groupWorksByApiRef(collection, works)) {
+    if (group.length < 2) continue;
+
+    const ranked = [...group].sort(
+      (a, b) =>
+        completeness(collection, b) - completeness(collection, a) ||
+        entryCount(b) - entryCount(a) ||
+        String(a._id).localeCompare(String(b._id))
+    );
+
+    const [survivor, ...duplicates] = ranked;
+
+    plans.push({
+      key,
+      survivorId: survivor._id,
+      duplicateIds: duplicates.map((w) => w._id),
+      updates: fillGapsFromDuplicates(collection, survivor, duplicates),
+      entriesToRepoint: duplicates.flatMap((w) =>
+        (entriesByWorkRef.get(w._id) ?? []).map((e) => e._id)
+      ),
+      titles: ranked.map(
+        (w) => w.englishTranslatedTitle ?? w.originalTitle ?? "(untitled)"
+      ),
+    });
+  }
+
+  return plans;
+};
+
+/**
+ * Nothing a duplicate knows is thrown away: any field the survivor is missing
+ * is taken from the first duplicate that has a usable value, and refs and
+ * links from every copy are unioned in.
+ */
+const fillGapsFromDuplicates = (collection, survivor, duplicates) => {
+  const updates = {};
+
+  for (const field of expectedFields(collection)) {
+    const usable = (work) =>
+      !isEmptyValue(work[field]) &&
+      !isCorruptField(collection, field, work[field]);
+    if (usable(survivor)) continue;
+    const donor = duplicates.find(usable);
+    if (donor) updates[field] = donor[field];
+  }
+
+  // `missingOnly` so the survivor's own refs and links win; a duplicate can
+  // only contribute a name the survivor doesn't already have.
+  const keepExisting = { missingOnly: true };
+
+  const apiRefs = duplicates.reduce(
+    (merged, duplicate) =>
+      mergeApiRefs(merged, duplicate.apiRefs ?? [], keepExisting),
+    survivor.apiRefs ?? []
+  );
+  if (!equal(apiRefs, survivor.apiRefs)) updates.apiRefs = apiRefs;
+
+  const externalUrls = duplicates.reduce(
+    (merged, duplicate) =>
+      mergeExternalUrls(merged, duplicate.externalUrls ?? [], keepExisting),
+    survivor.externalUrls ?? []
+  );
+  if (!equal(externalUrls, survivor.externalUrls)) {
+    updates.externalUrls = externalUrls;
+  }
+
+  return updates;
+};
+
+module.exports = {
+  groupWorksByApiRef,
+  groupKey,
+  planDedupe,
+  fillGapsFromDuplicates,
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+const equal = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);

--- a/src/db_maintenance/work_dedupe_plan.js
+++ b/src/db_maintenance/work_dedupe_plan.js
@@ -1,11 +1,8 @@
 /**
  * @file Works out which duplicate works to collapse and into what.
  *
- * populate_work_collections.js created one work document per *entry*, so the
- * same film cached for two users became two documents. The books path made it
- * worse: the works controller looked books up as `google__<isbn>` while the
- * adapter cached them as `ISBN__<isbn>`, so every retrieve missed the cache
- * and created another copy.
+ * The work collections hold multiple documents describing the same work —
+ * in some cases one per entry that referenced it.
  *
  * Pure and dependency-free: dedupe_works.js deletes documents based on what
  * this returns, so the decisions are unit tested
@@ -40,10 +37,10 @@ const groupWorksByApiRef = (collection, works) => {
  * The first prefix the work has a ref for, in `identityPrefixes` order.
  *
  * Only prefixes that actually establish identity count. An hltb id names a
- * HowLongToBeat page rather than the game, and 27 games in the database carry
- * the placeholder `hltb__N/A` — grouping on that would present 27 unrelated
- * games as copies of one another. `parseApiRef` drops placeholder values, so
- * a work whose only ref is one of those is left ungrouped and untouched.
+ * HowLongToBeat page rather than the game, and 27 games carry the placeholder
+ * `hltb__N/A`, so grouping on one would present unrelated games as copies of
+ * one another. `parseApiRef` drops placeholder values, so a work whose only
+ * ref is one of those is left ungrouped and untouched.
  */
 const groupKey = (collection, work) => {
   const refs = (Array.isArray(work.apiRefs) ? work.apiRefs : [])
@@ -69,11 +66,11 @@ const groupKey = (collection, work) => {
  * re-running after a partial failure converges.
  *
  * Groups whose members disagree about the title are NOT returned unless
- * `includeTitleMismatches` is set. Sharing an apiRef turns out not to mean
- * being the same work: the database has "Fargo - Season 1" and
- * "Fargo - Season 2" under one show id, five Haruhi Suzumiya volumes under
- * one ISBN, and "Demons" filed under The Da Vinci Code's. Merging those
- * would destroy distinct entries, so a title disagreement is a stop sign.
+ * `includeTitleMismatches` is set. Sharing an apiRef does not mean being the
+ * same work: "Fargo - Season 1" and "Fargo - Season 2" sit under one show id,
+ * five Haruhi Suzumiya volumes share one ISBN, and "Demons" is filed under
+ * The Da Vinci Code's. Those are distinct works, so a title disagreement is a
+ * stop sign.
  *
  * @type {(collection: any, works: any[], entries: any[], options?: { includeTitleMismatches?: boolean }) => Array<{
  *   key: string,

--- a/src/db_maintenance/work_dedupe_plan.js
+++ b/src/db_maintenance/work_dedupe_plan.js
@@ -37,20 +37,23 @@ const groupWorksByApiRef = (collection, works) => {
 };
 
 /**
- * The first prefix the work has a ref for, in `apiRefPrefixes` order, so a
- * book stored as `ISBN__x` and a book stored as `google__x` land in the same
- * group when they share the identifier.
+ * The first prefix the work has a ref for, in `identityPrefixes` order.
+ *
+ * Only prefixes that actually establish identity count. An hltb id names a
+ * HowLongToBeat page rather than the game, and 27 games in the database carry
+ * the placeholder `hltb__N/A` — grouping on that would present 27 unrelated
+ * games as copies of one another. `parseApiRef` drops placeholder values, so
+ * a work whose only ref is one of those is left ungrouped and untouched.
  */
 const groupKey = (collection, work) => {
   const refs = (Array.isArray(work.apiRefs) ? work.apiRefs : [])
     .map(parseApiRef)
     .filter((ref) => ref);
 
-  for (const prefix of collection.apiRefPrefixes) {
+  for (const prefix of collection.identityPrefixes) {
     const match = refs.find((ref) => ref.name === prefix);
     // Books are keyed on the bare identifier: ISBN__x and google__x are the
-    // same book. Everything else keeps its prefix, since an igdb id and an
-    // hltb id are different numbering schemes.
+    // same book. Everything else keeps its prefix.
     if (match) {
       return collection.type === "books" ? match.ref : `${prefix}__${match.ref}`;
     }
@@ -65,16 +68,29 @@ const groupKey = (collection, work) => {
  * already point at it and then by id, so the plan is deterministic and
  * re-running after a partial failure converges.
  *
- * @type {(collection: any, works: any[], entries: any[]) => Array<{
+ * Groups whose members disagree about the title are NOT returned unless
+ * `includeTitleMismatches` is set. Sharing an apiRef turns out not to mean
+ * being the same work: the database has "Fargo - Season 1" and
+ * "Fargo - Season 2" under one show id, five Haruhi Suzumiya volumes under
+ * one ISBN, and "Demons" filed under The Da Vinci Code's. Merging those
+ * would destroy distinct entries, so a title disagreement is a stop sign.
+ *
+ * @type {(collection: any, works: any[], entries: any[], options?: { includeTitleMismatches?: boolean }) => Array<{
  *   key: string,
  *   survivorId: string,
  *   duplicateIds: string[],
  *   updates: object,
  *   entriesToRepoint: string[],
  *   titles: string[],
+ *   titlesAgree: boolean,
  * }>}
  */
-const planDedupe = (collection, works, entries) => {
+const planDedupe = (
+  collection,
+  works,
+  entries,
+  { includeTitleMismatches = false } = {}
+) => {
   const entriesByWorkRef = new Map();
   for (const entry of entries) {
     if (!entry.workRef) continue;
@@ -99,6 +115,13 @@ const planDedupe = (collection, works, entries) => {
 
     const [survivor, ...duplicates] = ranked;
 
+    const titles = ranked.map(
+      (w) => w.englishTranslatedTitle ?? w.originalTitle ?? "(untitled)"
+    );
+    const titlesAgree = new Set(titles.map(normalizeTitle)).size === 1;
+
+    if (!titlesAgree && !includeTitleMismatches) continue;
+
     plans.push({
       key,
       survivorId: survivor._id,
@@ -107,14 +130,19 @@ const planDedupe = (collection, works, entries) => {
       entriesToRepoint: duplicates.flatMap((w) =>
         (entriesByWorkRef.get(w._id) ?? []).map((e) => e._id)
       ),
-      titles: ranked.map(
-        (w) => w.englishTranslatedTitle ?? w.originalTitle ?? "(untitled)"
-      ),
+      titles,
+      titlesAgree,
     });
   }
 
   return plans;
 };
+
+/** Punctuation and case vary between imports; a real difference doesn't. */
+const normalizeTitle = (title) =>
+  String(title)
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]/gu, "");
 
 /**
  * Nothing a duplicate knows is thrown away: any field the survivor is missing
@@ -158,6 +186,7 @@ const fillGapsFromDuplicates = (collection, survivor, duplicates) => {
 
 module.exports = {
   groupWorksByApiRef,
+  normalizeTitle,
   groupKey,
   planDedupe,
   fillGapsFromDuplicates,

--- a/src/db_maintenance/work_dedupe_plan.test.js
+++ b/src/db_maintenance/work_dedupe_plan.test.js
@@ -169,8 +169,8 @@ test("an hltb ref never establishes identity on its own", () => {
 });
 
 test("games sharing the placeholder hltb__N/A are never grouped", () => {
-  // The database really holds 27 of these. Grouping on the placeholder would
-  // present 27 unrelated games as copies and delete 26 of them.
+  // 27 games carry this placeholder. Grouping on it would present them as
+  // copies of one another and delete all but one.
   const games = COLLECTIONS.find((c) => c.type === "games");
   const placeholder = (id, title) => ({
     _id: id,

--- a/src/db_maintenance/work_dedupe_plan.test.js
+++ b/src/db_maintenance/work_dedupe_plan.test.js
@@ -159,21 +159,97 @@ test("a book cached as ISBN__ and as google__ is one book", () => {
   assert.deepEqual(plans[0].duplicateIds, ["b"]);
 });
 
-test("an igdb id and an hltb id are not confused for each other", () => {
-  const gamesCollection = COLLECTIONS.find((c) => c.type === "games");
+test("an hltb ref never establishes identity on its own", () => {
+  const games = COLLECTIONS.find((c) => c.type === "games");
 
-  assert.notEqual(
-    groupKey(gamesCollection, { apiRefs: ["igdb__100"] }),
-    groupKey(gamesCollection, { apiRefs: ["hltb__100"] })
+  // A HowLongToBeat id names a page, not the game, so two games that happen
+  // to share one are not duplicates.
+  assert.equal(groupKey(games, { apiRefs: ["hltb__100"] }), undefined);
+  assert.equal(groupKey(games, { apiRefs: ["igdb__100"] }), "igdb__100");
+});
+
+test("games sharing the placeholder hltb__N/A are never grouped", () => {
+  // The database really holds 27 of these. Grouping on the placeholder would
+  // present 27 unrelated games as copies and delete 26 of them.
+  const games = COLLECTIONS.find((c) => c.type === "games");
+  const placeholder = (id, title) => ({
+    _id: id,
+    entryType: "Game",
+    englishTranslatedTitle: title,
+    apiRefs: ["hltb__N/A"],
+  });
+
+  const works = [
+    placeholder("a", "Cards Against Humanity"),
+    placeholder("b", "Doom mod: Sigil"),
+    placeholder("c", "Resident Evil 4: Separate Ways"),
+  ];
+  const entries = works.map((w, i) => ({ _id: `e${i}`, workRef: w._id }));
+
+  assert.equal(groupKey(games, works[0]), undefined);
+  assert.deepEqual(planDedupe(games, works, entries), []);
+});
+
+test("films with undefined__undefined refs are never grouped", () => {
+  // 14 films in the database carry this.
+  const works = ["a", "b", "c"].map((id) => ({
+    _id: id,
+    entryType: "Film",
+    englishTranslatedTitle: `Film ${id}`,
+    apiRefs: ["undefined__undefined"],
+  }));
+
+  assert.equal(groupKey(films, works[0]), undefined);
+  assert.deepEqual(planDedupe(films, works, []), []);
+});
+
+test("a placeholder never masks a real identifier on the same work", () => {
+  const games = COLLECTIONS.find((c) => c.type === "games");
+
+  assert.equal(
+    groupKey(games, { apiRefs: ["hltb__N/A", "igdb__14593"] }),
+    "igdb__14593"
   );
 });
 
-test("duplicates with different titles are surfaced for review", () => {
-  const [plan] = planDedupe(
-    films,
-    [film("a", { imageUrl: "https://img" }), film("b", { englishTranslatedTitle: "Сталкер" })],
-    []
-  );
+test("works sharing an apiRef but not a title are not merged", () => {
+  // "Fargo - Season 1" and "Fargo - Season 2" really do sit under one tmdb
+  // id. Merging them would destroy one of the two seasons being tracked.
+  const works = [
+    film("a", { englishTranslatedTitle: "Fargo - Season 1", imageUrl: "https://img" }),
+    film("b", { englishTranslatedTitle: "Fargo - Season 2" }),
+  ];
 
-  assert.deepEqual(plan.titles, ["Stalker", "Сталкер"]);
+  assert.deepEqual(planDedupe(films, works, []), []);
+
+  const [forced] = planDedupe(films, works, [], {
+    includeTitleMismatches: true,
+  });
+  assert.equal(forced.titlesAgree, false);
+  assert.deepEqual(forced.titles, ["Fargo - Season 1", "Fargo - Season 2"]);
+});
+
+test("titles differing only in punctuation or case still count as agreeing", () => {
+  const works = [
+    film("a", { englishTranslatedTitle: "WALL·E", imageUrl: "https://img" }),
+    film("b", { englishTranslatedTitle: "Wall-E" }),
+  ];
+
+  const [plan] = planDedupe(films, works, []);
+
+  assert.equal(plan.titlesAgree, true);
+  assert.deepEqual(plan.duplicateIds, ["b"]);
+});
+
+test("a mixed group is skipped whole rather than partly merged", () => {
+  // Castlevania has Season 1 twice and Season 2 once under one id. The two
+  // Season 1 documents are genuine duplicates, but sorting that out means
+  // looking at it, so the whole group stays put.
+  const works = [
+    film("a", { englishTranslatedTitle: "Castlevania: Season 1" }),
+    film("b", { englishTranslatedTitle: "Castlevania: Season 1" }),
+    film("c", { englishTranslatedTitle: "Castlevania: Season 2" }),
+  ];
+
+  assert.deepEqual(planDedupe(films, works, []), []);
 });

--- a/src/db_maintenance/work_dedupe_plan.test.js
+++ b/src/db_maintenance/work_dedupe_plan.test.js
@@ -1,0 +1,179 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { COLLECTIONS } = require("./work_collections");
+const { planDedupe, groupKey } = require("./work_dedupe_plan");
+
+const films = COLLECTIONS.find((c) => c.type === "films");
+const books = COLLECTIONS.find((c) => c.type === "books");
+
+const film = (id, extra) => ({
+  _id: id,
+  entryType: "Film",
+  englishTranslatedTitle: "Stalker",
+  apiRefs: ["tmdb__1398"],
+  ...extra,
+});
+
+test("works that share no apiRef are left alone", () => {
+  const works = [film("a"), film("b", { apiRefs: ["tmdb__999"] })];
+
+  assert.deepEqual(planDedupe(films, works, []), []);
+});
+
+test("a work with no apiRef is never grouped", () => {
+  const works = [film("a", { apiRefs: [] }), film("b", { apiRefs: undefined })];
+
+  assert.deepEqual(planDedupe(films, works, []), []);
+});
+
+test("the most complete duplicate survives and absorbs the rest", () => {
+  const sparse = film("a", { imageUrl: undefined, genres: [] });
+  const rich = film("b", {
+    imageUrl: "https://img",
+    genres: ["Sci-Fi"],
+    releaseYear: 1979,
+    duration: 162,
+    directors: ["Andrei Tarkovsky"],
+    actors: ["Alisa Freindlich"],
+  });
+
+  const [plan] = planDedupe(films, [sparse, rich], []);
+
+  assert.equal(plan.survivorId, "b");
+  assert.deepEqual(plan.duplicateIds, ["a"]);
+});
+
+test("gaps in the survivor are filled from the duplicates", () => {
+  const survivor = film("a", {
+    imageUrl: "https://img",
+    genres: ["Sci-Fi"],
+    releaseYear: 1979,
+    duration: 162,
+    directors: [],
+    externalUrls: [{ name: "tmdb", url: "https://tmdb/1398" }],
+  });
+  const duplicate = film("b", {
+    directors: ["Andrei Tarkovsky"],
+    apiRefs: ["tmdb__1398", "imdb__tt0079944"],
+    externalUrls: [{ name: "imdb", url: "https://imdb/tt0079944" }],
+  });
+
+  const [plan] = planDedupe(films, [survivor, duplicate], []);
+
+  assert.equal(plan.survivorId, "a");
+  assert.deepEqual(plan.updates.directors, ["Andrei Tarkovsky"]);
+  assert.deepEqual(plan.updates.apiRefs, ["tmdb__1398", "imdb__tt0079944"]);
+  assert.deepEqual(plan.updates.externalUrls, [
+    { name: "tmdb", url: "https://tmdb/1398" },
+    { name: "imdb", url: "https://imdb/tt0079944" },
+  ]);
+});
+
+test("the survivor's own values are never replaced by a duplicate's", () => {
+  const survivor = film("a", {
+    imageUrl: "https://kept",
+    genres: ["Sci-Fi"],
+    releaseYear: 1979,
+    duration: 162,
+    directors: ["Andrei Tarkovsky"],
+    actors: ["Alisa Freindlich"],
+    externalUrls: [{ name: "tmdb", url: "https://kept" }],
+  });
+  const duplicate = film("b", {
+    imageUrl: "https://other",
+    externalUrls: [{ name: "tmdb", url: "https://other" }],
+  });
+
+  const [plan] = planDedupe(films, [survivor, duplicate], []);
+
+  assert.equal(plan.survivorId, "a");
+  assert.deepEqual(plan.updates, {});
+});
+
+test("entries pointing at a duplicate are repointed at the survivor", () => {
+  const survivor = film("a", { imageUrl: "https://img" });
+  const duplicate = film("b");
+  const entries = [
+    { _id: "e1", userId: "u1", workRef: "a" },
+    { _id: "e2", userId: "u2", workRef: "b" },
+    { _id: "e3", userId: "u3", workRef: "b" },
+    { _id: "e4", userId: "u4", workRef: null },
+  ];
+
+  const [plan] = planDedupe(films, [survivor, duplicate], entries);
+
+  assert.equal(plan.survivorId, "a");
+  assert.deepEqual(plan.entriesToRepoint.sort(), ["e2", "e3"]);
+});
+
+test("equally complete duplicates are ranked by how many entries use them", () => {
+  const entries = [
+    { _id: "e1", workRef: "b" },
+    { _id: "e2", workRef: "b" },
+    { _id: "e3", workRef: "a" },
+  ];
+
+  const [plan] = planDedupe(films, [film("a"), film("b")], entries);
+
+  assert.equal(plan.survivorId, "b");
+  assert.deepEqual(plan.entriesToRepoint, ["e3"]);
+});
+
+test("otherwise identical duplicates are ordered deterministically", () => {
+  const [forwards] = planDedupe(films, [film("a"), film("b")], []);
+  const [backwards] = planDedupe(films, [film("b"), film("a")], []);
+
+  assert.equal(forwards.survivorId, "a");
+  assert.equal(backwards.survivorId, "a");
+});
+
+test("re-running after a completed merge finds nothing to do", () => {
+  const survivor = film("a", { imageUrl: "https://img" });
+  const duplicate = film("b");
+  const entries = [{ _id: "e1", workRef: "b" }];
+
+  const [plan] = planDedupe(films, [survivor, duplicate], entries);
+  const merged = { ...survivor, ...plan.updates };
+  const repointed = entries.map((e) => ({ ...e, workRef: plan.survivorId }));
+
+  assert.deepEqual(planDedupe(films, [merged], repointed), []);
+});
+
+test("a book cached as ISBN__ and as google__ is one book", () => {
+  assert.equal(
+    groupKey(books, { apiRefs: ["ISBN__9780441013593"] }),
+    groupKey(books, { apiRefs: ["google__9780441013593"] })
+  );
+
+  const plans = planDedupe(
+    books,
+    [
+      { _id: "a", entryType: "Book", apiRefs: ["ISBN__9780441013593"] },
+      { _id: "b", entryType: "Book", apiRefs: ["google__9780441013593"] },
+    ],
+    []
+  );
+
+  assert.equal(plans.length, 1);
+  assert.deepEqual(plans[0].duplicateIds, ["b"]);
+});
+
+test("an igdb id and an hltb id are not confused for each other", () => {
+  const gamesCollection = COLLECTIONS.find((c) => c.type === "games");
+
+  assert.notEqual(
+    groupKey(gamesCollection, { apiRefs: ["igdb__100"] }),
+    groupKey(gamesCollection, { apiRefs: ["hltb__100"] })
+  );
+});
+
+test("duplicates with different titles are surfaced for review", () => {
+  const [plan] = planDedupe(
+    films,
+    [film("a", { imageUrl: "https://img" }), film("b", { englishTranslatedTitle: "Сталкер" })],
+    []
+  );
+
+  assert.deepEqual(plan.titles, ["Stalker", "Сталкер"]);
+});

--- a/src/db_maintenance/work_metadata_merge.js
+++ b/src/db_maintenance/work_metadata_merge.js
@@ -1,0 +1,186 @@
+/**
+ * @file The rules for deciding what a cached work is missing and how fresh
+ * API data should be folded into it.
+ *
+ * Pure and dependency-free on purpose: this is the part of the backfill that
+ * can silently corrupt the database, so it is unit tested
+ * (./work_metadata_merge.test.js) without needing a DB or API keys.
+ */
+const {
+  COMMON_FIELDS,
+  parseApiRef,
+  findApiRef,
+  isEmptyValue,
+  isCorruptStringArray,
+  isCorruptNumber,
+  isCorruptExternalUrls,
+} = require("./work_collections");
+
+/** The metadata fields we expect an adapter to fill for a given type. */
+const expectedFields = (collection) => [
+  ...COMMON_FIELDS,
+  ...collection.stringArrayFields.filter((f) => !COMMON_FIELDS.includes(f)),
+];
+
+const isCorruptField = (collection, field, value) => {
+  if (collection.stringArrayFields.includes(field)) {
+    return isCorruptStringArray(value);
+  }
+  if (collection.numberFields.includes(field)) return isCorruptNumber(value);
+  return false;
+};
+
+/** Every field of a work whose stored value is unusable. */
+const corruptFieldsOf = (collection, work) => {
+  const corrupt = [];
+  if (!Array.isArray(work.apiRefs)) corrupt.push("apiRefs");
+  if (isCorruptExternalUrls(work.externalUrls)) corrupt.push("externalUrls");
+  if (work.entryType !== collection.entryType) corrupt.push("entryType");
+  for (const field of collection.stringArrayFields) {
+    if (isCorruptStringArray(work[field])) corrupt.push(field);
+  }
+  for (const field of collection.numberFields) {
+    if (isCorruptNumber(work[field])) corrupt.push(field);
+  }
+  return corrupt;
+};
+
+/**
+ * Games that got a `duration` from mongodb_add_missing_durations.js but never
+ * the matching `hltb__` apiRef or HowLongToBeat externalUrl — the original
+ * symptom in issue #83, where the playtime column had nothing to link to.
+ */
+const isMissingHltbLink = (collection, work) => {
+  if (collection.type !== "games" || isEmptyValue(work.duration)) return false;
+  const hasRef = Boolean(findApiRef(work.apiRefs, "hltb"));
+  const hasUrl = (Array.isArray(work.externalUrls) ? work.externalUrls : []).some(
+    (url) => url?.name === "hltb"
+  );
+  return !hasRef || !hasUrl;
+};
+
+/** True when a work is worth spending an API call on. */
+const hasGaps = (collection, work) =>
+  expectedFields(collection).some((field) => isEmptyValue(work[field])) ||
+  corruptFieldsOf(collection, work).length > 0 ||
+  (Array.isArray(work.apiRefs) &&
+    work.apiRefs.some((ref) => parseApiRef(ref)?.flat === false)) ||
+  isMissingHltbLink(collection, work);
+
+/**
+ * Builds the `$set` payload for one work. Rules:
+ *   - a field the API has nothing to say about is never cleared
+ *   - apiRefs and externalUrls are unioned, so a ref we already know about
+ *     survives even when the API stops returning it
+ *   - with `missingOnly`, usable existing values are left alone
+ *
+ * @type {(collection: any, work: any, fresh: any, options?: { missingOnly?: boolean }) => { updates: any, notes: string[] }}
+ */
+const mergeWork = (collection, work, fresh, { missingOnly = false } = {}) => {
+  const updates = {};
+  const notes = [];
+
+  for (const [field, freshValue] of Object.entries(fresh)) {
+    if (field === "entryType") continue;
+    if (isEmptyValue(freshValue)) continue;
+
+    const currentValue = work[field];
+
+    if (field === "apiRefs") {
+      const merged = mergeApiRefs(currentValue, freshValue, { missingOnly });
+      if (!equal(currentValue, merged)) updates.apiRefs = merged;
+      continue;
+    }
+
+    if (field === "externalUrls") {
+      const merged = mergeExternalUrls(currentValue, freshValue, { missingOnly });
+      if (!equal(currentValue, merged)) updates.externalUrls = merged;
+      continue;
+    }
+
+    const usable =
+      !isEmptyValue(currentValue) &&
+      !isCorruptField(collection, field, currentValue);
+    if (missingOnly && usable) continue;
+    if (equal(currentValue, freshValue)) continue;
+
+    if (field === "englishTranslatedTitle" && usable) {
+      notes.push(
+        `title changes from "${currentValue}" to "${freshValue}" — check the apiRef points at the right work`
+      );
+    }
+
+    updates[field] = freshValue;
+  }
+
+  if (work.entryType !== collection.entryType) {
+    updates.entryType = collection.entryType;
+  }
+
+  return { updates, notes };
+};
+
+/**
+ * Existing refs are kept. A ref the API now reports under a name we already
+ * hold replaces the old one, unless `missingOnly` asked us not to touch what
+ * is already there.
+ */
+const mergeApiRefs = (currentValue, freshValue, { missingOnly = false } = {}) => {
+  const byName = new Map(
+    toParsedRefs(currentValue).map(({ name, ref }) => [name, ref])
+  );
+
+  for (const { name, ref } of toParsedRefs(freshValue)) {
+    if (missingOnly && byName.has(name)) continue;
+    byName.set(name, ref);
+  }
+
+  return [...byName.entries()].map(([name, ref]) => `${name}__${ref}`);
+};
+
+const mergeExternalUrls = (
+  currentValue,
+  freshValue,
+  { missingOnly = false } = {}
+) => {
+  const byName = new Map(toValidUrls(currentValue).map((u) => [u.name, u.url]));
+
+  for (const { name, url } of toValidUrls(freshValue)) {
+    if (missingOnly && byName.has(name)) continue;
+    byName.set(name, url);
+  }
+
+  return [...byName.entries()].map(([name, url]) => ({ name, url }));
+};
+
+/** How many of the expected fields a work actually has. Used to pick a
+ * survivor when the same work was cached more than once. */
+const completeness = (collection, work) =>
+  expectedFields(collection).filter(
+    (field) =>
+      !isEmptyValue(work[field]) && !isCorruptField(collection, field, work[field])
+  ).length;
+
+module.exports = {
+  expectedFields,
+  isCorruptField,
+  corruptFieldsOf,
+  isMissingHltbLink,
+  hasGaps,
+  mergeWork,
+  mergeApiRefs,
+  mergeExternalUrls,
+  completeness,
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+const toParsedRefs = (value) =>
+  (Array.isArray(value) ? value : []).map(parseApiRef).filter((ref) => ref);
+
+const toValidUrls = (value) =>
+  (Array.isArray(value) ? value : []).filter(
+    (url) => url && typeof url.name === "string" && typeof url.url === "string"
+  );
+
+const equal = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);

--- a/src/db_maintenance/work_metadata_merge.js
+++ b/src/db_maintenance/work_metadata_merge.js
@@ -46,9 +46,8 @@ const corruptFieldsOf = (collection, work) => {
 };
 
 /**
- * Games that got a `duration` from mongodb_add_missing_durations.js but never
- * the matching `hltb__` apiRef or HowLongToBeat externalUrl — the original
- * symptom in issue #83, where the playtime column had nothing to link to.
+ * A game that has a duration but no HowLongToBeat ref or link: the playtime
+ * column has a number to show and nothing to link it to.
  */
 const isMissingHltbLink = (collection, work) => {
   if (collection.type !== "games" || isEmptyValue(work.duration)) return false;

--- a/src/db_maintenance/work_metadata_merge.test.js
+++ b/src/db_maintenance/work_metadata_merge.test.js
@@ -31,8 +31,7 @@ const freshGame = {
   ],
 };
 
-/** What mongodb_add_missing_durations.js left behind: a duration, but no
- * hltb ref and no HowLongToBeat link. */
+/** A game with a duration but no hltb ref and no HowLongToBeat link. */
 const staleGame = {
   _id: "a",
   entryType: "Game",

--- a/src/db_maintenance/work_metadata_merge.test.js
+++ b/src/db_maintenance/work_metadata_merge.test.js
@@ -208,3 +208,41 @@ test("completeness counts usable expected fields", () => {
   assert.equal(completeness(games, {}), 0);
   assert.ok(completeness(games, backfilled()) > completeness(games, staleGame));
 });
+
+test("placeholder refs are not treated as identifiers", () => {
+  const { parseApiRef, findApiRef } = require("./work_collections");
+
+  for (const bad of [
+    "hltb__N/A",
+    "undefined__undefined",
+    "igdb__",
+    "tmdb__null",
+    "igdb__0",
+    "ISBN__NaN",
+  ]) {
+    assert.equal(parseApiRef(bad), undefined, `${bad} should not parse`);
+  }
+
+  assert.deepEqual(parseApiRef("igdb__14593"), {
+    name: "igdb",
+    ref: "14593",
+    flat: true,
+  });
+  assert.equal(findApiRef(["hltb__N/A", "igdb__1"], "hltb"), undefined);
+});
+
+test("a placeholder ref is dropped rather than carried forward", () => {
+  const work = { ...staleGame, apiRefs: ["igdb__14593", "hltb__N/A"] };
+
+  assert.deepEqual(mergeWork(games, work, freshGame).updates.apiRefs, [
+    "igdb__14593",
+    "hltb__26286",
+  ]);
+});
+
+test("a work whose only ref is a placeholder cannot be refreshed", () => {
+  const { findApiRef } = require("./work_collections");
+  const work = { _id: "x", entryType: "Game", apiRefs: ["hltb__N/A"] };
+
+  assert.equal(findApiRef(work.apiRefs, games.retrievePrefix), undefined);
+});

--- a/src/db_maintenance/work_metadata_merge.test.js
+++ b/src/db_maintenance/work_metadata_merge.test.js
@@ -1,0 +1,210 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { COLLECTIONS } = require("./work_collections");
+const {
+  hasGaps,
+  mergeWork,
+  mergeApiRefs,
+  mergeExternalUrls,
+  corruptFieldsOf,
+  completeness,
+} = require("./work_metadata_merge");
+
+const games = COLLECTIONS.find((c) => c.type === "games");
+const books = COLLECTIONS.find((c) => c.type === "books");
+
+const freshGame = {
+  entryType: "Game",
+  englishTranslatedTitle: "Hollow Knight",
+  releaseYear: 2017,
+  duration: 1500,
+  imageUrl: "https://img",
+  genres: ["Platform"],
+  platforms: ["PC"],
+  studios: ["Team Cherry"],
+  publishers: ["Team Cherry"],
+  apiRefs: ["igdb__14593", "hltb__26286"],
+  externalUrls: [
+    { name: "igdb", url: "https://igdb.com/hk" },
+    { name: "hltb", url: "https://howlongtobeat.com/game?id=26286" },
+  ],
+};
+
+/** What mongodb_add_missing_durations.js left behind: a duration, but no
+ * hltb ref and no HowLongToBeat link. */
+const staleGame = {
+  _id: "a",
+  entryType: "Game",
+  englishTranslatedTitle: "Hollow Knight",
+  duration: 1500,
+  apiRefs: ["igdb__14593"],
+  externalUrls: [{ name: "igdb", url: "https://igdb.com/hk" }],
+};
+
+const backfilled = () => ({
+  ...staleGame,
+  ...mergeWork(games, staleGame, freshGame).updates,
+});
+
+test("a game with a duration but no HowLongToBeat link is flagged", () => {
+  assert.equal(hasGaps(games, staleGame), true);
+});
+
+test("backfilling adds the hltb ref and url without losing the igdb ones", () => {
+  const { updates, notes } = mergeWork(games, staleGame, freshGame);
+
+  assert.deepEqual(updates.apiRefs, ["igdb__14593", "hltb__26286"]);
+  assert.deepEqual(updates.externalUrls, [
+    { name: "igdb", url: "https://igdb.com/hk" },
+    { name: "hltb", url: "https://howlongtobeat.com/game?id=26286" },
+  ]);
+  assert.deepEqual(updates.genres, ["Platform"]);
+  assert.equal("duration" in updates, false, "unchanged values aren't rewritten");
+  assert.deepEqual(notes, []);
+});
+
+test("a backfilled game is left alone on the next pass", () => {
+  const work = backfilled();
+  assert.deepEqual(mergeWork(games, work, freshGame).updates, {});
+  assert.equal(hasGaps(games, work), false);
+});
+
+test("empty API values never clear stored data", () => {
+  const work = { ...backfilled(), imageUrl: "https://kept" };
+  const sparse = {
+    ...freshGame,
+    genres: [],
+    imageUrl: "",
+    studios: undefined,
+    publishers: null,
+  };
+
+  assert.deepEqual(mergeWork(games, work, sparse).updates, {});
+});
+
+test("fields absent from the API response are left untouched", () => {
+  const work = { ...backfilled(), notes: "hand written" };
+  const updates = mergeWork(games, work, { entryType: "Game" }).updates;
+
+  assert.deepEqual(updates, {});
+});
+
+test("missingOnly fills gaps but refuses to overwrite usable values", () => {
+  const work = { ...backfilled(), genres: ["Metroidvania"], imageUrl: "" };
+  const updates = mergeWork(games, work, freshGame, { missingOnly: true }).updates;
+
+  assert.deepEqual(updates, { imageUrl: "https://img" });
+});
+
+test("a changed title is applied but called out for review", () => {
+  const { updates, notes } = mergeWork(games, backfilled(), {
+    ...freshGame,
+    englishTranslatedTitle: "Silksong",
+  });
+
+  assert.equal(updates.englishTranslatedTitle, "Silksong");
+  assert.equal(notes.length, 1);
+  assert.match(notes[0], /Hollow Knight.*Silksong/);
+});
+
+test("legacy object-shaped apiRefs are normalised to flat strings", () => {
+  const legacy = { ...staleGame, apiRefs: [{ name: "igdb", ref: "14593" }] };
+
+  assert.equal(hasGaps(games, legacy), true);
+  assert.deepEqual(mergeWork(games, legacy, freshGame).updates.apiRefs, [
+    "igdb__14593",
+    "hltb__26286",
+  ]);
+});
+
+test("a ref the API stops reporting still survives a refresh", () => {
+  const work = backfilled();
+  const withoutHltb = {
+    ...freshGame,
+    apiRefs: ["igdb__14593"],
+    externalUrls: [{ name: "igdb", url: "https://igdb.com/hk" }],
+  };
+
+  assert.deepEqual(mergeWork(games, work, withoutHltb).updates, {});
+});
+
+test("mergeApiRefs prefers fresh refs, or existing ones with missingOnly", () => {
+  assert.deepEqual(mergeApiRefs(["hltb__1"], ["hltb__2"]), ["hltb__2"]);
+  assert.deepEqual(mergeApiRefs(["hltb__1"], ["hltb__2"], { missingOnly: true }), [
+    "hltb__1",
+  ]);
+  assert.deepEqual(mergeApiRefs(undefined, ["igdb__3"]), ["igdb__3"]);
+  assert.deepEqual(mergeApiRefs(["nonsense"], ["igdb__3"]), ["igdb__3"]);
+});
+
+test("mergeExternalUrls drops malformed links and keeps one per name", () => {
+  assert.deepEqual(
+    mergeExternalUrls(
+      [{ name: "igdb", url: "https://old" }, { url: "https://nameless" }],
+      [{ name: "igdb", url: "https://new" }, { name: "hltb", url: "https://hltb" }]
+    ),
+    [
+      { name: "igdb", url: "https://new" },
+      { name: "hltb", url: "https://hltb" },
+    ]
+  );
+});
+
+test("the Promise mongodb_add_missing_book_publishers.js stored is repaired", () => {
+  // An un-awaited Promise lands in Mongo as {}.
+  const corruptBook = {
+    _id: "b",
+    entryType: "Book",
+    englishTranslatedTitle: "Dune",
+    imageUrl: "https://img",
+    releaseYear: 1965,
+    duration: 412,
+    genres: ["Sci-Fi"],
+    authors: ["Frank Herbert"],
+    publishers: {},
+    apiRefs: ["ISBN__9780441013593"],
+  };
+
+  assert.deepEqual(corruptFieldsOf(books, corruptBook), ["publishers"]);
+  assert.equal(hasGaps(books, corruptBook), true);
+
+  const updates = mergeWork(
+    books,
+    corruptBook,
+    {
+      entryType: "Book",
+      publishers: ["Ace Books"],
+      apiRefs: ["ISBN__9780441013593"],
+    },
+    { missingOnly: true }
+  ).updates;
+
+  assert.deepEqual(updates, { publishers: ["Ace Books"] });
+});
+
+test("an array of arrays counts as corrupt, not as data", () => {
+  assert.deepEqual(
+    corruptFieldsOf(books, {
+      entryType: "Book",
+      apiRefs: [],
+      publishers: [["Ace Books"]],
+    }),
+    ["publishers"]
+  );
+});
+
+test("a wrong entryType is repaired", () => {
+  const updates = mergeWork(
+    games,
+    { ...backfilled(), entryType: "Film" },
+    freshGame
+  ).updates;
+
+  assert.deepEqual(updates, { entryType: "Game" });
+});
+
+test("completeness counts usable expected fields", () => {
+  assert.equal(completeness(games, {}), 0);
+  assert.ok(completeness(games, backfilled()) > completeness(games, staleGame));
+});

--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -263,12 +263,35 @@ const playtimeFormatter = (_, row) => {
     : rawMins < 40 ?  '&frac12'
     : '&frac34'
   const durationText = `${hours}h${minsAsHrFraction}`
-  const hltbRef = row.commonMetadata.apiRefs?.find(ref => ref.name === 'hltb')?.ref
-  return durationInMin && hltbRef
-    ? `<a href="https://howlongtobeat.com/game?id=${hltbRef}">${durationText}</a>`
+  const hltbUrl = toHltbUrl(row)
+  return durationInMin && hltbUrl
+    ? `<a href="${hltbUrl}">${durationText}</a>`
     : durationInMin
     ? durationText
     : '-'
+}
+
+/**
+ * apiRefs are flat strings (`hltb__12345`) since the work collections were
+ * flattened, so the old `{ name, ref }` lookup never matched and no playtime
+ * ever linked out. Both shapes are read here, and the externalUrls entry the
+ * adapter writes alongside the ref is preferred when present.
+ */
+const toHltbUrl = (row) => {
+  const { apiRefs, externalUrls } = get(row, ['apiRefs', 'externalUrls'])
+
+  const url = externalUrls?.find((link) => link?.name === 'hltb')?.url
+  if (url) return url
+
+  const ref = apiRefs
+    ?.map((apiRef) =>
+      typeof apiRef === 'string'
+        ? apiRef.startsWith('hltb__') ? apiRef.slice('hltb__'.length) : undefined
+        : apiRef?.name === 'hltb' ? apiRef.ref : undefined
+    )
+    ?.find((hltbRef) => hltbRef)
+
+  return ref ? `https://howlongtobeat.com/game?id=${ref}` : undefined
 }
 
 const relativeTime = (ts) => {

--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -283,13 +283,15 @@ const toHltbUrl = (row) => {
   const url = externalUrls?.find((link) => link?.name === 'hltb')?.url
   if (url) return url
 
+  // Some games carry `hltb__N/A` rather than an id. Only a numeric id makes a
+  // page that exists, so anything else is treated as no link at all.
   const ref = apiRefs
     ?.map((apiRef) =>
       typeof apiRef === 'string'
         ? apiRef.startsWith('hltb__') ? apiRef.slice('hltb__'.length) : undefined
-        : apiRef?.name === 'hltb' ? apiRef.ref : undefined
+        : apiRef?.name === 'hltb' ? String(apiRef.ref) : undefined
     )
-    ?.find((hltbRef) => hltbRef)
+    ?.find((hltbRef) => /^\d+$/.test(hltbRef ?? ''))
 
   return ref ? `https://howlongtobeat.com/game?id=${ref}` : undefined
 }

--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -272,10 +272,10 @@ const playtimeFormatter = (_, row) => {
 }
 
 /**
- * apiRefs are flat strings (`hltb__12345`) since the work collections were
- * flattened, so the old `{ name, ref }` lookup never matched and no playtime
- * ever linked out. Both shapes are read here, and the externalUrls entry the
- * adapter writes alongside the ref is preferred when present.
+ * apiRefs are flat strings (`hltb__12345`), though some documents still hold
+ * the older `{ name, ref }` objects, so both shapes are read. The
+ * externalUrls entry the adapter writes alongside the ref is preferred when
+ * present.
  */
 const toHltbUrl = (row) => {
   const { apiRefs, externalUrls } = get(row, ['apiRefs', 'externalUrls'])

--- a/src/frontend/_includes/js/utils/columns.test.js
+++ b/src/frontend/_includes/js/utils/columns.test.js
@@ -1,0 +1,68 @@
+/**
+ * @file The frontend scripts are plain globals concatenated into a bundle
+ * rather than modules, so this loads columns.js into a vm context with the
+ * globals it expects and pulls the formatter out of the script's scope.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "columns.js"), "utf8");
+
+const playtimeFormatter = vm.runInContext(
+  `${source}\n;playtimeFormatter`,
+  vm.createContext({
+    Utils: { html: (strings) => strings.raw.join("") },
+    Conversions: { apiTypeToType: {}, statusToTitle: () => "" },
+    console,
+  })
+);
+
+const playtime = (commonMetadata, overrides) =>
+  playtimeFormatter(null, { commonMetadata, overrides });
+
+test("a flat hltb apiRef links the playtime to HowLongToBeat", () => {
+  assert.equal(
+    playtime({ duration: 600, apiRefs: ["igdb__1", "hltb__555"] }),
+    '<a href="https://howlongtobeat.com/game?id=555">10h</a>'
+  );
+});
+
+test("the externalUrls link wins over the apiRef", () => {
+  assert.equal(
+    playtime({
+      duration: 630,
+      apiRefs: ["igdb__1", "hltb__555"],
+      externalUrls: [
+        { name: "igdb", url: "https://igdb.com/x" },
+        { name: "hltb", url: "https://howlongtobeat.com/game?id=999" },
+      ],
+    }),
+    '<a href="https://howlongtobeat.com/game?id=999">10h&frac12</a>'
+  );
+});
+
+test("apiRefs still stored as objects are understood", () => {
+  assert.equal(
+    playtime({ duration: 600, apiRefs: [{ name: "hltb", ref: "77" }] }),
+    '<a href="https://howlongtobeat.com/game?id=77">10h</a>'
+  );
+});
+
+test("without an hltb ref the playtime is plain text", () => {
+  assert.equal(playtime({ duration: 600, apiRefs: ["igdb__1"] }), "10h");
+});
+
+test("a work with no metadata at all doesn't throw", () => {
+  assert.equal(playtime({}), "-");
+  assert.equal(playtime({ apiRefs: ["hltb__5"] }), "-");
+});
+
+test("a user's duration override still wins over the cached metadata", () => {
+  assert.equal(
+    playtime({ duration: 600, apiRefs: ["hltb__5"] }, { duration: 120 }),
+    '<a href="https://howlongtobeat.com/game?id=5">2h</a>'
+  );
+});

--- a/src/frontend/_includes/js/utils/columns.test.js
+++ b/src/frontend/_includes/js/utils/columns.test.js
@@ -66,3 +66,14 @@ test("a user's duration override still wins over the cached metadata", () => {
     '<a href="https://howlongtobeat.com/game?id=5">2h</a>'
   );
 });
+
+test("a placeholder hltb ref renders no link at all", () => {
+  // 27 games in the database carry `hltb__N/A`; linking to
+  // howlongtobeat.com/game?id=N/A would be a dead link on every one of them.
+  assert.equal(playtime({ duration: 600, apiRefs: ["hltb__N/A"] }), "10h");
+  assert.equal(playtime({ duration: 600, apiRefs: ["hltb__"] }), "10h");
+  assert.equal(
+    playtime({ duration: 600, apiRefs: [{ name: "hltb", ref: "N/A" }] }),
+    "10h"
+  );
+});

--- a/src/frontend/_includes/js/utils/tables.js
+++ b/src/frontend/_includes/js/utils/tables.js
@@ -93,14 +93,6 @@ const statuses = ['InProgress', 'Completed', 'Dropped', 'Planned']
 
 const filmStatuses = ['Completed', 'Planned']
 
-const formatApiRefs = (apiRefs) =>
-  apiRefs
-    .map(({ name, ref }) =>
-        name === 'hltb'
-      ? `<a href="https://howlongtobeat.com/game?id=${ref}">HowLongToBeat page</a>`
-      : name === 'igdb'
-    )
-
 Tables = {
   initTable,
   detailFormatter,


### PR DESCRIPTION
Fixes #83.

Issue #83 has two halves: HowLongToBeat isn't propagated to the entries, and metadata across the database is missing or out of date. This fixes three bugs behind the first half and adds the tooling to repair the data.

## Bugs fixed

**The playtime column doesn't link to HowLongToBeat.** `playtimeFormatter` looked up `apiRefs.find(ref => ref.name === 'hltb')`, but `apiRefs` are flat strings (`hltb__12345`). The lookup returned `undefined` for every game, so every playtime rendered as unlinked text. It now reads the `externalUrls` entry the adapter writes, falls back to the ref in either shape, and requires a numeric id — 27 games carry `hltb__N/A`, which would otherwise produce a dead link. This restores the link for the 775 games that hold a real HowLongToBeat ref.

**Every book retrieve creates a duplicate book.** The Google Books adapter caches books under `ISBN__<isbn>` while `retrieveWork` asked for `google__<isbn>`. That lookup can never hit, so it falls through to `createWork` and inserts another copy of a book already cached. It now looks books up under `ISBN__`, accepting `google__` as well since some documents are stored under that name.

**`mongodb_add_missing_book_publishers.js` writes Promises into the database.** It assigned the un-awaited axios call to `publishers`, so the guard was always true and Mongo stored the Promise as `{}`. 601 of 707 books are in that state; only 29 hold a valid publisher list. The script now awaits the response and takes the first result.

## Maintenance scripts

Three scripts in `src/db_maintenance/`, all **dry run unless given `--apply`**, each taking a JSON backup before writing:

| script | what it does | needs API keys |
| --- | --- | --- |
| `audit_database.js` | read-only report: works that can't be refreshed, missing and corrupt fields, games with a duration but no HowLongToBeat link, duplicate works, orphans, entries with a missing or dangling `workRef` | no |
| `backfill_work_metadata.js` | re-runs the same adapters the API uses; fills gaps and refreshes stale metadata | yes |
| `dedupe_works.js` | merges duplicate works into the most complete document and repoints `workRef` | no |

**User overrides can't be clobbered.** Overrides live on the entry documents (`entry.overrides`) and the frontend prefers them over `commonMetadata`. The backfill only ever writes to work documents, so it cannot reach them. Beyond that: a field the API says nothing about is never cleared, `apiRefs` and `externalUrls` are merged rather than replaced, and a `metadataUpdatedDate` makes runs resumable.

**An apiRef is not a reliable identity key**, which shapes how `dedupe_works.js` decides anything:

- 27 games carry the placeholder `hltb__N/A` and 14 films carry `undefined__undefined`. `parseApiRef` rejects placeholder values, so they can't be mistaken for identifiers anywhere in the codebase.
- A HowLongToBeat id names a page rather than a game, so it never establishes identity. Only `igdb` does for games, `tmdb` for films and TV, and the ISBN for books.
- Sharing an identifier still doesn't mean being the same work. "Fargo - Season 1" and "Fargo - Season 2" sit under one show id, five Haruhi Suzumiya volumes share one ISBN, and "Demons" is filed under The Da Vinci Code's — 44 of 78 groups in the live data disagree about the title. A group is merged only when its titles agree; the rest are printed and skipped unless `--merge-title-mismatches` is passed.

## Run against production

Against a snapshot verified first — manifest counts, file counts and live `countDocuments()` agreeing across all 13 collections, every SHA-256 matching, no live document missing from it.

`dedupe_works.js --apply`:

| | works before | after | deleted | entries repointed |
| --- | --- | --- | --- | --- |
| films | 1560 | 1555 | 5 | 4 |
| tvShows | 512 | 509 | 3 | 3 |
| games | 1168 | 1145 | 23 | 8 |
| books | 707 | 693 | 14 | 5 |

45 documents removed, 20 entries repointed, zero dangling references, entry counts unchanged.

`backfill_work_metadata.js --only=games --missing-only --apply`: 142 games updated with genres, studios, publishers, release years, platforms and cover images; 296 already current; 11 failed; 40 have no `igdb__` ref to refresh from. Films, TV and books have not been backfilled yet.

## A limitation worth knowing before merging

**The `howlongtobeat` package is dead.** Version 1.8.0 returns 404 on every search; it is the latest release and was last published in 2023. The games adapter swallows the failure (`.catch(() => undefined)`), so it degrades silently.

Two consequences. New game entries added through the site get no duration and no HowLongToBeat link at all. And the ~215 games that hold a duration without a link cannot be repaired by refreshing — there is no working source to refresh from. The frontend fix above is what recovers issue #83's visible symptom, for the 775 games whose refs are already stored; this PR does not restore the integration itself.

`docs/API_choices.md` records the alternatives, measured. IGDB has a `/game_time_to_beats` endpoint reachable with the credentials this app already holds, covering 63% of the library, but its times agree with the stored HowLongToBeat values for only about 30% of games and its median sample size is 3 submissions, so adopting it would visibly change playtimes. SteamSpy no longer populates its playtime fields, and RAWG measures average total playtime rather than time to beat. The change itself belongs in its own issue rather than here.

## Tests and CI

The repository had neither. The rules deciding what gets written (`work_metadata_merge.js`) and what gets deleted (`work_dedupe_plan.js`) are pure, dependency-free modules — the scripts hold the I/O — so `node --test` runs with no framework, no install, no database and no API keys. The placeholder and title-collision cases are tested by name using the real examples above, and the frontend test loads `columns.js` into a `vm` context to assert the playtime link, including that a user's duration override still wins.

CI runs the suite and parses every tracked JS file on push and pull request.

## Follow-ups

- Restoring HowLongToBeat, or replacing it with IGDB `/game_time_to_beats`, per the comparison in `docs/API_choices.md`.
- 462 of the 496 missing tvShows fields are `directors`, which TMDB rarely populates for TV. Those works re-select on every `--missing-only` run and mostly change nothing, so `directors` probably shouldn't be an expected field for TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

