### PR TITLE
Give an entry whose work is missing its type back

### DIFF
--- a/src/api/utils/db/shapes.js
+++ b/src/api/utils/db/shapes.js
@@ -1,0 +1,45 @@
+/**
+ * @file The shapes the db module hands out, without the database.
+ *
+ * `db.js` builds a MongoClient at require time and throws without
+ * `MONGODB_URL`, so nothing in unsafe_functions.js can be reached from
+ * `node --test`. What a query returns is worth testing even so — a wrong
+ * shape reaches the page as a missing field rather than as an error — so the
+ * shaping lives here, pure and dependency-free, and the queries call it.
+ * See shapes.test.js.
+ */
+
+/**
+ * @info This function exists because we migrated from FaunaDB to MongoDB.
+ * @typedef {{ data: any, ref: { id: string }}} FaunaShaped
+ * @type {(dcmt: any) => FaunaShaped}
+ */
+const toSameFormatAsFaunaDb = (dcmt) => ({
+  data: dcmt,
+  ref: { id: dcmt._id },
+})
+
+/**
+ * One row of a list query: the entry, and beside it the work it points at.
+ *
+ * `work` comes off the entry rather than travelling with it. The caller
+ * returns it as `commonMetadata`, and left in place it would also go back as
+ * a second, identical copy on every entry — a third of the response.
+ *
+ * `$lookup` returns an array, empty when an entry's `workRef` names a work
+ * that isn't there, and the stand-in has to be a bare work document rather
+ * than a wrapped one. The page reads `commonMetadata.entryType` off it;
+ * wrapped, that read lands on `undefined` and the row loses its type — no
+ * status label, and a review request to `/api/reviews/undefined/:id`.
+ *
+ * @type {(row: any, entryType: string) => { entry: FaunaShaped, work: { data: any }}}
+ */
+const toEntryWithMetadata = ({ work, ...entry }, entryType) => ({
+  entry: toSameFormatAsFaunaDb(entry),
+  work: { data: work?.[0] ?? { entryType } },
+})
+
+module.exports = {
+  toSameFormatAsFaunaDb,
+  toEntryWithMetadata,
+}

--- a/src/api/utils/db/shapes.test.js
+++ b/src/api/utils/db/shapes.test.js
@@ -1,0 +1,69 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const { toSameFormatAsFaunaDb, toEntryWithMetadata } = require('./shapes')
+
+/**
+ * One row of the list aggregate: the entry document, with `$lookup`'s array of
+ * matched works on it.
+ * @type {(id: string, work: object[]) => object}
+ */
+const row = (id, work) => ({
+  _id: id,
+  workRef: work[0]?._id ?? 'w-that-is-gone',
+  status: 'Completed',
+  score: 6,
+  updatedDate: 1786336961244,
+  work,
+})
+
+const ghostKiller = {
+  _id: 'w1',
+  entryType: 'Film',
+  englishTranslatedTitle: 'Ghost Killer',
+  releaseYear: 2025,
+}
+
+test('a document is wrapped with its id where a fauna ref used to be', () => {
+  assert.deepEqual(toSameFormatAsFaunaDb({ _id: 'e1', score: 6 }), {
+    data: { _id: 'e1', score: 6 },
+    ref: { id: 'e1' },
+  })
+})
+
+test('the joined work comes back beside the entry, not on it', () => {
+  const { entry, work } = toEntryWithMetadata(row('e1', [ghostKiller]), 'Film')
+
+  assert.deepEqual(work.data, ghostKiller)
+  assert.equal(entry.ref.id, 'e1')
+  assert.equal(entry.data.workRef, 'w1')
+  // The caller spreads the entry into the row alongside `commonMetadata`, so a
+  // `work` left here would be the same document a second time.
+  assert.equal('work' in entry.data, false)
+})
+
+test('an entry whose work is missing still knows what type it is', () => {
+  const { work } = toEntryWithMetadata(row('e1', []), 'Film')
+
+  // The shape a found work has, not a wrapped one: this becomes
+  // `commonMetadata`, and the page reads `commonMetadata.entryType` off it.
+  assert.deepEqual(work.data, { entryType: 'Film' })
+  assert.equal(work.data.entryType, 'Film')
+  assert.equal('data' in work.data, false)
+})
+
+test('the stand-in is built per row rather than shared between them', () => {
+  const first = toEntryWithMetadata(row('e1', []), 'Game')
+  const second = toEntryWithMetadata(row('e2', []), 'Game')
+
+  first.work.data.englishTranslatedTitle = 'set by a caller'
+  assert.deepEqual(second.work.data, { entryType: 'Game' })
+})
+
+test('an entry that lost its work keeps everything the entry itself recorded', () => {
+  const { entry } = toEntryWithMetadata(row('e1', []), 'Book')
+
+  assert.equal(entry.data.score, 6)
+  assert.equal(entry.data.status, 'Completed')
+  assert.equal(entry.data.workRef, 'w-that-is-gone')
+})

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -10,6 +10,7 @@ const { mongo } = require('./db')
 const { v4: uuidv4 } = require('uuid')
 const { throwIt } = require('../general')
 const parsers = require('../parsers/')
+const { toSameFormatAsFaunaDb, toEntryWithMetadata } = require('./shapes')
 
 /** @type {(collection: ValidCollection, field: string, value: any) => Promise<object>} */
 const _findOneByField = (collection, field, value) =>
@@ -86,7 +87,6 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
     tvShowEntries: 'TVShow',
     bookEntries: 'Book',
   }[collection]
-  const emptyWork = { data: { entryType } }
 
   const results = await mongo((db) => db
     .collection(collection)
@@ -115,13 +115,7 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
       { $project: { review: 0, userId: 0 } },
     ])
     .toArray()
-    // `work` is dropped from the entry it was joined onto: the caller returns
-    // it as `commonMetadata`, and left in place it would also travel back as a
-    // second, identical copy on every entry — a third of the response.
-    .then((arr) => arr.map(({ work, ...entry }) => ({
-      entry: toSameFormatAsFaunaDb(entry),
-      work: { data: work?.[0] ?? emptyWork },
-    })))
+    .then((arr) => arr.map((row) => toEntryWithMetadata(row, entryType)))
   )
 
   return { data: results }
@@ -158,15 +152,6 @@ const find = (collection, filter) =>
     .toArray()
     .then((arr) => arr.map(toSameFormatAsFaunaDb))
   )
-
-/**
- * @type {(docOrDocs: any) => { data: any, ref: { id: string }}}
- * @info This function exists because we migrated from FaunaDB to MongoDB.
- */
-const toSameFormatAsFaunaDb = (dcmt) => ({
-  data: dcmt,
-  ref: { id: dcmt._id },
-})
 
 /** @type {(collection: ValidCollection, data: any) => Promise<object>} */
 const unsafeCreateDoc = (collection, data) =>

--- a/src/api/utils/export_view.test.js
+++ b/src/api/utils/export_view.test.js
@@ -104,6 +104,22 @@ test('an empty note is left out rather than exported as an empty string', () => 
   assert.ok(!('notes' in entry))
 })
 
+test('an entry whose work is missing exports what the entry itself knows', () => {
+  // The stand-in `toEntryWithMetadata` supplies when an entry's `workRef`
+  // names a work that isn't there. Which list this is comes from the url, so
+  // `entryType` is not a field to export.
+  const entry = toExportEntry('films', { ...film, work: { entryType: 'Film' } })
+
+  assert.deepEqual(entry, {
+    id: 'e1',
+    status: 'Completed',
+    score: 6,
+    completedDate: '2026-08-09',
+    updatedDate: '2026-08-10',
+    notes: 'A bit too zany.',
+  })
+})
+
 test('each type names its numbers and its people after what they are', () => {
   const game = toExportEntry('games', {
     entry: { _id: 'g1', status: 'Completed' },


### PR DESCRIPTION
An entry whose `workRef` points at a work that isn't there got a stand-in built one level too deep: `{ data: { entryType } }`, where a found work is a bare document. `getUserEntries` hands that straight to `commonMetadata`, so those rows arrived at the page as `commonMetadata.data.entryType` and every read of `commonMetadata.entryType` came back `undefined` — no status label beside the title in `englishTitleAndLastUpdatedFormatter`, and `detailFormatter` opening the row against `/api/reviews/undefined/:id`. A handful of entries in production are affected; the giveaway was a `data` key showing up in a field-size histogram of the `/entries/films/nil` response.

The fallback is now `{ entryType }`, the same shape as `work?.[0]`, and it is built per row rather than being one object shared by every work-less entry in a response.

## Where the shaping lives

`db.js` builds a `MongoClient` at require time and throws without `MONGODB_URL`, which puts everything in `unsafe_functions.js` out of `node --test`'s reach — so the shape that broke here had nowhere to be tested. The row-to-`{ entry, work }` mapping moves to `src/api/utils/db/shapes.js`, pure and dependency-free, next to `toSameFormatAsFaunaDb`, which came along because it is the other half of the same contract and `find` still uses it from there. The query keeps the parts that are the database's job: #95's `$sort`, `$limit` and `$project` stages are untouched, and so is dropping `work` from the entry it was joined onto.

## Tests

`shapes.test.js` covers the missing-work shape, the per-row stand-in, the joined work coming off the entry rather than being copied off it, and what an entry keeps when its work is gone. Reintroducing `{ data: { entryType } }` fails two of them.

The export path reads the same `{ entry, work }` pairs. It was never wrong here — `toExportEntry` reads named fields and `compact` drops the rest, so neither `data` nor `entryType` ever reached the output, and the export's list type comes from the url rather than from the work — but nothing pinned that, so `export_view.test.js` now has a case for an entry whose work is missing.

Spotted while working on #86 and left alone in #95, which was a performance change.
