### PR TITLE
fix: delete an entry's review along with the entry

### DIFF
--- a/src/api/controllers/entries.js
+++ b/src/api/controllers/entries.js
@@ -115,6 +115,12 @@ const deleteEntry_ = async (col, entry) => {
   // The history and the draft only describe an entry that no longer exists.
   await discardHistory(entry.ref.id)
 
+  // The review is only ever found by `entryRef`, so leaving it behind doesn't
+  // hide it — it stores a note the user asked to be rid of, unreachable by
+  // every code path. Its failure is swallowed for the same reason the
+  // history's is: a cleanup must not fail the delete the user asked for.
+  await db.deleteAllByField_(toReviewCollection(col), 'entryRef', entry.ref.id).unwrapOr(undefined)
+
   return response
 }
 

--- a/src/db_maintenance/scripts/audit_database.js
+++ b/src/db_maintenance/scripts/audit_database.js
@@ -66,8 +66,12 @@ const main = async () => {
 const auditCollection = async (db, collection) => {
   const works = await db.collection(collection.works).find().toArray();
   const entries = await db.collection(collection.entries).find().toArray();
+  const reviews = await db.collection(toReviewCollection(collection))
+    .find()
+    .toArray();
 
   const workIds = new Set(works.map((w) => w._id));
+  const entryIds = new Set(entries.map((e) => e._id));
   const referencedWorkIds = new Set(
     entries.map((e) => e.workRef).filter((ref) => ref)
   );
@@ -124,9 +128,21 @@ const auditCollection = async (db, collection) => {
     .filter((e) => e.workRef && !workIds.has(e.workRef))
     .map((e) => ({ id: e._id, userId: e.userId, workRef: e.workRef }));
 
+  // A review is only ever found by `entryRef`, so one whose entry is gone is
+  // unreachable rather than deleted. The text is a user's private note and
+  // stays out of the report; its length is enough to size what is left behind.
+  const orphanReviews = reviews
+    .filter((r) => !r.entryRef || !entryIds.has(r.entryRef))
+    .map((r) => ({
+      id: r._id,
+      entryRef: r.entryRef ?? null,
+      textLength: r.text?.length ?? 0,
+    }));
+
   const result = {
     works: works.length,
     entries: entries.length,
+    reviews: reviews.length,
     noApiRef,
     legacyObjectApiRefs,
     missingFields,
@@ -136,11 +152,17 @@ const auditCollection = async (db, collection) => {
     orphanWorks,
     entriesWithoutWorkRef,
     entriesWithDanglingWorkRef,
+    orphanReviews,
   };
 
   printSummary(collection, result);
   return result;
 };
+
+/** An entry's review lives in the collection of the same name, with
+ * `Entries` swapped for `Reviews` — the API's rule, in `controllers/utils.js`. */
+const toReviewCollection = (collection) =>
+  collection.entries.replace("Entries", "Reviews");
 
 const hasRetrieveRef = (collection, work) =>
   Array.isArray(work.apiRefs) &&
@@ -156,7 +178,9 @@ const describe = (work) => ({
 
 const printSummary = (collection, r) => {
   console.log(`\n=== ${collection.works} ===`);
-  console.log(`  works: ${r.works}, entries: ${r.entries}`);
+  console.log(
+    `  works: ${r.works}, entries: ${r.entries}, reviews: ${r.reviews}`
+  );
   const lines = [
     [`no ${collection.retrievePrefix}__ ref (cannot be refreshed)`, r.noApiRef],
     ["apiRefs still stored as objects", r.legacyObjectApiRefs],
@@ -169,6 +193,7 @@ const printSummary = (collection, r) => {
     ["works no entry points at", r.orphanWorks],
     ["entries with no workRef", r.entriesWithoutWorkRef],
     ["entries with a dangling workRef", r.entriesWithDanglingWorkRef],
+    ["reviews with no entry", r.orphanReviews],
   ];
   for (const [label, items] of lines) {
     console.log(`  ${String(items.length).padStart(5)}  ${label}`);


### PR DESCRIPTION
`deleteEntry_` removed the entry document and its revision history but left the matching `*Reviews` document behind. Reviews are only ever found by `entryRef` — `controllers/reviews.js`, `controllers/revisions.js` and the export controller all look them up that way — so once the entry is gone the review is unreachable by every code path. It was never deleted, only made invisible: the user asked for their note to be gone and it was still stored, and `filmReviews` / `tvShowReviews` / `gameReviews` / `bookReviews` accumulated orphans nothing would ever collect.

The fix is one more deletion in `deleteEntry_`, in the same shape as `discardHistory`. Its failure is swallowed for the same reason the history's is — a cleanup must not fail the delete the user asked for — and the comment says so.

The second commit adds a "reviews with no entry" count to `src/db_maintenance/scripts/audit_database.js`, to size the orphans that have already accumulated. It is read-only, like the rest of that script. The review text is deliberately left out of the report — it is a user's private note, and its length is enough to size what is left behind. Actually deleting those existing orphans is a separate job under the usual rules in CLAUDE.md: snapshot, dry run, then a human before `--apply`. Nothing here writes to production data.

`npm test` passes: 208 tests, 0 failures, 11 skipped (the ones that skip themselves without dependencies).

Closes #99
