### PR TITLE
Stop a long list waiting on things it could have asked for at once

### DIFF
--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -66,9 +66,14 @@ const _create = (collection, data) =>
     (err) => throwIt(err)
   )
 
-/** @type {(collection: 'filmEntries' | 'gameEntries' | 'tvShowEntries' | 'bookEntries', userId: string, limit?: number) => Promise<object>} */
+/**
+ * A whole list in one query. The ordering and the limit are the database's
+ * job rather than this function's, so a limited request joins the metadata
+ * onto the entries it is going to return instead of onto all of them.
+ *
+ * @type {(collection: 'filmEntries' | 'gameEntries' | 'tvShowEntries' | 'bookEntries', userId: string, limit?: number) => Promise<object>}
+ */
 const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
-  console.log('in _findAllUserEntriesWithMetadata')
   const workCollection = {
     filmEntries: 'films',
     gameEntries: 'games',
@@ -87,6 +92,14 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
     .collection(collection)
     .aggregate([
       { $match: { userId } },
+      // The order the caller used to sort into after the fact. A missing
+      // `updatedDate` sorts last here too. `_id` only breaks ties, of which
+      // there are a great many — a bulk import stamps a whole list with one
+      // millisecond — and it breaks them the same way every time, which the
+      // sort it replaces did not: that one left entries stamped the same
+      // millisecond in whatever order the database happened to return them.
+      { $sort: { updatedDate: -1, _id: 1 } },
+      ...(limit ? [{ $limit: limit }] : []),
       {
         $lookup: {
           from: workCollection,
@@ -95,25 +108,23 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
           as: 'work',
         },
       },
+      // Nobody reads either of these from a list, and they are not small:
+      // `review` is the whole note, which the reviews endpoint serves when a
+      // row is actually opened, and `userId` is an auth0 id repeated once per
+      // entry for anyone who asks for the list.
+      { $project: { review: 0, userId: 0 } },
     ])
     .toArray()
-    .then((arr) => arr
-      .map(toSameFormatAsFaunaDb)
-      .map((entry) => ({ entry, work: { data: entry.data.work?.[0] ?? emptyWork }}))
-    )
+    // `work` is dropped from the entry it was joined onto: the caller returns
+    // it as `commonMetadata`, and left in place it would also travel back as a
+    // second, identical copy on every entry — a third of the response.
+    .then((arr) => arr.map(({ work, ...entry }) => ({
+      entry: toSameFormatAsFaunaDb(entry),
+      work: { data: work?.[0] ?? emptyWork },
+    })))
   )
 
-  const resultsByLastUpdatedIfPossible =
-    [...results].sort((a, b) =>
-      (b.entry?.data?.updatedDate ?? 0) - (a.entry?.data?.updatedDate ?? 0)
-    )
-
-  const finalResults =
-    limit
-      ? resultsByLastUpdatedIfPossible.slice(0, limit)
-      : resultsByLastUpdatedIfPossible
-
-  return { data: finalResults }
+  return { data: results }
 }
 
 module.exports = {

--- a/src/frontend/_includes/js/components/list/index.js
+++ b/src/frontend/_includes/js/components/list/index.js
@@ -1,20 +1,36 @@
 const { initComponent, Error404, WithRemoteData } = Components
-const { getUserIdFromName } = Netlify
+const { getUserIdFromName, getUserName, getEntries } = Netlify
 const { getNameFromUrl, getEntryTypeFromUrl } = Http
 const { List } = Components.List
 const { typeToTitle } = Conversions
 
 const ListPage = () => initComponent({
-  content: ({ include }) => include(
-    typeToTitle[getEntryTypeFromUrl()]
-      ? WithRemoteData({
-        remoteData: getUserIdFromName(getNameFromUrl()),
-        component: ({ data }) => data
-          ? List(getNameFromUrl())
-          : Error404()
-      })
-      : Error404()
-  ),
+  content: ({ include }) => {
+    const entryType = getEntryTypeFromUrl()
+    const username = getNameFromUrl()
+
+    if (!typeToTitle[entryType]) return include(Error404())
+
+    // All three requests go out together, before any of them has answered.
+    // Asked for in the order the page needs them — does this user exist, then
+    // the list, then may this visitor edit it — they cost three round trips
+    // end to end, and the entries, by far the slowest and the only one the
+    // page has to wait for, would be the last to be sent.
+    const user = getUserIdFromName(username)
+    const entries = getEntries(entryType, username)
+    // Resolved once and shared: every table on the page asks whose list this
+    // is, and each of them used to ask the server again.
+    const isOwner = getUserName()
+      .map((resp) => resp?.username === username)
+      .unwrapOr(false)
+
+    return include(WithRemoteData({
+      remoteData: user,
+      component: ({ data }) => data
+        ? List({ username, entryType, entries, isOwner })
+        : Error404()
+    }))
+  },
   initializer: () => {
     const typeTitle = typeToTitle[getEntryTypeFromUrl()]
     const user = getNameFromUrl()

--- a/src/frontend/_includes/js/components/list/list.js
+++ b/src/frontend/_includes/js/components/list/list.js
@@ -1,33 +1,31 @@
 const { html, css } = Utils
-const { getEntries, getUserName } = Netlify
 const { col, initTable, detailFormatter, allColumns, statuses, entryTypeToFullColumns, editColumn, filmStatuses } = Tables
 const { typeToTitle, statusToTitle } = Conversions
 const { initComponent, WithRemoteData, appendContent, Nothing } = Components
 const { Modal_ } = Components.UI
 const { AddEntryButton } = Components.List
-const { getEntryTypeFromUrl, getNameFromUrl } = Http
 const { EntryForm } = Components.List
 
-const List = (username) => initComponent({
+/** `entries` and `isOwner` are already in flight; see `list/index.js`. */
+const List = ({ username, entryType, entries, isOwner }) => initComponent({
   content: ({ include }) => html`
     <div class="container">
       <div class="row" style="padding:20px">
         <div id="list-header">
           ${include(
-            ListPageHeader(typeToTitle[getEntryTypeFromUrl()], username)
+            ListPageHeader(typeToTitle[entryType], username)
           )}
         </div>
           ${include(WithRemoteData({
-            remoteData: getUserName().unwrapOr(null),
-            component: (resp) =>
-              resp?.username === getNameFromUrl()
-                ? AddEntryButton(getEntryTypeFromUrl())
-                : Nothing()
+            remoteData: isOwner,
+            component: (isOwner) =>
+              isOwner ? AddEntryButton(entryType) : Nothing()
           }))}
           ${include(WithRemoteData({
-            remoteData: getEntries(getEntryTypeFromUrl(), username),
+            remoteData: entries,
             component: (entries) => SubLists(
-              getEntryTypeFromUrl(),
+              entryType,
+              isOwner,
               [...entries]
                 .sort((a, b) =>
                   a.commonMetadata.englishTranslatedTitle
@@ -125,10 +123,10 @@ const ListPageHeader = (title, username) => initComponent({
   `
 })
 
-const SubLists = (entryType, data) => initComponent({
+const SubLists = (entryType, isOwner, data) => initComponent({
   content: ({ include }) => html`
     ${(entryType === 'films' ? filmStatuses : statuses)
-      .map((status) => include(SubList(status, entryType, data)))
+      .map((status) => include(SubList(status, entryType, isOwner, data)))
       .join('')
     }
     <div id="global-stats">
@@ -148,7 +146,7 @@ const SubLists = (entryType, data) => initComponent({
   `
 })
 
-const SubList = (status, entryType, data) => initComponent({
+const SubList = (status, entryType, isOwner, data) => initComponent({
   content: ({ id }) => html`
     <div class="row">
       <div class="col-md-10 col-md-offset-1 sublist-wrapper">
@@ -161,24 +159,24 @@ const SubList = (status, entryType, data) => initComponent({
     </div>
   `,
   initializer: ({ id }) => {
-    getUserName()
-      .map((resp) => resp?.username === getNameFromUrl())
-      .unwrapOr(false)
-      .then((isOwner) => {
-        initFullTable(`#${id}-list`, data.filter((e) => e.status === status), entryType, isOwner, status)
-        $(`#${id}-title`).click(() => {
-          const nextEl = $(`#${id}-title`).next()
-          const elsToHide =
-            nextEl.attr('id') === 'click-to-see-comments'
-              ? [nextEl, nextEl.next(), nextEl.parent().parent().next()]
-              : [nextEl, nextEl.parent().parent().next()]
+    $(`#${id}-title`).click(() => {
+      const nextEl = $(`#${id}-title`).next()
+      const elsToHide =
+        nextEl.attr('id') === 'click-to-see-comments'
+          ? [nextEl, nextEl.next(), nextEl.parent().parent().next()]
+          : [nextEl, nextEl.parent().parent().next()]
 
-          elsToHide.forEach(el => {
-            el.toggle(200)
-            el.toggleClass('is-collapsed')
-          })
-        })
+      elsToHide.forEach(el => {
+        el.toggle(200)
+        el.toggleClass('is-collapsed')
       })
+    })
+
+    // Settled long before the entries arrive, so this is a microtask rather
+    // than the round trip per table it used to be.
+    isOwner.then((isOwner) => {
+      initFullTable(`#${id}-list`, data.filter((e) => e.status === status), entryType, isOwner, status)
+    })
   },
   style: () => css`
     .sublist-wrapper {
@@ -232,6 +230,11 @@ const SubList = (status, entryType, data) => initComponent({
 })
 
 const initFullTable = (selector, data, entryType, isOwner, status) => {
+  // The edit button names its row rather than carrying a copy of it, so
+  // rows are kept here for it to name. `dbRef` is unique across the page, so
+  // one registry serves every table on it.
+  data.forEach((row) => { Rows.byRef[row.dbRef] = row })
+
   initTable(selector, data, {
     detailView: true,
     detailFormatter,
@@ -246,10 +249,10 @@ const initFullTable = (selector, data, entryType, isOwner, status) => {
       ...(isOwner ? [Columns.edit()] : []),
     ]
   })
-  window.editEntry = (data) => {
+  window.editEntry = (dbRef) => {
     appendContent('body', Modal_({
       title: "Edit an entry",
-      content: EntryForm(entryType, data),
+      content: EntryForm(entryType, Rows.byRef[dbRef]),
       showCloseConfirmationDialog: () => window.hasUnsavedChange === true
     }))
   }

--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -92,9 +92,14 @@ const edit = () =>
     formatter: (_, row, i) => {
       // We use `onclick` and a global (window.xx) function instead of binding
       // an event, because bootstrap-table destroys the node and rebuilds it
-      // when changing displayed columns
+      // when changing displayed columns.
+      //
+      // The attribute names the row rather than holding it: an owner's list
+      // used to write a JSON copy of every entry — metadata, overrides and
+      // all — into the markup, which on a long list was more bytes of DOM
+      // than the visible table. `Rows.byRef` is filled in by `initFullTable`.
       return html`
-        <i id="edit-${row.status}-${i}" class="fas fa-edit edit-button" onclick='window.editEntry(${JSON.stringify(row).replace(/'/g, `&#39;`)})'></i>
+        <i id="edit-${row.status}-${i}" class="fas fa-edit edit-button" onclick="window.editEntry('${row.dbRef}')"></i>
       `
     },
     cellStyle: () => ({ css: { 'width': '20px' } }),
@@ -166,6 +171,11 @@ const publishers = () =>
 const authors = () =>
   col('Authors', 'commonMetadata.authors', sortableAndLinked('authors'))
 
+/** The rows on the page, by `dbRef`, for the handlers that only get an id. */
+Rows = {
+  byRef: {},
+}
+
 Columns = {
   title,
   status,
@@ -215,7 +225,12 @@ const titleFormatter = (_, row) => {
   const url = externalUrls?.[0]?.url || toWikipediaUrl(englishTranslatedTitle)
   const cover = imageUrl || '/img/mawaru.png'
   const anchorId = `entry-${row.dbRef}`
-  return `<span id="${anchorId}" class="title-with-cover"><img class="mini-thumb" src="${cover}"><a href="${url}">${label}</span>`
+  // Lazily: a list is one row per work and every row carries a cover, so a
+  // long one asked for a thousand full-size posters at once in order to draw
+  // them sixteen pixels wide. The browser now fetches the handful that are
+  // actually on screen. `.mini-thumb` fixes the size, so nothing shifts as
+  // the rest arrive.
+  return `<span id="${anchorId}" class="title-with-cover"><img class="mini-thumb" src="${cover}" loading="lazy" decoding="async" alt=""><a href="${url}">${label}</span>`
 }
 
 const englishTitleAndLastUpdatedFormatter = (_, row) => {

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -17,19 +17,29 @@
         {% include "css/main.css" %}
     </style>
 
+    {# The page cannot draw until every script below has been fetched and run,
+       so anything not needed to draw it carries `defer` and gets out of the
+       way. What is left is what the block of app code at the end of this head
+       reaches for while it is being parsed: jQuery, Ramda, and the libraries
+       the first render calls into. #}
     <!-- JavaScript -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.5/purify.min.js" integrity="sha512-GaomFB92Lot7wDqZgVgLMJwQhuVUEcPHP99xmWSVE4Kq54t1jDyH7mdKDsmN8jOMSjiQq8pf7Et+OM4ml/PVMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
-    <script src="https://cdn.jsdelivr.net/npm/litepicker/dist/litepicker.js"></script>
-    <script type="text/javascript" src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+    {# Only the profile page's charts and the entry form's date fields, both
+       of which are drawn long after the page is. #}
+    <script defer src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/litepicker/dist/litepicker.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.25.0/ramda.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.24.0/axios.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js" integrity="sha512-hzyXu3u+VDu/7vpPjRKFp9w33Idx7pWWNazPm+aCMRu26yZXFCby1gn1JxevVv3LDwnSbyKrvLo3JNdi4Qx1ww==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script type="text/javascript"
-       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    {# Straight to what `cdn.mathjax.org/mathjax/latest` has been a shim for
+       since 2017, so this is one request rather than two. It typesets
+       whatever is on the page when it loads, and at this point that is
+       nothing — `#site` is still empty — so nothing waits on it. #}
+    <script defer type="text/javascript"
+       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
 
     {# macro to include JS with its own const variable scope


### PR DESCRIPTION
Closes #86.

A list of 1500 films took about two and a half seconds to appear, and almost all of that was spent waiting rather than working. Measured on `/films/nil` in Chrome, warm cache. Four things, in the order the page hits them.

### The head blocked on scripts the first render doesn't touch

`netlify-identity-widget.js` was the worst of them — 290ms of render-blocking time — and nothing has referenced it since the Auth0 flow replaced it in January 2022. It's gone. The profile page's charts (apexcharts) and the entry form's date picker (litepicker) load with `defer`, since both are drawn long after the page is. MathJax now points straight at the cdnjs build that `cdn.mathjax.org/mathjax/latest` has been a shim for since 2017, which is one request rather than two, and it is deferred too: it typesets whatever is on the page when it loads, and at that point `#site` is still empty.

`domInteractive`: **495ms → 248ms**.

### The three requests were a chain

The page asked whether the user existed; only once told yes did it build the list component, which asked for the entries — the slow request, and the only one anything actually waits for. Then each table's initializer asked `/name` *again*, and wouldn't draw until that came back.

They now all go out together from `ListPage`, and the answer to "may this visitor edit this list" is resolved once and handed down to the tables that need it. On the films list, entries used to start at 685ms and the tables were still blocked on `/name` at 2194ms. Everything now starts at ~250ms, and there are three requests instead of five.

### The response was twice the size it needed to be

`$lookup` writes the joined work into the entry document, so every work came back once as `commonMetadata` and then again, byte for byte, as `entry.work` — 37% of a 2.1MB response. Dropped, along with two more the list never reads: `review` (the whole note; `/reviews` serves it when a row is opened) and `userId`, an auth0 id repeated once per entry for anyone who asks for a public list.

Sorting and limiting also move into the pipeline, so `/entries/films/nil/5` — what the profile page asks for — joins metadata onto five entries instead of onto 1517 and then slicing. Sorting in Mongo makes the order stable, which sorting a result set that came back in no particular order was not; `_id` breaks ties, of which there are many, because a bulk import stamps a whole list with one millisecond.

Checked against production, read-only: same 1517 entries, same sequence of `updatedDate`s, byte-identical apart from the three dropped fields.

| | before | after |
|---|---|---|
| `/entries/films/nil` | 2,139,927 B | 1,197,486 B (−44%) |
| aggregation | 384 ms | 210 ms |
| `?limit=5` | 1517 docs joined, then sliced | 5 docs, 33 ms |

### Every cover was fetched at once

One row per work, one cover per row, so a long list asked the browser for a thousand-odd full-size posters in order to draw them sixteen pixels wide. `loading="lazy"`, so it fetches the ones on screen — 227 image requests during load became 0. `.mini-thumb` already fixes the size, so nothing shifts as the rest arrive.

### The edit button carried its whole row in an attribute

`JSON.stringify(row)` into an `onclick`, for every row, so an owner looking at their own list got the entire list written into the markup a second time. It carries the row's `dbRef` now and looks the row up in a registry `initFullTable` fills in. Only owners ever saw this cost, which is why it isn't in the numbers above.

## What this doesn't do

- **Caching.** `/entries` answers `Cache-Control: no-cache`, and an edge cache with a short `s-maxage` would be the largest remaining win for anyone who isn't the owner. It's left out because getting invalidation wrong means someone saves an entry and doesn't see it.
- **A `userId` index.** `filmEntries` has only `{_id: 1}`, so the `$match` is a collection scan — but 1517 of the 1526 documents in it belong to this user, so an index would save nothing until there are more users.
- **`emptyWork` is double-wrapped.** An entry whose `workRef` points at nothing gets `commonMetadata: { data: { entryType } }` rather than `{ entryType }`, so it loses the `entryType` its formatters read. Pre-existing, a handful of entries, and unrelated to speed — left exactly as it was rather than quietly fixed in a perf change.

## Verification

`npm test` (202 pass) and the CI syntax check. Beyond that, the built frontend was driven against live data and its output compared with production's, page for page: the films and games lists render the same sublists, the same 1519 and 1064 rows, the same per-sublist and global stats, and the same first row. The edit modal was opened through the new registry path and came back with the right entry in every field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
