### PR TITLE
fix: restore the site, which a JSDoc brace had blanked

### DIFF
--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -1,0 +1,51 @@
+/**
+ * @file The frontend bundle is built by Nunjucks `{% include %}`-ing every
+ * file listed in base.njk into one inline <script>, each wrapped in its own
+ * IIFE. So Nunjucks reads these .js files as templates, and anything that
+ * looks like a Nunjucks delimiter is not JavaScript to it.
+ *
+ * When that happens nothing fails loudly: the include renders to nothing, the
+ * IIFE around it loses its closing brace, and the whole 130KB bundle becomes
+ * one syntax error. The build is green, the deploy is green, and every page
+ * on the site is blank. A JSDoc `@typedef {{ a: string }}` cost us exactly
+ * that, so the delimiters are worth a test.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const LAYOUT = path.join(__dirname, "..", "layouts", "base.njk");
+
+/** The files base.njk inlines, in the order it inlines them. */
+const includedFiles = () =>
+  [...fs.readFileSync(LAYOUT, "utf8").matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)]
+    .map(([, includePath]) => includePath);
+
+/** `{{ … }}` interpolates, `{% … %}` is a tag, `{# … #}` is a comment. */
+const DELIMITERS = [
+  ["{{", /\{\{/],
+  ["{%", /\{%/],
+  ["{#", /\{#/],
+];
+
+test("base.njk still inlines the frontend scripts", () => {
+  assert.ok(includedFiles().length > 0, "found no js() includes in base.njk");
+});
+
+includedFiles().forEach((includePath) => {
+  test(`${includePath} holds no Nunjucks delimiter`, () => {
+    const file = path.join(__dirname, "..", includePath);
+    const lines = fs.readFileSync(file, "utf8").split("\n");
+
+    lines.forEach((line, i) => {
+      DELIMITERS.forEach(([delimiter, pattern]) =>
+        assert.ok(
+          !pattern.test(line),
+          `${includePath}:${i + 1} contains ${delimiter}, which Nunjucks ` +
+            `reads as a template delimiter and swallows:\n  ${line.trim()}`
+        )
+      );
+    });
+  });
+});

--- a/src/frontend/_includes/js/utils/diff.js
+++ b/src/frontend/_includes/js/utils/diff.js
@@ -11,9 +11,12 @@
 const MAX_LINES = 1500
 
 /**
- * @typedef {{ type: 'same' | 'added' | 'removed', text: string }} DiffLine
- * @type {(before: string, after: string) => DiffLine[]}
+ * @typedef {object} DiffLine
+ * @property {'same' | 'added' | 'removed'} type
+ * @property {string} text
  */
+
+/** @type {(before: string, after: string) => DiffLine[]} */
 const lineDiff = (before, after) => {
   const oldLines = toLines(before)
   const newLines = toLines(after)


### PR DESCRIPTION
`nil.moe` has been serving a blank page on every route since #87 deployed. The page arrives, the CSS arrives, `#site` stays empty.

`base.njk` inlines all 40 frontend scripts into one `<script>` in `<head>`, each wrapped in its own IIFE by the `js()` macro, which means Nunjucks reads those `.js` files as templates. `diff.js` opened a JSDoc typedef with `{{`:

```js
 * @typedef {{ type: 'same' | 'added' | 'removed', text: string }} DiffLine
```

Nunjucks took that for an interpolation. The include rendered to nothing and took the macro's closing `})();` with it, so the built bundle read:

```js
      (() => {          // diff.js -- empty body, and no closer
        
      
      (() => {          // entry_form_io.js
```

One unclosed brace, and the whole 130KB script is a single `SyntaxError: Unexpected end of input`. Nothing in it runs, so `Components` is never defined and the router never renders. The browser reports it as two errors, the second a consequence of the first:

```
Uncaught SyntaxError: Unexpected end of input
Uncaught (in promise) ReferenceError: Components is not defined
```

Nothing failed loudly anywhere upstream of that. Eleventy built green, CI's per-file parse was green — it checks each file on its own, and each file is fine — and Netlify deployed green. The concatenation is the only place the damage exists, and until now nothing looked at it.

Writing the typedef as `@property` lines keeps the type and drops the delimiter. That alone restores the site.

The second commit's worth of change is a guard, because this failure mode is silent and total: `bundle.test.js` reads the `js(...)` include list straight out of `base.njk` and asserts that none of the listed files contain `{{`, `{%` or `{#`, naming the file and line when one does. Reading the list from the layout rather than globbing means a newly inlined file is covered the moment it's added. It needs no install, no DOM and no network, in keeping with the rest of the suite.

## Verified

- `npm test`: 178 tests, 0 failures, 41 of them new.
- Built with `npm run build` from a clean local `npm ci`. The bundle now parses under `node --check`, and grew 132,742 to 135,497 bytes — `diff.js` is genuinely in the page for the first time, `const lineDiff` and `Diff = {` both present.
- Served the built `dist/` and loaded it: renders "Welcome to memo. Log in to start listing.", no console errors.

Closes the blank-page regression from #87.
