### PR TITLE
feat: start an empty game note from the template every game note uses

### DIFF
--- a/src/frontend/_includes/js/components/list/add_edit_entry/personal_fields.js
+++ b/src/frontend/_includes/js/components/list/add_edit_entry/personal_fields.js
@@ -2,6 +2,7 @@ const { html, css } = Utils
 const { initComponent, WithRemoteData } = Components
 const { statuses, filmStatuses } = Tables
 const { statusToTitle } = Conversions
+const { initialReviewText } = ReviewTemplate
 
 const PersonalFields = (data, type) => {
   const isEdit = data?.status ?? false
@@ -105,9 +106,9 @@ const PersonalFields = (data, type) => {
           isEdit
             ? WithRemoteData({
                 remoteData: Netlify.getReview(type, data.dbRef),
-                component: CommentsField,
+                component: (review) => CommentsField(type, review),
               })
-            : CommentsField()
+            : CommentsField(type)
           )}
       </div>
     `,
@@ -158,11 +159,11 @@ Components.List.PersonalFields = PersonalFields
 
 ///////////////////////////////////////////////////////////////////////////////
 
-const CommentsField = (review) => initComponent({
+const CommentsField = (type, review) => initComponent({
   content: () => html`
     <div style="margin: 15px 0">
       <label for="review">Comments</label><br>
-      <textarea id="review" name="review" rows="19" cols="50">${review?.data?.text ?? ''}</textarea>
+      <textarea id="review" name="review" rows="19" cols="50">${initialReviewText(type, review?.data?.text)}</textarea>
     </div>
   `
 })

--- a/src/frontend/_includes/js/utils/review_template.js
+++ b/src/frontend/_includes/js/utils/review_template.js
@@ -1,0 +1,56 @@
+/**
+ * @file The first draft an empty note starts from.
+ *
+ * Game notes all follow the same shape — a summary, then a section per facet,
+ * then the running lists of details — and retyping that scaffolding before
+ * every note is the boring part of writing one. So an empty note opens with
+ * the scaffolding already in it, as a suggestion: it is ordinary text in the
+ * textarea, and deleting it is deleting text.
+ *
+ * Only a note with nothing in it gets one. A note that has been written in,
+ * however little, is never touched.
+ */
+
+/** The shape every game note follows. */
+const GAME_TEMPLATE = [
+  'Summary paragraph here.',
+  '',
+  '__Writing.__',
+  '',
+  '__Gameplay.__',
+  '',
+  '__Visuals & Audio.__',
+  '',
+  '__Details I like:__',
+  '',
+  '+ N/A',
+  '',
+  "__Details I'm ambivalent about:__",
+  '',
+  '+ N/A',
+  '',
+  "__Details I don't like:__",
+  '',
+  '+ N/A',
+  '',
+  '## Resources and Miscellanea',
+  '',
+].join('\n')
+
+/** Templates by entry type. A type without one starts from a blank note. */
+const templates = {
+  games: GAME_TEMPLATE,
+}
+
+/**
+ * What the comments field should open with, given whatever text the note
+ * already holds.
+ *
+ * @type {(type: string, text?: string | null) => string}
+ */
+const initialReviewText = (type, text) =>
+  (text ?? '').trim() === '' ? templates[type] ?? '' : text
+
+ReviewTemplate = {
+  initialReviewText,
+}

--- a/src/frontend/_includes/js/utils/review_template.test.js
+++ b/src/frontend/_includes/js/utils/review_template.test.js
@@ -1,0 +1,57 @@
+/**
+ * @file The frontend scripts are plain globals concatenated into a bundle
+ * rather than modules, so this evaluates review_template.js and pulls the
+ * global it defines out of it. The module touches nothing else, so it needs
+ * no context of its own.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "review_template.js"),
+  "utf8"
+);
+
+const { initialReviewText } = vm.runInThisContext(`${source}\n;ReviewTemplate`);
+
+test("a new game note starts from the template", () => {
+  const text = initialReviewText("games", undefined);
+
+  assert.match(text, /^Summary paragraph here\.\n/);
+  ["__Writing.__", "__Gameplay.__", "__Visuals & Audio.__"].forEach(
+    (heading) => assert.ok(text.includes(`\n${heading}\n`), heading)
+  );
+  [
+    "__Details I like:__",
+    "__Details I'm ambivalent about:__",
+    "__Details I don't like:__",
+  ].forEach((heading) =>
+    assert.ok(text.includes(`${heading}\n\n+ N/A`), heading)
+  );
+  assert.ok(text.trimEnd().endsWith("## Resources and Miscellanea"));
+});
+
+test("a game note with nothing in it gets the template too", () => {
+  const template = initialReviewText("games", undefined);
+
+  assert.equal(initialReviewText("games", ""), template);
+  assert.equal(initialReviewText("games", "\n\n  \n"), template);
+  assert.equal(initialReviewText("games", null), template);
+});
+
+test("a note that has been written in is left exactly as it is", () => {
+  assert.equal(initialReviewText("games", "Loved it."), "Loved it.");
+  // Whitespace around a real note is the user's, not ours to trim.
+  assert.equal(initialReviewText("games", "  Loved it.\n"), "  Loved it.\n");
+});
+
+test("the other types still start from a blank note", () => {
+  ["films", "books", "tv"].forEach((type) => {
+    assert.equal(initialReviewText(type, ""), "");
+    assert.equal(initialReviewText(type, undefined), "");
+    assert.equal(initialReviewText(type, "Loved it."), "Loved it.");
+  });
+});

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -54,6 +54,7 @@
       {{ js("js/utils/netlify.js") }}
       {{ js("js/utils/diff.js") }}
       {{ js("js/utils/entry_form_io.js") }}
+      {{ js("js/utils/review_template.js") }}
       {{ js("js/utils/columns.js") }}
       {{ js("js/utils/tables.js") }}
       {{ js("js/components/index.js") }}


### PR DESCRIPTION
Closes #88.

Every game note in this list follows the same shape — a summary paragraph, a section per facet, then the three running lists of details, then `## Resources and Miscellanea` — so retyping that scaffolding is the boring part of starting a note. An empty game note now opens with the scaffolding already in it.

It is a suggestion, not a form. What lands in the textarea is ordinary text, deleting it is deleting text, and nothing about it is enforced on submit. Only a note with *nothing* in it gets one: a note that has been written in, however little, is never touched, and whitespace the user put there is theirs and is left alone.

## What's here

`js/utils/review_template.js` holds the template and the single decision it needs — `initialReviewText(type, text)`, which returns the type's template when the note is empty, blank, or absent, and returns the text untouched otherwise. Templates sit in a per-type map, and only `games` has one, so films, books and TV still open blank; a second type is a one-line addition when one wants a shape of its own.

`CommentsField` in `personal_fields.js` now takes the entry type and runs the existing review text through that function. Both paths the field is built from go through it — the brand-new entry, and the edit of an existing game whose note happens to be empty — which is what "any empty notes page" asks for.

Keeping the template out of the component is what makes it testable: the module touches no DOM and no globals, so `review_template.test.js` covers the template's shape, the empty/blank/null cases, that a written-in note comes back byte-identical, and that the other three types are unaffected — with no install and no jsdom, as the rest of the suite does.

## Worth knowing

Prefilling doesn't dispatch an `input` event, so it doesn't trip the unsaved-changes warning, and it doesn't start the draft autosave in `draft.js` — that file takes its baseline after the comments field loads, so the template is part of the baseline and won't be offered back as a recovered draft.

The flip side of "suggested first draft" is real, though: open a game entry with an empty note and save it without touching the note, and the scaffolding is what gets stored, where before nothing was. That is the behaviour the issue asks for, but it is a behaviour change on entries that already exist, not only on new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
