### PR TITLE
fix: retry the metadata APIs instead of turning their blips into 500s

### DIFF
--- a/src/api/utils/external_api_adapters/books/google.js
+++ b/src/api/utils/external_api_adapters/books/google.js
@@ -7,6 +7,7 @@
 const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const axios = require('axios').default
+const { retrying, describeFailure, statusOf } = require('../retry')
 
 const { GOOGLE_API_KEY } = process.env
 
@@ -18,46 +19,44 @@ const urlKey =
 
 /** @type SearchFunction */
 const search = (titleSearch) => ResultAsync.fromPromise(
-  axios({
+  retrying(() => axios({
     method: 'get',
     url: `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(titleSearch)}&maxResults=40${urlKey}`
-  })
-    .then(({ data }) => data.items
+  }))
+    .then(({ data }) => volumesOf(data)
       .filter(({ volumeInfo }) =>
-        volumeInfo?.industryIdentifiers?.some((i) => i.type.includes('ISBN'))
+        volumeInfo?.industryIdentifiers?.some((i) => i.type?.includes('ISBN'))
       )
       .map(({ volumeInfo }) => ({
         title: `${volumeInfo?.title} [${volumeInfo?.authors?.join(', ')}]`,
         year: volumeInfo?.publishedDate?.substring(0, 4),
-        ref: volumeInfo?.industryIdentifiers?.find((i) => i.type.includes('ISBN'))?.identifier,
+        ref: volumeInfo?.industryIdentifiers?.find((i) => i.type?.includes('ISBN'))?.identifier,
         imageUrl: volumeInfo?.imageLinks?.thumbnail,
       }))
     ),
-  () => errors.internal('Problem retrieving book with Google Books.')
+  toError('searching for books')
 )
 
 /** @type BookRetrieveFunction */
 const retrieve = (ref) => ResultAsync.fromPromise(
-  axios({
+  retrying(() => axios({
     method: 'get',
     url: `https://www.googleapis.com/books/v1/volumes?q=isbn:${ref}${urlKey}`
-  }).then(({ data }) => data.items.map(({ volumeInfo }) => ({
-    entryType: 'Book',
-    publishers: volumeInfo.publisher ? [volumeInfo.publisher] : undefined,
-    englishTranslatedTitle: volumeInfo.title,
-    releaseYear: parseInt(volumeInfo.publishedDate?.substring(0, 4)) || undefined,
-    duration: volumeInfo.pageCount,
-    imageUrl: volumeInfo?.imageLinks?.thumbnail,
-    authors: volumeInfo?.authors,
-    apiRefs: [`ISBN__${ref}`],
-    externalUrls: volumeInfo?.canonicalVolumeLink
-      ? [{ name: 'Google Play', url: volumeInfo?.canonicalVolumeLink }]
-      : [],
-  }))[0]).catch((e) => {
-    console.log(e)
-    throw 'Something terrible happened'
-  }),
-  () => errors.internal('Problem retrieving book with Google Books.')
+  }))
+    .then(({ data }) => volumesOf(data).map(({ volumeInfo }) => ({
+      entryType: 'Book',
+      publishers: volumeInfo.publisher ? [volumeInfo.publisher] : undefined,
+      englishTranslatedTitle: volumeInfo.title,
+      releaseYear: parseInt(volumeInfo.publishedDate?.substring(0, 4)) || undefined,
+      duration: volumeInfo.pageCount,
+      imageUrl: volumeInfo?.imageLinks?.thumbnail,
+      authors: volumeInfo?.authors,
+      apiRefs: [`ISBN__${ref}`],
+      externalUrls: volumeInfo?.canonicalVolumeLink
+        ? [{ name: 'Google Play', url: volumeInfo?.canonicalVolumeLink }]
+        : [],
+    }))[0] ?? throwNoSuchVolume(ref)),
+  toError('retrieving a book')
 )
 
 /** @type Adapter */
@@ -66,4 +65,35 @@ module.exports = {
   retrieve
 }
 
-const log = x => (console.log(x), x)
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Google omits `items` entirely when nothing matched, rather than sending an
+ * empty array. Reading it as one was a TypeError, and a search with no hits
+ * came back a 500 instead of "No results found for this query...".
+ * @type {(data: any) => any[]}
+ */
+const volumesOf = (data) => data?.items ?? []
+
+/** @type {(ref: string) => never} */
+const throwNoSuchVolume = (ref) => {
+  throw Object.assign(
+    new Error(`Google Books holds no volume under ISBN ${ref}.`),
+    { status: 404 },
+  )
+}
+
+/**
+ * Google Books answers a fair share of requests with a 503, so a failure that
+ * gets this far has already been retried and is worth logging with the status
+ * that caused it — the message that used to reach the user said only that
+ * there was a "problem".
+ * @type {(doing: string) => (err: any) => Error}
+ */
+const toError = (doing) => (err) => {
+  console.error(`Google Books failed while ${doing}: ${describeFailure(err)}`)
+
+  return statusOf(err) === 404
+    ? errors.notFound('Google Books')
+    : errors.internal(`Google Books failed while ${doing} (${describeFailure(err)})`)
+}

--- a/src/api/utils/external_api_adapters/films/tmdb.js
+++ b/src/api/utils/external_api_adapters/films/tmdb.js
@@ -9,6 +9,7 @@ const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const { match } = require('ts-pattern')
 const { throwIt } = require('../../general')
+const { retrying, describeFailure, statusOf } = require('../retry')
 
 const { TMDB_API_KEY } = process.env
 
@@ -16,7 +17,7 @@ const tmdbClient = new tmdb(TMDB_API_KEY ?? throwIt('TMDB_API_KEY is not set.'))
 
 /** @type SearchFunction */
 const search = (titleSearch) => ResultAsync.fromPromise(
-   tmdbClient.search.movies({ query: { query: titleSearch } })
+  retrying(() => tmdbClient.search.movies({ query: { query: titleSearch } }))
     .then(({ data }) =>
       data.results.map((result) => ({
         title: result.title,
@@ -32,10 +33,10 @@ const search = (titleSearch) => ResultAsync.fromPromise(
 
 /** @type FilmRetrieveFunction */
 const retrieve = (ref) => ResultAsync.fromPromise(
-  Promise.all([
+  retrying(() => Promise.all([
     tmdbClient.movie.getDetails({ pathParameters: { movie_id: ref } }),
     tmdbClient.movie.getCredits({ pathParameters: { movie_id: ref } })
-  ])
+  ]))
     .then(([{ data }, { data: credits }]) => ({
       entryType: 'Film',
       originalTitle: data.original_title,
@@ -66,9 +67,17 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/** @type {(err: any) => Error} */
-const toError = (err) => match(err.errorCode)
+/**
+ * `statusOf` rather than `err.errorCode`, because node-themoviedb only wraps
+ * the statuses it has a class for and throws `got`'s own error through for
+ * the rest — including the 5xx that `retrying` has just given up on.
+ * @type {(err: any) => Error}
+ */
+const toError = (err) => match(statusOf(err))
   .with(404, () => errors.notFound('tmdb'))
   .with(401, () => errors.unauthorized('tmdb'))
   .with(408, () => errors.internal('tmdb timed out'))
-  .otherwise(() => errors.internal(`unknown tmdb error: ${JSON.stringify(err)}`))
+  .otherwise(() => {
+    console.error(`tmdb failed: ${describeFailure(err)}`)
+    return errors.internal(`tmdb failed (${describeFailure(err)})`)
+  })

--- a/src/api/utils/external_api_adapters/games/igdb.js
+++ b/src/api/utils/external_api_adapters/games/igdb.js
@@ -23,136 +23,149 @@ const {
   timeToBeatQuery,
   toPlaytime,
 } = require('./time_to_beat')
+const { retrying, describeFailure } = require('../retry')
 
 const { TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET } = process.env
 if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET) {
   throw "Must set TWITCH_CLIENT_SECRET and TWITCH_CLIENT_ID environment variables."
 }
 
-const twitchToken =
-  axios({
+/**
+ * The token used to live in a module-level promise, which meant one bad
+ * minute at Twitch poisoned every request the warm function served afterwards
+ * — a rejected promise stays rejected. It is fetched on demand now, kept only
+ * once it has worked, and forgotten again if it hasn't.
+ * @type {Promise<string> | undefined}
+ */
+let pendingToken
+
+/** @type {() => Promise<string>} */
+const twitchToken = () => {
+  pendingToken ??= retrying(() => axios({
     method: 'post',
     url: `https://id.twitch.tv/oauth2/token?client_id=${TWITCH_CLIENT_ID}&client_secret=${TWITCH_CLIENT_SECRET}&grant_type=client_credentials`
-  })
-    .then(({ data }) => data.access_token)
+  })).then(({ data }) => data.access_token)
 
-const igdbClient = twitchToken.then((token) => igdb(TWITCH_CLIENT_ID, token))
+  return pendingToken.catch((err) => {
+    pendingToken = undefined
+    throw err
+  })
+}
+
+/** @type {() => Promise<any>} */
+const igdbClient = async () => igdb(TWITCH_CLIENT_ID, await twitchToken())
 
 /** @type SearchFunction */
 const search = (titleSearch) => ResultAsync.fromPromise(
-  (async () => {
-    try {
-      const client = await igdbClient
+  retrying(async () => {
+    const client = await igdbClient()
 
-      const req = await client
-        .fields(['name', 'cover.url', 'release_dates.*', 'platforms.abbreviation'])
-        .limit(50)
-        .search(titleSearch)
-        .request('/games')
+    const req = await client
+      .fields(['name', 'cover.url', 'release_dates.*', 'platforms.abbreviation'])
+      .limit(50)
+      .search(titleSearch)
+      .request('/games')
 
-      const results = req.data.map(({ name, id, release_dates, cover, platforms }) => {
-        const earliest_date = release_dates?.sort((a,b) => a.date - b.date)[0]?.date * 1000
-        return {
-          title: name + ` [${platforms?.map((p) => p.abbreviation ?? '?')?.join(', ') ?? '?'}]`,
-          ref: id,
-          year: earliest_date ? (new Date(earliest_date)).toISOString().substring(0, 4) : undefined,
-          imageUrl: cover?.url ? 'https:' + cover.url : undefined,
-        }
-      })
-
-      return results
-    } catch (e) {
-      console.log(e)
-      throw "Something went terribly wrong..."
-    }
-  })(),
-  () => errors.internal('Problem searching for games with igdb.')
+    return req.data.map(({ name, id, release_dates, cover, platforms }) => {
+      const earliest_date = release_dates?.sort((a,b) => a.date - b.date)[0]?.date * 1000
+      return {
+        title: name + ` [${platforms?.map((p) => p.abbreviation ?? '?')?.join(', ') ?? '?'}]`,
+        ref: id,
+        year: earliest_date ? (new Date(earliest_date)).toISOString().substring(0, 4) : undefined,
+        imageUrl: cover?.url ? 'https:' + cover.url : undefined,
+      }
+    })
+  }),
+  toError('searching for games')
 )
 
 /** @type GameRetrieveFunction */
 const retrieve = (ref) => ResultAsync.fromPromise(
-  (async () => {
-    try {
-      const client = await igdbClient
-      const mainData = await client
-        .fields(['name', 'alternative_names.*', 'cover.url', 'release_dates.*', 'genres.name', 'platforms.abbreviation', 'involved_companies.*', 'url'])
-        .where(`id = ${ref}`)
-        .request('/games')
-        .then(({ data }) => data[0])
+  retrying(async () => {
+    const client = await igdbClient()
+    const mainData = await client
+      .fields(['name', 'alternative_names.*', 'cover.url', 'release_dates.*', 'genres.name', 'platforms.abbreviation', 'involved_companies.*', 'url'])
+      .where(`id = ${ref}`)
+      .request('/games')
+      .then(({ data }) => data[0])
 
-      const playtime = toPlaytime(await retrieveTimeToBeat(mainData.id))
+    const playtime = toPlaytime(await retrieveTimeToBeat(mainData.id))
 
-      const publisherIds =
-        mainData
-          .involved_companies
-          ?.filter((c) => c.publisher)
-          ?.map((c) => c.company)
-          ?? []
+    const publisherIds =
+      mainData
+        .involved_companies
+        ?.filter((c) => c.publisher)
+        ?.map((c) => c.company)
+        ?? []
 
-      const studioIds =
-        mainData
-          .involved_companies
-          ?.filter((c) => c.developer)
-          ?.map((c) => c.company)
-          ?? []
+    const studioIds =
+      mainData
+        .involved_companies
+        ?.filter((c) => c.developer)
+        ?.map((c) => c.company)
+        ?? []
 
-      const companies = await (
-        [studioIds, publisherIds].some((arr) => arr.length > 0)
-          ? client
-              .fields(['name'])
-              .where(
-                `id = (${[...studioIds, ...publisherIds].join(', ')})`
-              )
-              .limit(50)
-              .request('/companies')
-              .then((resp) => resp.data)
-          : []
+    const companies = await (
+      [studioIds, publisherIds].some((arr) => arr.length > 0)
+        ? client
+            .fields(['name'])
+            .where(
+              `id = (${[...studioIds, ...publisherIds].join(', ')})`
+            )
+            .limit(50)
+            .request('/companies')
+            .then((resp) => resp.data)
+        : []
+    )
+
+    const publisherNames =
+      publisherIds
+        .map((id) => companies.find((c) => c.id === id)?.name)
+
+    const studioNames =
+      studioIds
+        .map((id) => companies.find((c) => c.id === id)?.name)
+
+    const releaseYearTs =
+      mainData.release_dates?.sort((a, b) => a.date - b.date)[0].date
+
+    const releaseYear = releaseYearTs
+      ? parseInt(
+        (new Date(releaseYearTs * 1000)).toISOString() .substring(0, 4)
       )
+        || undefined
+      : undefined
 
-      const publisherNames =
-        publisherIds
-          .map((id) => companies.find((c) => c.id === id)?.name)
-
-      const studioNames =
-        studioIds
-          .map((id) => companies.find((c) => c.id === id)?.name)
-
-      const releaseYearTs =
-        mainData.release_dates?.sort((a, b) => a.date - b.date)[0].date
-
-      const releaseYear = releaseYearTs
-        ? parseInt(
-          (new Date(releaseYearTs * 1000)).toISOString() .substring(0, 4)
-        )
-          || undefined
-        : undefined
-
-      return {
-        entryType: 'Game',
-        englishTranslatedTitle: mainData.name,
-        originalTitle: mainData.alternative_names
-          ?.find((n) => n.comment?.includes('riginal'))
-          ?.name,
-        releaseYear,
-        // `duration` and `durationSource` together, or neither of them.
-        ...playtime,
-        imageUrl: mainData.cover.url ? 'https:' + mainData.cover.url : '',
-        genres: mainData.genres?.map((g) => g.name) ?? [],
-        platforms: mainData.platforms?.map((p) => p.abbreviation ?? '?') ?? [],
-        studios: studioNames,
-        publishers: publisherNames,
-        apiRefs: [`igdb__${mainData.id}`],
-        externalUrls: [
-          ...(mainData.url ? [{ name: 'igdb', url: mainData.url }] : []),
-        ]
-      }
-    } catch (e) {
-      console.log(e)
-      throw "Something went very wrong..."
+    return {
+      entryType: 'Game',
+      englishTranslatedTitle: mainData.name,
+      originalTitle: mainData.alternative_names
+        ?.find((n) => n.comment?.includes('riginal'))
+        ?.name,
+      releaseYear,
+      // `duration` and `durationSource` together, or neither of them.
+      ...playtime,
+      imageUrl: mainData.cover.url ? 'https:' + mainData.cover.url : '',
+      genres: mainData.genres?.map((g) => g.name) ?? [],
+      platforms: mainData.platforms?.map((p) => p.abbreviation ?? '?') ?? [],
+      studios: studioNames,
+      publishers: publisherNames,
+      apiRefs: [`igdb__${mainData.id}`],
+      externalUrls: [
+        ...(mainData.url ? [{ name: 'igdb', url: mainData.url }] : []),
+      ]
     }
-  })(),
-  () => errors.internal('Problem retrieving game with igdb.')
+  }),
+  toError('retrieving a game')
 )
+
+/** @type Adapter */
+module.exports = {
+  search,
+  retrieve
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 /**
  * IGDB holds no time to beat for roughly a third of games. That is ordinary,
@@ -169,28 +182,36 @@ const retrieve = (ref) => ResultAsync.fromPromise(
  */
 const retrieveTimeToBeat = async (gameId) => {
   try {
-    const { data } = await axios({
-      method: 'post',
-      url: TIME_TO_BEATS_URL,
-      headers: {
-        'Client-ID': TWITCH_CLIENT_ID,
-        Authorization: `Bearer ${await twitchToken}`,
-        Accept: 'application/json',
-      },
-      data: timeToBeatQuery([gameId]),
+    const data = await retrying(async () => {
+      const response = await axios({
+        method: 'post',
+        url: TIME_TO_BEATS_URL,
+        headers: {
+          'Client-ID': TWITCH_CLIENT_ID,
+          Authorization: `Bearer ${await twitchToken()}`,
+          Accept: 'application/json',
+        },
+        data: timeToBeatQuery([gameId]),
+      })
+      return response.data
     })
     return data?.[0]
   } catch (e) {
     console.error(
-      `IGDB time to beat lookup failed for game ${gameId}: ` +
-      `${e?.response?.status ?? ''} ${e?.response?.data ?? e?.message ?? e}`
+      `IGDB time to beat lookup failed for game ${gameId}: ${describeFailure(e)}`
     )
     return undefined
   }
 }
 
-/** @type Adapter */
-module.exports = {
-  search,
-  retrieve
+/**
+ * A failure that reaches here has already been retried, so it is worth saying
+ * what it actually was. It used to arrive as the string "Something went
+ * terribly wrong...", which told nobody anything.
+ * @type {(doing: string) => (err: any) => Error}
+ */
+const toError = (doing) => (err) => {
+  console.error(`igdb failed while ${doing}: ${describeFailure(err)}`)
+
+  return errors.internal(`igdb failed while ${doing} (${describeFailure(err)})`)
 }

--- a/src/api/utils/external_api_adapters/retry.js
+++ b/src/api/utils/external_api_adapters/retry.js
@@ -1,0 +1,128 @@
+/**
+ * @file Retrying the external metadata APIs when they blink.
+ *
+ * Google Books answers something like one search in eight with a 503, and
+ * TMDB and IGDB have the same habit. Every one of those blips reached the
+ * user as a bare 500 from `/works/search` — a search that works when you run
+ * it again is issue #80.
+ *
+ * The retry lives here rather than in each adapter: it is dependency-free and
+ * takes its clock as an argument, so it is testable without a network or a
+ * wait, and the adapters keep nothing but their own mapping code.
+ */
+
+/**
+ * Statuses worth a second attempt. Anything outside this set is either a real
+ * answer or our own mistake, and retrying it only makes the user wait longer
+ * for the same failure.
+ */
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504])
+
+/**
+ * Network failures that say nothing about the request itself — a connection
+ * that died, a DNS lookup that didn't come back.
+ */
+const RETRYABLE_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'ECONNRESET',
+  'EPIPE',
+  'ETIMEDOUT',
+  'ERR_NETWORK',
+])
+
+/** Attempts in total, not retries after the first. */
+const ATTEMPTS = 3
+
+const BASE_DELAY_MS = 200
+const MAX_DELAY_MS = 2000
+
+/**
+ * The three clients here report a status in three different places: axios on
+ * `response.status`, `got` — which node-themoviedb throws straight through
+ * for anything it has no class for — on `response.statusCode`, and
+ * node-themoviedb's own error classes on `errorCode`.
+ * @type {(err: any) => number | undefined}
+ */
+const statusOf = (err) =>
+  err?.response?.status
+  ?? err?.response?.statusCode
+  ?? err?.errorCode
+  ?? err?.status
+
+/** @type {(err: any) => boolean} */
+const isTransient = (err) =>
+  RETRYABLE_STATUSES.has(/** @type any */ (statusOf(err)))
+  || RETRYABLE_CODES.has(err?.code)
+
+/**
+ * Exponential, capped so three attempts stay well inside a function's
+ * ten seconds.
+ * @type {(attempt: number) => number}
+ */
+const backoffMs = (attempt) =>
+  Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS)
+
+/**
+ * What went wrong, in the few words worth putting in a log line or a 500
+ * body. `JSON.stringify` of an Error is `{}`, which is how these failures
+ * came to be indistinguishable from one another.
+ * @type {(err: any) => string}
+ */
+const describeFailure = (err) => {
+  const status = statusOf(err)
+
+  return [
+    status === undefined ? undefined : `HTTP ${status}`,
+    typeof err?.code === 'string' ? err.code : undefined,
+    err?.message,
+  ]
+    .filter((part) => part)
+    .join(' ')
+    || String(err)
+}
+
+/**
+ * Calls `attempt` until it succeeds, until a failure looks permanent, or
+ * until the attempts run out — whichever comes first, rethrowing the last
+ * failure. `attempt` is a thunk and not a promise so that each try is a fresh
+ * request.
+ *
+ * @template T
+ * @type {(
+ *   attempt: () => Promise<T>,
+ *   options?: { attempts?: number, sleep?: (ms: number) => Promise<void> },
+ * ) => Promise<T>}
+ */
+const retrying = async (attempt, { attempts = ATTEMPTS, sleep = wait } = {}) => {
+  for (let n = 1; ; n++) {
+    try {
+      return await attempt()
+    } catch (err) {
+      if (n >= attempts || !isTransient(err)) throw err
+
+      console.warn(
+        `Retrying after attempt ${n} of ${attempts}: ${describeFailure(err)}`
+      )
+      await sleep(backoffMs(n))
+    }
+  }
+}
+
+module.exports = {
+  ATTEMPTS,
+  BASE_DELAY_MS,
+  MAX_DELAY_MS,
+  RETRYABLE_CODES,
+  RETRYABLE_STATUSES,
+  backoffMs,
+  describeFailure,
+  isTransient,
+  retrying,
+  statusOf,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/** @type {(ms: number) => Promise<void>} */
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/api/utils/external_api_adapters/retry.test.js
+++ b/src/api/utils/external_api_adapters/retry.test.js
@@ -1,0 +1,146 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  ATTEMPTS,
+  MAX_DELAY_MS,
+  backoffMs,
+  describeFailure,
+  isTransient,
+  retrying,
+  statusOf,
+} = require('./retry')
+
+/** A 503 exactly as axios throws it — the Google Books failure in issue #80. */
+const axiosError = (status) =>
+  Object.assign(new Error(`Request failed with status code ${status}`), {
+    response: { status },
+  })
+
+/** `got`'s HTTPError, which node-themoviedb rethrows for anything non-4xx. */
+const gotError = (statusCode) =>
+  Object.assign(new Error('Response code 503 (Service Unavailable)'), {
+    name: 'HTTPError',
+    response: { statusCode },
+  })
+
+/** node-themoviedb's own error classes, which carry `errorCode`. */
+const tmdbError = (errorCode) =>
+  Object.assign(new Error('Too many requests per IP'), { code: 0, errorCode })
+
+/** A dead connection, which carries no status at all. */
+const networkError = (code) =>
+  Object.assign(new Error('socket hang up'), { code })
+
+/** Resolves at once, and records what it was asked to wait for. */
+const recordingSleep = (delays) => (ms) => (delays.push(ms), Promise.resolve())
+
+test('a status is found wherever the client of the day put it', () => {
+  assert.equal(statusOf(axiosError(503)), 503)
+  assert.equal(statusOf(gotError(502)), 502)
+  assert.equal(statusOf(tmdbError(429)), 429)
+  assert.equal(statusOf(networkError('ECONNRESET')), undefined)
+  assert.equal(statusOf(new TypeError('items is undefined')), undefined)
+  assert.equal(statusOf(undefined), undefined)
+})
+
+test('the failures the APIs recover from on their own are transient', () => {
+  // 503 is the one issue #80 is about; the rest fail the same way.
+  ;[408, 425, 429, 500, 502, 503, 504].forEach((status) => {
+    assert.equal(isTransient(axiosError(status)), true, `HTTP ${status}`)
+    assert.equal(isTransient(gotError(status)), true, `HTTP ${status}`)
+  })
+  assert.equal(isTransient(tmdbError(429)), true)
+  assert.equal(isTransient(networkError('ECONNRESET')), true)
+  assert.equal(isTransient(networkError('EAI_AGAIN')), true)
+})
+
+test('an answer, or a mistake of ours, is not', () => {
+  // Retrying these only makes the user wait for the same failure. A 401 in
+  // particular means the key is wrong and will still be wrong in 200ms.
+  ;[400, 401, 403, 404, 422].forEach((status) => {
+    assert.equal(isTransient(axiosError(status)), false, `HTTP ${status}`)
+  })
+  assert.equal(isTransient(tmdbError(404)), false)
+  assert.equal(isTransient(new TypeError('items is undefined')), false)
+  assert.equal(isTransient('Something terrible happened'), false)
+  assert.equal(isTransient(undefined), false)
+})
+
+test('backoff grows, and stops growing', () => {
+  assert.equal(backoffMs(1), 200)
+  assert.equal(backoffMs(2), 400)
+  assert.equal(backoffMs(3), 800)
+  assert.equal(backoffMs(20), MAX_DELAY_MS)
+})
+
+test('a call that works is made once and returned', async () => {
+  let calls = 0
+
+  const result = await retrying(async () => (calls++, 'ok'))
+
+  assert.equal(result, 'ok')
+  assert.equal(calls, 1)
+})
+
+test('a blip is retried, and the second answer is the one returned', async () => {
+  const delays = []
+  let calls = 0
+
+  const result = await retrying(
+    async () => {
+      calls++
+      if (calls === 1) throw axiosError(503)
+      return 'ok'
+    },
+    { sleep: recordingSleep(delays) },
+  )
+
+  assert.equal(result, 'ok')
+  assert.equal(calls, 2)
+  assert.deepEqual(delays, [200])
+})
+
+test('an API that stays down gives up, and says how it failed', async () => {
+  const delays = []
+  let calls = 0
+
+  await assert.rejects(
+    retrying(
+      async () => { calls++; throw axiosError(503) },
+      { sleep: recordingSleep(delays) },
+    ),
+    /status code 503/,
+  )
+
+  assert.equal(calls, ATTEMPTS)
+  assert.deepEqual(delays, [200, 400])
+})
+
+test('a permanent failure is not retried at all', async () => {
+  const delays = []
+  let calls = 0
+
+  await assert.rejects(
+    retrying(
+      async () => { calls++; throw axiosError(404) },
+      { sleep: recordingSleep(delays) },
+    ),
+    /status code 404/,
+  )
+
+  assert.equal(calls, 1)
+  assert.deepEqual(delays, [])
+})
+
+test('failures describe themselves rather than stringifying to {}', () => {
+  // `JSON.stringify(new Error(...))` is `{}`, which is how one upstream
+  // failure came to look exactly like every other one in the logs.
+  assert.equal(
+    describeFailure(axiosError(503)),
+    'HTTP 503 Request failed with status code 503',
+  )
+  assert.equal(describeFailure(networkError('ECONNRESET')), 'ECONNRESET socket hang up')
+  assert.equal(describeFailure('Something terrible happened'), 'Something terrible happened')
+  assert.equal(describeFailure(undefined), 'undefined')
+})

--- a/src/api/utils/external_api_adapters/tv_shows/tmdb.js
+++ b/src/api/utils/external_api_adapters/tv_shows/tmdb.js
@@ -13,6 +13,7 @@ const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const { match } = require('ts-pattern')
 const { throwIt } = require('../../general')
+const { retrying, describeFailure, statusOf } = require('../retry')
 
 const { TMDB_API_KEY } = process.env
 
@@ -20,7 +21,7 @@ const tmdbClient = new tmdb(TMDB_API_KEY ?? throwIt('TMDB_API_KEY is not set.'))
 
 /** @type SearchFunction */
 const search = (titleSearch) => ResultAsync.fromPromise(
-   tmdbClient.search.TVShows({ query: { query: titleSearch } })
+  retrying(() => tmdbClient.search.TVShows({ query: { query: titleSearch } }))
     .then(({ data }) =>
       data.results.map((result) => ({
         title: result.name,
@@ -36,10 +37,10 @@ const search = (titleSearch) => ResultAsync.fromPromise(
 
 /** @type TVShowRetrieveFunction */
 const retrieve = (ref) => ResultAsync.fromPromise(
-  Promise.all([
+  retrying(() => Promise.all([
     tmdbClient.tv.getDetails({ pathParameters: { tv_id: ref } }),
     tmdbClient.tv.getCredits({ pathParameters: { tv_id: ref } })
-  ])
+  ]))
     .then(([{ data }, { data: credits }]) => ({
       entryType: 'TVShow',
       originalTitle: data.original_name,
@@ -73,12 +74,17 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/** @type {(err: any) => Error} */
-const toError = (err) => match(err.errorCode)
+/**
+ * `statusOf` rather than `err.errorCode`, because node-themoviedb only wraps
+ * the statuses it has a class for and throws `got`'s own error through for
+ * the rest — including the 5xx that `retrying` has just given up on.
+ * @type {(err: any) => Error}
+ */
+const toError = (err) => match(statusOf(err))
   .with(404, () => errors.notFound('tmdb'))
   .with(401, () => errors.unauthorized('tmdb'))
   .with(408, () => errors.internal('tmdb timed out'))
   .otherwise(() => {
-    console.log(err)
-    return errors.internal(`unknown tmdb error: ${JSON.stringify(err)}`)
+    console.error(`tmdb failed: ${describeFailure(err)}`)
+    return errors.internal(`tmdb failed (${describeFailure(err)})`)
   })


### PR DESCRIPTION
Fixes #80.

Google Books answers roughly one search in eight with a 503. Nothing caught that, so every blip left the search modal with a 500 and the user retyping the same query. TMDB and IGDB fail the same way, just less often, which is the "happens occasionally for various databases" part of the issue.

Reproduced against production — six failures in twenty-five requests, each one `"Problem retrieving book with Google Books."`:

```
for i in $(seq 1 25); do curl -s -o /dev/null -w "%{http_code} " "https://nil.moe/.netlify/functions/works/search/books/honjin%20murders"; done
200 500 200 500 200 200 200 200 200 200 500 500 200 200 200 500 200 200 200 500 200 200 200 200 200
```

`retrying`, in the new `external_api_adapters/retry.js`, wraps every upstream call. Three attempts, capped exponential backoff, and only for failures an API recovers from on its own: 408, 425, 429, 5xx and dead connections. A 401 or a 404 is answered at once, as before — retrying a wrong key only makes the user wait for the same failure. It is dependency-free and takes its clock as an argument, so its tests need neither a network nor a wait.

Three other things had to change for a retry to be possible, or worth having.

**Google omits `items` when nothing matched**, rather than sending an empty array. Reading it as one was a TypeError, so a search with no hits came back a 500 instead of "No results found for this query...". That one is not intermittent — it is every no-hit search, on every deploy since.

**The adapters threw the failure away.** IGDB rethrew the string `"Something went terribly wrong..."`; TMDB reported `JSON.stringify(err)`, which for an Error is `{}`. Nothing downstream — including a retry — could tell a 503 from a bad key. `describeFailure` now says which it was, in the log line and in the response body.

**The Twitch token lived in a module-level promise**, so one bad minute at Twitch poisoned every game request the warm function served afterwards: a rejected promise stays rejected, and nothing re-requested. It is fetched on demand now, kept only once it has worked and forgotten again if it hasn't. This is the one change here that is speculative rather than reproduced — but it turns a single transient failure into a persistent one, which is worse than what #80 reports.

An ISBN Google can't resolve is now a 404 rather than a 500, which is what it is.

## Worth arguing with

- **Three attempts, 200ms then 400ms.** Chosen to stay well inside a function's ten seconds while Netlify's own timeout is the real ceiling. At Google's observed failure rate this takes a search's chance of failing from about one in eight to about one in five hundred.
- **429 is retried.** A burst against a per-minute quota recovers in exactly the way a backoff is for. A per-*day* quota does not, and those requests will now take an extra 600ms before failing. `Retry-After` is not honoured, deliberately: Google's is measured in hours when the daily quota is what ran out.
- **`toError` matches on `statusOf(err)` rather than `err.errorCode`** in the TMDB adapters. node-themoviedb only wraps the statuses it has a class for and throws `got`'s own error through for everything else, so the previous `err.errorCode` match never saw a 5xx at all.

## Testing

`retry.test.js` covers the status-shape differences between the three clients, which failures count as transient, the backoff curve, and that `retrying` retries a blip, gives up after three, and does not retry a 404. It injects `sleep`, so it runs in 58ms with no network. `npm test` is 201 passing, and 190 passing with 11 skipped under CI's no-install run.

Against the live APIs: thirty consecutive "honjin murders" searches all returned their fourteen results, absorbing four real 503s on the way; a no-hit search returns `[]`; a bogus ISBN returns NotFound. Games, films and TV search and retrieve still work, and IGDB playtimes still populate — Super Mario 64 comes back 780 minutes from `igdb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
