### PR TITLE
Serve the lists as data, so a model can read one

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ there is a history of backups rather than one overwritten dump;
 `restore_backup.js` puts a snapshot (or one collection of it) back. See
 [src/db_maintenance/README.md](src/db_maintenance/README.md).
 
+**Reading a list without a browser.** The lists are drawn client-side, so
+fetching `https://nil.moe/films/nil` and reading the HTML gets you an empty
+`<div id="site">` — no titles, no scores, no notes. That is a problem for
+anything that isn't a browser, a language model above all. The export
+endpoint is the same lists as data:
+
+```
+GET /api/export/:type/:username      # one list: films, tv, games or books
+GET /api/export/:username            # all four at once
+?format=md                           # Markdown instead of JSON
+?limit=200                           # the N most recently updated, per list
+```
+
+Every entry comes with the work's metadata (with the user's overrides
+applied, as the page shows it), the score, the dates and the long note.
+`workRef`, `userId`, `apiRefs` and the raw override object stay out of it;
+durations are in minutes and dates are `YYYY-MM-DD`, so nothing has to be
+decoded. It is public, exposing exactly what the rendered page already does —
+drafts and edit history stay owner-only.
+
+**A Netlify function may return 6 MB.** All four of `nil`'s lists are already
+over 4 MB and the notes are what grow, so the all-in-one url is the one that
+will hit the ceiling first. Over 5 MB it answers `413` naming the per-type
+urls and `?limit=`, rather than letting Netlify return a 502 with nothing in
+it. One list at a time is the shape that keeps working.
+
+The `<noscript>` block in `layouts/base.njk` is the only part of a page that
+is in its source, and it points at these urls, so a reader that fetches
+`/films/nil` and finds nothing is told where to look. `_redirects` maps
+`/api/*` onto `/.netlify/functions/*`, which is what makes every url in this
+README real rather than aspirational.
+
 **Entry history and drafts.** Saving an entry stores the version it replaced
 in the `entryRevisions` collection, and the edit form autosaves what is in it
 to the same collection while it is open. The edit modal grows a *History*

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,9 @@
 /img/*	/img/:splat	200!
+
+# The functions answer at `/.netlify/functions/*`, which is not a url anyone
+# would type or hand to a language model. `/api/*` is the one the README and
+# the export endpoint advertise. `getUrlSegments` strips either prefix, so it
+# doesn't matter which of the two Netlify reports as the request path.
+/api/*	/.netlify/functions/:splat	200
+
 /*	/index.html	200!

--- a/src/api/controllers/export.js
+++ b/src/api/controllers/export.js
@@ -1,0 +1,192 @@
+/**
+ * @file A user's lists in one response, for readers that aren't browsers.
+ *
+ * The lists on the site are public but they are drawn client-side, so
+ * fetching `https://nil.moe/films/nil` gets you an empty page and no data.
+ * This is the same thing in a form a language model, a script or `curl` can
+ * read: every entry with its metadata and its long note, as JSON or as
+ * Markdown.
+ *
+ * Public, and deliberately so — it exposes exactly what the rendered page
+ * already does. Drafts and edit history stay owner-only; see revisions.js.
+ */
+/** @typedef {import('@netlify/functions').HandlerEvent} Event */
+/** @typedef {import('../utils/responses').Response} Response */
+/** @typedef {import('../utils/parsers').ValidCollection} ValidCollection */
+const { combine } = require('neverthrow')
+const responses = require('../utils/responses')
+const errors = require('../utils/errors')
+const db = require('../utils/db/')
+const { getSegment, findIdOfName, toEntryCollection, toReviewCollection } = require('./utils')
+const { safeJSONStringify, warn } = require('../utils/general')
+const {
+  ENTRY_TYPES,
+  toExportList,
+  toExportDocument,
+  toMarkdown,
+} = require('../utils/export_view')
+
+/**
+ * A Netlify function may return 6 MB, and going over is a 502 with nothing in
+ * it to explain itself. All four of one heavy user's lists already come to
+ * north of 4 MB, so the ceiling is real; this leaves headroom for the headers
+ * and for a list that grew since the last time anyone checked.
+ */
+const MAX_BODY_BYTES = 5 * 1024 * 1024
+
+/**
+ * GET /api/export/:username           — every list
+ * GET /api/export/:type/:username     — one list
+ *
+ * `?format=md` for Markdown; JSON otherwise. `?limit=N` keeps the N
+ * most recently updated entries of each list, as `/api/entries` does.
+ * @type {(event: Event) => Promise<Response>}
+ */
+const exportUserLists = async (event) => {
+  const [entryTypes, username] = getSegment(1, event)
+    ? [[getSegment(0, event)], getSegment(1, event)]
+    : [ENTRY_TYPES, getSegment(0, event)]
+
+  const collections = combine(entryTypes.map(toEntryCollection))
+  // Whoever hit this is likely guessing at the url, so say what would have
+  // worked rather than only that this didn't.
+  if (collections.isErr()) {
+    return responses.fromError(
+      errors.notFound(`no such list type; try one of ${ENTRY_TYPES.join(', ')}`)
+    )
+  }
+
+  const userId = await findIdOfName(username).unwrapOr(undefined)
+  // A name nobody has taken and a name whose lists happen to be empty are
+  // different things, and only the first is a 404.
+  if (!userId) return responses.fromError(errors.notFound(`no such user: ${username}`))
+
+  const limit = toLimit(event)
+  const lists = await Promise.all(
+    collections.value.map(async (collection, index) =>
+      toExportList(entryTypes[index], await findListEntries(collection, userId, limit))
+    )
+  )
+
+  const siteUrl = toSiteUrl(event)
+  const document = toExportDocument({ username, lists, siteUrl })
+
+  return wantsMarkdown(event)
+    ? withinBudget('text/markdown; charset=utf-8', toMarkdown(document, siteUrl), username)
+    : asJson(document, username)
+}
+
+module.exports = {
+  exportUserLists,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * The entries of one list with their works and their notes. Two queries per
+ * list: the entries joined to their works, then every note of those entries
+ * at once.
+ * @type {(collection: ValidCollection, userId: string, limit?: number) => Promise<object[]>}
+ */
+const findListEntries = async (collection, userId, limit) => {
+  const found = await db
+    .findAllUserEntriesWithMetadata_(collection, userId, limit)
+    .unwrapOr({ data: [] })
+
+  const rows = found?.data ?? []
+  const reviews = await findReviews(
+    toReviewCollection(collection),
+    rows.map(({ entry }) => entry?.ref?.id).filter(Boolean)
+  )
+
+  return rows.map(({ entry, work }) => ({
+    entry: entry?.data ?? {},
+    work: work?.data ?? {},
+    review: reviews.get(entry?.ref?.id),
+  }))
+}
+
+/**
+ * The notes of a whole list, keyed by the entry they belong to. A note the
+ * user has since emptied is stored as an empty string, which is not something
+ * to export.
+ * @type {(collection: ValidCollection, entryRefs: string[]) => Promise<Map<string, string>>}
+ */
+const findReviews = async (collection, entryRefs) => {
+  const found = await db
+    .findAllByFieldIn_(collection, 'entryRef', entryRefs)
+    .unwrapOr([])
+
+  return new Map(
+    (found ?? [])
+      .map(({ data }) => data)
+      .filter((review) => review?.entryRef && review?.text)
+      .map((review) => [review.entryRef, review.text])
+  )
+}
+
+/**
+ * The site this was fetched from, so the export can link back to the pages it
+ * mirrors. Netlify gives the function the original request url in `rawUrl`.
+ * @type {(event: Event) => string | undefined}
+ */
+const toSiteUrl = (event) => {
+  try {
+    return new URL(event.rawUrl).origin
+  } catch (error) {
+    warn(`Could not read the site url from ${event?.rawUrl}: ${error}`)
+    return undefined
+  }
+}
+
+/** @type {(event: Event) => boolean} */
+const wantsMarkdown = (event) =>
+  ['md', 'markdown', 'text'].includes(
+    (event.queryStringParameters?.format ?? '').toLowerCase()
+  )
+
+/** @type {(event: Event) => number | undefined} */
+const toLimit = (event) =>
+  parseInt(event.queryStringParameters?.limit ?? '') || undefined
+
+/**
+ * `responses.ok` stringifies but sends no content type, which leaves this
+ * arriving as `text/plain`, and a reader deciding how to parse a body
+ * deserves to be told. Not indented: it costs a quarter of the response and
+ * every reader of this — browsers included — formats JSON itself.
+ * @type {(body: object, username: string) => Response}
+ */
+const asJson = (body, username) =>
+  safeJSONStringify(body).match(
+    (text) => withinBudget('application/json; charset=utf-8', text, username),
+    (error) => (warn(error), responses.internalError(errors.internal(error)))
+  )
+
+/**
+ * A body over the ceiling never reaches the caller, so say what happened and
+ * what to ask for instead. Both suggestions are smaller by construction: one
+ * list is a quarter of four, and a limit is whatever the caller can take.
+ * @type {(contentType: string, body: string, username: string) => Response}
+ */
+const withinBudget = (contentType, body, username) =>
+  Buffer.byteLength(body) <= MAX_BODY_BYTES
+    ? asText(contentType, body)
+    : responses.payloadTooLarge({
+        error: 'These lists are too big to send in one response.',
+        tryInstead: [
+          ...ENTRY_TYPES.map((type) => `/api/export/${type}/${username}`),
+          `/api/export/${username}?limit=200`,
+        ],
+      })
+
+/** @type {(contentType: string, body: string) => Response} */
+const asText = (contentType, body) => ({
+  statusCode: 200,
+  headers: {
+    'content-type': contentType,
+    // Public data, and reading it from a page or a notebook shouldn't need a
+    // proxy.
+    'access-control-allow-origin': '*',
+  },
+  body,
+})

--- a/src/api/routes/export.js
+++ b/src/api/routes/export.js
@@ -1,0 +1,17 @@
+/** @file export */
+/** @typedef {import('@netlify/functions').Handler} Handler */
+const responses = require('../utils/responses')
+const { exportUserLists } = require('../controllers/export')
+const { matchVerbAndNumberOfUrlSegments } = require('../router')
+
+/** @type Handler */
+exports.handler = async (event, context) =>
+  matchVerbAndNumberOfUrlSegments(event)
+
+    // GET /api/export/:username
+    .with(['GET', 1], () => exportUserLists(event))
+
+    // GET /api/export/:type/:username
+    .with(['GET', 2], () => exportUserLists(event))
+
+    .otherwise(() => responses.notFound())

--- a/src/api/utils/db/index.js
+++ b/src/api/utils/db/index.js
@@ -17,7 +17,7 @@
 /** @typedef {import('../parsers').ValidCollection} ValidCollection */
 /** @typedef {import('../errors').Error} Error */
 const { ResultAsync } = require('neverthrow')
-const { _findOneByField, _findOneByRef, _findAllByField, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
+const { _findOneByField, _findOneByRef, _findAllByField, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
 const { compose } = require('ramda')
 const { toResponse, toResult } = require('./into_safe_values')
 
@@ -38,6 +38,9 @@ const findAllByField = compose(toResponse, _findAllByField)
 
 /** @type {(collection: ValidCollection, field: string, value: any, limit?: number) => ResultAsync<any, Error>} */
 const findAllByField_ = compose(toResult, _findAllByField)
+
+/** @type {(collection: ValidCollection, field: string, values: any[]) => ResultAsync<any, Error>} */
+const findAllByFieldIn_ = compose(toResult, _findAllByFieldIn)
 
 /** @type {(collection: ValidCollection, userId: string, limit?: number) => ResultAsync<any, Error>} */
 const findAllUserEntriesWithMetadata_ = compose(toResult, _findAllUserEntriesWithMetadata)
@@ -72,6 +75,7 @@ module.exports = {
   findAll,
   findAllByField,
   findAllByField_,
+  findAllByFieldIn_,
   findOneByField,
   findOneByField_,
   findAllUserEntriesWithMetadata_,

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -27,6 +27,17 @@ const _findAllInCollection = (collection) =>
 const _findAllByField = (collection, field, value) =>
   findAll(collection, { [field]: value })
 
+/**
+ * One query for many values of the same field, rather than one query per
+ * value. A whole list's reviews are 400-odd `entryRef`s, and 400 round trips
+ * is the difference between a response and a function timeout.
+ * @type {(collection: ValidCollection, field: string, values: any[]) => Promise<object>}
+ */
+const _findAllByFieldIn = (collection, field, values) =>
+  values.length === 0
+    ? Promise.resolve([])
+    : findAll(collection, { [field]: { $in: values } })
+
 /** @type {(collection: ValidCollection, ref: string, update: any) => Promise<object>} */
 const _updateOneByRef = (collection, ref, update) =>
   mongo((db) => db
@@ -110,6 +121,7 @@ module.exports = {
   _findOneByRef,
   _findAllInCollection,
   _findAllByField,
+  _findAllByFieldIn,
   _findAllUserEntriesWithMetadata,
   _updateOneByRef,
   _create,

--- a/src/api/utils/export_view.js
+++ b/src/api/utils/export_view.js
@@ -1,0 +1,302 @@
+/**
+ * @file A list as something other than a rendered page.
+ *
+ * The site draws its lists in the browser, out of `/api/entries` plus one
+ * `/api/reviews` call per opened row, so anything that fetches a list url and
+ * reads the HTML — a language model, a script, `curl` — gets an empty
+ * `<div id="site">` and none of the data. This module turns the documents a
+ * list is made of into one self-contained view of it: every entry, the note
+ * included, with the internals (`workRef`, `userId`, `apiRefs`, the raw
+ * override object) left out and the numbers in units a reader can use.
+ *
+ * Deliberately pure and dependency-free (no zod, no ramda, no database), so
+ * it is covered by `node --test` without an install — see export_view.test.js.
+ */
+
+/** The `:type` segment of a list url, in the order the lists are exported. */
+const ENTRY_TYPES = ['films', 'tv', 'games', 'books']
+
+const TYPE_TITLES = {
+  films: 'Films',
+  tv: 'TV Shows',
+  games: 'Video Games',
+  books: 'Literature',
+}
+
+/**
+ * Statuses in reading order — what is happening now, then what is done, then
+ * what was abandoned, then what hasn't started.
+ */
+const STATUS_ORDER = ['InProgress', 'Completed', 'Dropped', 'Planned']
+
+const IN_PROGRESS_LABELS = {
+  films: 'Watching',
+  tv: 'Watching',
+  games: 'Playing',
+  books: 'Reading',
+}
+
+const PLANNED_LABELS = {
+  films: 'To watch',
+  tv: 'To watch',
+  games: 'To play',
+  books: 'To read',
+}
+
+/**
+ * The same wording the page's sublist headings use, so a reader of the export
+ * and a reader of the site are talking about the same thing.
+ * @type {(entryType: string, status: string) => string}
+ */
+const statusLabel = (entryType, status) =>
+  ({
+    InProgress: IN_PROGRESS_LABELS[entryType],
+    Completed: 'Completed',
+    Dropped: 'Dropped',
+    Planned: PLANNED_LABELS[entryType],
+  }[status]) ?? status
+
+/**
+ * One entry, flattened: the work's metadata with the user's overrides applied
+ * over it (which is what the page shows), the fields that vary by type under
+ * names that say what they hold, and the long note as `notes`.
+ *
+ * @typedef {{ entry: object, work?: object, review?: string }} RawEntry
+ * @type {(entryType: string, raw: RawEntry) => object}
+ */
+const toExportEntry = (entryType, { entry = {}, work = {}, review }) => {
+  const metadata = withOverrides(work, entry.overrides)
+
+  return compact({
+    id: entry._id,
+    title: metadata.englishTranslatedTitle,
+    // Only when it says something the title doesn't. A work whose original
+    // title is its English one would otherwise repeat itself on every row.
+    originalTitle:
+      metadata.originalTitle !== metadata.englishTranslatedTitle
+        ? metadata.originalTitle
+        : undefined,
+    status: statusLabel(entryType, entry.status),
+    score: entry.score,
+    releaseYear: metadata.releaseYear,
+    ...typeSpecificFields(entryType, entry, metadata),
+    genres: metadata.genres,
+    startedDate: toDay(entry.startedDate),
+    completedDate: toDay(entry.completedDate),
+    updatedDate: toDay(entry.updatedDate),
+    notes: review,
+    url: metadata.externalUrls?.[0]?.url,
+  })
+}
+
+/**
+ * Every entry of one type, in the order the page stacks them: by status, then
+ * by score, then by title. `count` is here so a reader can tell a short list
+ * from a truncated one.
+ * @type {(entryType: string, raws: RawEntry[]) => object}
+ */
+const toExportList = (entryType, raws = []) => {
+  const entries = raws
+    .map((raw) => toExportEntry(entryType, raw))
+    .sort(byStatusThenScoreThenTitle(entryType))
+
+  return {
+    type: entryType,
+    title: TYPE_TITLES[entryType] ?? entryType,
+    count: entries.length,
+    entries,
+  }
+}
+
+/**
+ * What the endpoint returns: the lists asked for, and enough context to say
+ * whose they are and how old the numbers are.
+ * @type {(args: { username: string, lists: object[], siteUrl?: string, generatedAt?: number }) => object}
+ */
+const toExportDocument = ({ username, lists, siteUrl, generatedAt }) => ({
+  user: username,
+  ...(siteUrl ? { url: `${siteUrl}/profile/${username}` } : {}),
+  generatedAt: new Date(generatedAt ?? Date.now()).toISOString(),
+  lists,
+})
+
+/**
+ * The same document as Markdown, for a reader that would rather have prose
+ * than JSON. Notes are markdown already, so they go in as they were written.
+ * @type {(doc: object, siteUrl?: string) => string}
+ */
+const toMarkdown = (doc, siteUrl) =>
+  [
+    `# ${doc.user}'s lists`,
+    '',
+    `Exported ${doc.generatedAt}.`,
+    ...doc.lists.flatMap((list) => ['', ...listToMarkdown(doc.user, list, siteUrl)]),
+    '',
+  ].join('\n')
+
+module.exports = {
+  ENTRY_TYPES,
+  TYPE_TITLES,
+  STATUS_ORDER,
+  statusLabel,
+  toExportEntry,
+  toExportList,
+  toExportDocument,
+  toMarkdown,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * An override of `null` is the form's way of saying "the work's value is
+ * wrong and there is no replacement" — an unknown release year, say. It must
+ * not shadow the metadata with a null, which is what a plain spread would do.
+ * @type {(work: object, overrides?: object) => object}
+ */
+const withOverrides = (work, overrides) => ({
+  ...work,
+  ...Object.fromEntries(
+    Object.entries(overrides ?? {}).filter(([_field, value]) => value != null)
+  ),
+})
+
+/** @type {(entryType: string, entry: object, metadata: object) => object} */
+const typeSpecificFields = (entryType, entry, metadata) =>
+  ({
+    films: {
+      runtimeMinutes: toDuration(metadata.duration),
+      directors: metadata.directors,
+      actors: metadata.actors,
+    },
+    tv: {
+      runtimeMinutes: toDuration(metadata.duration),
+      episodes: metadata.episodes,
+      // A completed show has been watched through, whatever the last recorded
+      // progress was — the page counts it that way too.
+      episodesWatched:
+        entry.status === 'Completed' ? metadata.episodes : entry.progress,
+      directors: metadata.directors,
+      actors: metadata.actors,
+    },
+    games: {
+      playtimeMinutes: toDuration(metadata.duration),
+      platforms: metadata.platforms,
+      studios: metadata.studios,
+      publishers: metadata.publishers,
+    },
+    books: {
+      pages: toDuration(metadata.duration),
+      authors: metadata.authors,
+      publishers: metadata.publishers,
+    },
+  }[entryType] ?? {})
+
+/**
+ * A stored duration of `0` is not a duration — it means nobody knows, the
+ * same as a missing one, and the page renders both as `-`.
+ * @type {(duration: any) => number | undefined}
+ */
+const toDuration = (duration) =>
+  typeof duration === 'number' && duration > 0 ? duration : undefined
+
+/**
+ * Dates are stored as epoch milliseconds, which no reader should have to
+ * decode. The day is all an entry ever meant.
+ * @type {(timestamp: any) => string | undefined}
+ */
+const toDay = (timestamp) => {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) return undefined
+  const date = new Date(timestamp)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString().slice(0, 10)
+}
+
+/**
+ * Absent fields are left out rather than exported as nulls: a reader can tell
+ * "this list has no genres" from "this entry has no genre" more easily when
+ * the key simply isn't there.
+ * @type {(obj: object) => object}
+ */
+const compact = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(
+      ([_field, value]) =>
+        value != null &&
+        value !== '' &&
+        !(Array.isArray(value) && value.length === 0)
+    )
+  )
+
+/** @type {(entryType: string) => (a: object, b: object) => number} */
+const byStatusThenScoreThenTitle = (entryType) => (a, b) =>
+  statusRank(entryType, a.status) - statusRank(entryType, b.status) ||
+  (b.score ?? -1) - (a.score ?? -1) ||
+  String(a.title ?? '').localeCompare(String(b.title ?? ''))
+
+/** @type {(entryType: string, label: string) => number} */
+const statusRank = (entryType, label) => {
+  const index = STATUS_ORDER.findIndex(
+    (status) => statusLabel(entryType, status) === label
+  )
+  return index === -1 ? STATUS_ORDER.length : index
+}
+
+/** @type {(username: string, list: object, siteUrl?: string) => string[]} */
+const listToMarkdown = (username, list, siteUrl) => {
+  const source = siteUrl ? ` — ${siteUrl}/${list.type}/${username}` : ''
+
+  return [
+    `## ${list.title} (${list.count})${source}`,
+    ...STATUS_ORDER.map((status) => statusLabel(list.type, status))
+      .filter((label, index, labels) => labels.indexOf(label) === index)
+      .flatMap((label) => {
+        const entries = list.entries.filter((entry) => entry.status === label)
+        return entries.length === 0
+          ? []
+          : [
+              '',
+              `### ${label} (${entries.length})`,
+              ...entries.flatMap((entry) => entryToMarkdown(entry)),
+            ]
+      }),
+  ]
+}
+
+/** @type {(entry: object) => string[]} */
+const entryToMarkdown = (entry) => {
+  const heading = [
+    entry.title ?? 'Untitled',
+    entry.originalTitle ? `(${entry.originalTitle})` : '',
+    entry.releaseYear ? `[${entry.releaseYear}]` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const facts = [
+    entry.score != null ? `Score: ${entry.score}/10` : undefined,
+    entry.runtimeMinutes ? `${entry.runtimeMinutes} min` : undefined,
+    entry.playtimeMinutes ? `${entry.playtimeMinutes} min played` : undefined,
+    entry.pages ? `${entry.pages} pages` : undefined,
+    entry.episodes ? `${entry.episodesWatched ?? 0}/${entry.episodes} episodes` : undefined,
+    joinNames('Directed by', entry.directors),
+    joinNames('Written by', entry.authors),
+    joinNames('Starring', entry.actors),
+    joinNames('By', entry.studios),
+    joinNames('Published by', entry.publishers),
+    joinNames('On', entry.platforms),
+    joinNames('Genres:', entry.genres),
+    entry.startedDate ? `started ${entry.startedDate}` : undefined,
+    entry.completedDate ? `finished ${entry.completedDate}` : undefined,
+    entry.url,
+  ].filter(Boolean)
+
+  return [
+    '',
+    `#### ${heading}`,
+    ...(facts.length ? ['', facts.join(' · ')] : []),
+    ...(entry.notes ? ['', entry.notes] : []),
+  ]
+}
+
+/** @type {(label: string, names?: string[]) => string | undefined} */
+const joinNames = (label, names) =>
+  names?.length ? `${label} ${names.join(', ')}` : undefined

--- a/src/api/utils/export_view.js
+++ b/src/api/utils/export_view.js
@@ -214,17 +214,28 @@ const toDay = (timestamp) => {
  * Absent fields are left out rather than exported as nulls: a reader can tell
  * "this list has no genres" from "this entry has no genre" more easily when
  * the key simply isn't there.
+ *
+ * Empty strings inside the name lists count as absent too. A blank director
+ * is invisible on the page — it renders as an empty link — but `[""]` in the
+ * data reads as a director whose name is nothing, and `directors` on 538 TV
+ * shows is exactly that.
  * @type {(obj: object) => object}
  */
 const compact = (obj) =>
   Object.fromEntries(
-    Object.entries(obj).filter(
-      ([_field, value]) =>
-        value != null &&
-        value !== '' &&
-        !(Array.isArray(value) && value.length === 0)
-    )
+    Object.entries(obj)
+      .map(([field, value]) => [field, Array.isArray(value) ? withoutBlanks(value) : value])
+      .filter(
+        ([_field, value]) =>
+          value != null &&
+          value !== '' &&
+          !(Array.isArray(value) && value.length === 0)
+      )
   )
+
+/** @type {(values: any[]) => any[]} */
+const withoutBlanks = (values) =>
+  values.filter((value) => !(typeof value === 'string' && value.trim() === ''))
 
 /** @type {(entryType: string) => (a: object, b: object) => number} */
 const byStatusThenScoreThenTitle = (entryType) => (a, b) =>

--- a/src/api/utils/export_view.test.js
+++ b/src/api/utils/export_view.test.js
@@ -1,0 +1,207 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  statusLabel,
+  toExportEntry,
+  toExportList,
+  toExportDocument,
+  toMarkdown,
+} = require('./export_view')
+
+const film = {
+  entry: {
+    _id: 'e1',
+    workRef: 'w1',
+    userId: 'auth0|abc',
+    status: 'Completed',
+    score: 6,
+    completedDate: 1786233600000,
+    updatedDate: 1786336961244,
+  },
+  work: {
+    _id: 'w1',
+    entryType: 'Film',
+    apiRefs: ['tmdb__1330435'],
+    externalUrls: [{ name: 'tmdb', url: 'https://www.themoviedb.org/movie/1330435' }],
+    englishTranslatedTitle: 'Ghost Killer',
+    originalTitle: 'ゴーストキラー',
+    releaseYear: 2025,
+    duration: 105,
+    genres: ['Action', 'Comedy'],
+    directors: ['Kensuke Sonomura'],
+  },
+  review: 'A bit too zany.',
+}
+
+test('an exported entry carries what the page shows, and not the internals', () => {
+  assert.deepEqual(toExportEntry('films', film), {
+    id: 'e1',
+    title: 'Ghost Killer',
+    originalTitle: 'ゴーストキラー',
+    status: 'Completed',
+    score: 6,
+    releaseYear: 2025,
+    runtimeMinutes: 105,
+    directors: ['Kensuke Sonomura'],
+    genres: ['Action', 'Comedy'],
+    completedDate: '2026-08-09',
+    updatedDate: '2026-08-10',
+    notes: 'A bit too zany.',
+    url: 'https://www.themoviedb.org/movie/1330435',
+  })
+})
+
+test("an override wins over the work's metadata, the way the page renders it", () => {
+  const entry = toExportEntry('films', {
+    ...film,
+    entry: { ...film.entry, overrides: { englishTranslatedTitle: 'Ghost Killer (2025)', duration: 110 } },
+  })
+
+  assert.equal(entry.title, 'Ghost Killer (2025)')
+  assert.equal(entry.runtimeMinutes, 110)
+})
+
+test('an override of null clears the field rather than shadowing the metadata with a null', () => {
+  const entry = toExportEntry('films', {
+    ...film,
+    entry: { ...film.entry, overrides: { releaseYear: null } },
+  })
+
+  assert.equal(entry.releaseYear, 2025)
+})
+
+test('an original title that only repeats the English one is left out', () => {
+  const entry = toExportEntry('films', {
+    ...film,
+    work: { ...film.work, originalTitle: 'Ghost Killer' },
+  })
+
+  assert.ok(!('originalTitle' in entry))
+})
+
+test('a duration of 0 is not a duration', () => {
+  const entry = toExportEntry('films', { ...film, work: { ...film.work, duration: 0 } })
+
+  assert.ok(!('runtimeMinutes' in entry))
+})
+
+test('an empty note is left out rather than exported as an empty string', () => {
+  const entry = toExportEntry('films', { ...film, review: '' })
+
+  assert.ok(!('notes' in entry))
+})
+
+test('each type names its numbers and its people after what they are', () => {
+  const game = toExportEntry('games', {
+    entry: { _id: 'g1', status: 'Completed' },
+    work: { duration: 1500, platforms: ['PC'], studios: ['Team Cherry'], publishers: ['Team Cherry'] },
+  })
+  assert.equal(game.playtimeMinutes, 1500)
+  assert.deepEqual(game.platforms, ['PC'])
+
+  const book = toExportEntry('books', {
+    entry: { _id: 'b1', status: 'InProgress' },
+    work: { duration: 320, authors: ['Ursula K. Le Guin'] },
+  })
+  assert.equal(book.pages, 320)
+  assert.equal(book.status, 'Reading')
+  assert.deepEqual(book.authors, ['Ursula K. Le Guin'])
+})
+
+test('a completed show has been watched through, whatever progress was last recorded', () => {
+  const watched = toExportEntry('tv', {
+    entry: { _id: 't1', status: 'Completed', progress: 3 },
+    work: { episodes: 12 },
+  })
+  assert.equal(watched.episodesWatched, 12)
+
+  const watching = toExportEntry('tv', {
+    entry: { _id: 't2', status: 'InProgress', progress: 3 },
+    work: { episodes: 12 },
+  })
+  assert.equal(watching.episodesWatched, 3)
+  assert.equal(watching.status, 'Watching')
+})
+
+test('a list is ordered by status, then score, then title', () => {
+  const list = toExportList('films', [
+    { entry: { _id: 'a', status: 'Planned' }, work: { englishTranslatedTitle: 'Anatahan' } },
+    { entry: { _id: 'b', status: 'Completed', score: 7 }, work: { englishTranslatedTitle: 'Barry Lyndon' } },
+    { entry: { _id: 'c', status: 'Completed', score: 9 }, work: { englishTranslatedTitle: 'Cure' } },
+    { entry: { _id: 'd', status: 'Completed', score: 9 }, work: { englishTranslatedTitle: 'Andrei Rublev' } },
+  ])
+
+  assert.equal(list.count, 4)
+  assert.deepEqual(
+    list.entries.map(({ title }) => title),
+    ['Andrei Rublev', 'Cure', 'Barry Lyndon', 'Anatahan']
+  )
+})
+
+test('a status the labels do not cover still exports, at the end', () => {
+  const list = toExportList('films', [
+    { entry: { _id: 'a', status: 'Whatever' }, work: { englishTranslatedTitle: 'A' } },
+    { entry: { _id: 'b', status: 'Completed' }, work: { englishTranslatedTitle: 'B' } },
+  ])
+
+  assert.deepEqual(
+    list.entries.map(({ status }) => status),
+    ['Completed', 'Whatever']
+  )
+})
+
+test('a list of a type nobody named keeps its own name', () => {
+  assert.equal(toExportList('films', []).title, 'Films')
+  assert.equal(statusLabel('films', 'Planned'), 'To watch')
+  assert.equal(statusLabel('games', 'InProgress'), 'Playing')
+})
+
+test('the document says whose lists these are and when they were read', () => {
+  const doc = toExportDocument({
+    username: 'nil',
+    lists: [toExportList('films', [film])],
+    siteUrl: 'https://nil.moe',
+    generatedAt: 1786336961244,
+  })
+
+  assert.equal(doc.user, 'nil')
+  assert.equal(doc.url, 'https://nil.moe/profile/nil')
+  assert.equal(doc.generatedAt, '2026-08-10T04:42:41.244Z')
+  assert.equal(doc.lists[0].entries[0].title, 'Ghost Killer')
+})
+
+test('the markdown groups by status and keeps the note as it was written', () => {
+  const markdown = toMarkdown(
+    toExportDocument({
+      username: 'nil',
+      lists: [toExportList('films', [film])],
+      generatedAt: 1786336961244,
+    }),
+    'https://nil.moe'
+  )
+
+  assert.match(markdown, /^# nil's lists$/m)
+  assert.match(markdown, /^## Films \(1\) — https:\/\/nil\.moe\/films\/nil$/m)
+  assert.match(markdown, /^### Completed \(1\)$/m)
+  assert.match(markdown, /^#### Ghost Killer \(ゴーストキラー\) \[2025\]$/m)
+  assert.match(markdown, /Score: 6\/10 · 105 min · Directed by Kensuke Sonomura/)
+  assert.match(markdown, /^A bit too zany\.$/m)
+})
+
+test('an entry with nothing recorded but a title still renders', () => {
+  const markdown = toMarkdown(
+    toExportDocument({
+      username: 'nil',
+      lists: [
+        toExportList('books', [
+          { entry: { _id: 'b1', status: 'Planned' }, work: { englishTranslatedTitle: 'Solaris' } },
+        ]),
+      ],
+      generatedAt: 0,
+    })
+  )
+
+  assert.match(markdown, /^### To read \(1\)$/m)
+  assert.match(markdown, /^#### Solaris$/m)
+})

--- a/src/api/utils/export_view.test.js
+++ b/src/api/utils/export_view.test.js
@@ -86,6 +86,18 @@ test('a duration of 0 is not a duration', () => {
   assert.ok(!('runtimeMinutes' in entry))
 })
 
+test('a blank name is not a name, and a list of nothing but blanks is no list', () => {
+  const entry = toExportEntry('tv', {
+    entry: { _id: 't1', status: 'InProgress' },
+    // What 538 of the real TV shows carry: a director field that is there but
+    // says nothing.
+    work: { directors: [''], actors: ['Javier Bardem', '  '] },
+  })
+
+  assert.ok(!('directors' in entry))
+  assert.deepEqual(entry.actors, ['Javier Bardem'])
+})
+
 test('an empty note is left out rather than exported as an empty string', () => {
   const entry = toExportEntry('films', { ...film, review: '' })
 

--- a/src/api/utils/responses.js
+++ b/src/api/utils/responses.js
@@ -33,6 +33,7 @@ module.exports = {
   badRequest: response(400),
   unauthorized: response(401),
   notFound: response(404),
+  payloadTooLarge: response(413),
   internalError: response(500),
   fromError,
 }

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -91,6 +91,30 @@
     </script>
   </head>
   <body>
+    {#
+      Every page is drawn client-side, so anything that fetches a url here and
+      reads the HTML — a language model, a scraper, `curl` — finds an empty
+      `#site` and concludes the list is empty. This is the one piece of the
+      page that is in the source, and it says where the data actually is.
+    #}
+    <noscript>
+      <h1>Memo</h1>
+      <p>
+        This page is rendered in the browser, so there is nothing to read in
+        its source. The same lists are served as data, and that is what to
+        fetch instead:
+      </p>
+      <ul>
+        <li><code>/api/export/&lt;type&gt;/&lt;username&gt;</code> — one list, where <code>&lt;type&gt;</code> is <code>films</code>, <code>tv</code>, <code>games</code> or <code>books</code></li>
+        <li><code>/api/export/&lt;username&gt;</code> — all four at once, if they fit in one response</li>
+        <li>append <code>?format=md</code> for Markdown instead of JSON, or <code>?limit=200</code> for the most recently updated entries only</li>
+      </ul>
+      <p>
+        Both include every entry with its metadata, its score and its notes.
+        For example, <a href="/api/export/films/nil">/api/export/films/nil</a>
+        is what <a href="/films/nil">/films/nil</a> draws.
+      </p>
+    </noscript>
     <div id="site"></div>
     <script>
       // The 0 timeout is necessary to detect netlify auth token


### PR DESCRIPTION
Closes #76.

The lists are drawn client-side, so fetching `https://nil.moe/films/nil` and reading the HTML gets an empty `<div id="site">` — no titles, no scores, no notes. A model can't read a list at all, and the workaround in the issue (pasting a copied page) loses the notes, which are the part worth reading. This adds the same lists as data.

```
GET /api/export/:type/:username      # one list: films, tv, games or books
GET /api/export/:username            # all four at once
?format=md                           # Markdown instead of JSON
?limit=200                           # the N most recently updated, per list
```

Each entry carries the work's metadata **with the user's overrides applied** — what the page actually shows, not what the API returned — plus the score, the dates and the note. `workRef`, `userId`, `apiRefs` and the raw override object stay out of it; durations are minutes, dates are `YYYY-MM-DD`, and absent fields are omitted rather than exported as nulls. It is public because the rendered page already is; drafts and edit history stay owner-only.

The shaping is pure and dependency-free in `export_view.js` with 15 tests, so the suite still runs with no install and no database.

## Two supporting changes worth looking at

**`_redirects` now maps `/api/*` onto `/.netlify/functions/*`.** The functions have only ever answered at the long path, so every `/api/...` url this README already documents falls through to the catch-all and returns `index.html`. I checked against production before writing it: `/.netlify/functions/entries/films/nil` is `200 text/plain`, `/api/entries/films/nil` is `200 text/html`. `getUrlSegments` already strips either prefix, so it doesn't matter which of the two Netlify reports as the request path.

**`findAllByFieldIn_`** fetches a whole list's notes in one `$in` query. One round trip per entry would be 1500 of them for the films list — the difference between a response and a function timeout. Worth an index on `entryRef` in the review collections if it ever gets slow, same as `entryRevisions`.

## The size ceiling, which is the decision I'd argue with

A Netlify function may return 6 MB, and going over is a 502 with nothing in it to explain itself. On the deploy preview, all four lists come to **4.75 MB** — real, with every note. The notes are what grow.

So: JSON is **not** pretty-printed (a quarter of the response, and every reader including browsers formats JSON itself), and a body over 5 MB answers `413` naming the per-type urls and `?limit=` instead of letting Netlify fail opaquely. That threshold is the arguable part: at 4.75 MB today, `/api/export/nil` will start refusing within a few hundred entries, while Netlify could still carry it to 6 MB. I'd rather refuse early with instructions than 502 late with none, but the number is easy to move. Per-type is the shape that keeps working — the biggest single list is games at 1.9 MB.

## Discovery

The `<noscript>` block added to `base.njk` is the only part of a page that is present in its source. It names these urls, so something that fetches `/films/nil`, finds nothing, and would otherwise conclude the list is empty is told where to look instead.

## Testing

`npm test` passes (192 tests) and every tracked `.js` file parses. Beyond that, everything below was run against the deploy preview, on the real database:

- `/api/export/films/nil` → `200 application/json`, 1517 entries, 1.07 MB — so the new `/api/*` redirect does resolve to the function.
- `/api/export/nil` → 200, 4.75 MB, all four lists.
- `?format=md` → `200 text/markdown`, notes intact and grouped under Watching / Completed / Dropped / To watch.
- `?limit=3` → 3 entries, most recently updated first.
- `/api/export/albums/nil` → 404 `no such list type; try one of films, tv, games, books`; `/api/export/nobodyatall` → 404 `no such user`.
- `/films/nil` serves the `<noscript>` block intact through the html-minifier.

The preview is also what turned up the second commit here: 538 TV shows carry `directors: [""]`, which the page hides as an empty link but the export was faithfully reporting as a director whose name is nothing.

The 413 path is the one thing only covered by a stubbed-database run, since producing it for real would mean writing 5 MB of notes.
