### PR TITLE
fix: stop a game with no cover or no release date 500ing

### DIFF
--- a/src/api/utils/external_api_adapters/games/igdb.js
+++ b/src/api/utils/external_api_adapters/games/igdb.js
@@ -23,11 +23,18 @@ const {
   timeToBeatQuery,
   toPlaytime,
 } = require('./time_to_beat')
-const { retrying, describeFailure } = require('../retry')
+const { earliestReleaseDate } = require('./release_dates')
+const { throwIt } = require('../../general')
+const { retrying, describeFailure, statusOf } = require('../retry')
 
 const { TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET } = process.env
 if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET) {
-  throw "Must set TWITCH_CLIENT_SECRET and TWITCH_CLIENT_ID environment variables."
+  // A real Error rather than the bare string this used to throw: this runs at
+  // require time, so it kills the cold start before any handler exists to
+  // report it, and a string leaves no stack behind to say where it came from.
+  throwIt(new Error(
+    'Must set TWITCH_CLIENT_SECRET and TWITCH_CLIENT_ID environment variables.'
+  ))
 }
 
 /**
@@ -67,7 +74,7 @@ const search = (titleSearch) => ResultAsync.fromPromise(
       .request('/games')
 
     return req.data.map(({ name, id, release_dates, cover, platforms }) => {
-      const earliest_date = release_dates?.sort((a,b) => a.date - b.date)[0]?.date * 1000
+      const earliest_date = earliestReleaseDate(release_dates) * 1000
       return {
         title: name + ` [${platforms?.map((p) => p.abbreviation ?? '?')?.join(', ') ?? '?'}]`,
         ref: id,
@@ -88,6 +95,12 @@ const retrieve = (ref) => ResultAsync.fromPromise(
       .where(`id = ${ref}`)
       .request('/games')
       .then(({ data }) => data[0])
+
+    // `where(id = ...)` on an id IGDB doesn't hold is an empty array, not an
+    // error, and every read below would be a TypeError on undefined. Thrown
+    // from inside `retrying` on purpose: a 404 isn't transient, so it comes
+    // straight back out rather than costing two more attempts.
+    if (!mainData) throwNoSuchGame(ref)
 
     const playtime = toPlaytime(await retrieveTimeToBeat(mainData.id))
 
@@ -126,8 +139,7 @@ const retrieve = (ref) => ResultAsync.fromPromise(
       studioIds
         .map((id) => companies.find((c) => c.id === id)?.name)
 
-    const releaseYearTs =
-      mainData.release_dates?.sort((a, b) => a.date - b.date)[0].date
+    const releaseYearTs = earliestReleaseDate(mainData.release_dates)
 
     const releaseYear = releaseYearTs
       ? parseInt(
@@ -145,7 +157,7 @@ const retrieve = (ref) => ResultAsync.fromPromise(
       releaseYear,
       // `duration` and `durationSource` together, or neither of them.
       ...playtime,
-      imageUrl: mainData.cover.url ? 'https:' + mainData.cover.url : '',
+      imageUrl: mainData.cover?.url ? 'https:' + mainData.cover.url : '',
       genres: mainData.genres?.map((g) => g.name) ?? [],
       platforms: mainData.platforms?.map((p) => p.abbreviation ?? '?') ?? [],
       studios: studioNames,
@@ -205,13 +217,32 @@ const retrieveTimeToBeat = async (gameId) => {
 }
 
 /**
+ * `status` is what carries this back out to `toError`, the same way
+ * `throwNoSuchVolume` marks a missing ISBN in books/google.js — `statusOf`
+ * reads it, so nothing else needs to know how the two got here.
+ * @type {(ref: string | number) => never}
+ */
+const throwNoSuchGame = (ref) => {
+  throw Object.assign(
+    new Error(`IGDB holds no game under id ${ref}.`),
+    { status: 404 },
+  )
+}
+
+/**
  * A failure that reaches here has already been retried, so it is worth saying
  * what it actually was. It used to arrive as the string "Something went
  * terribly wrong...", which told nobody anything.
+ *
+ * A 404 is the exception: it is an answer rather than a failure — an id
+ * IGDB doesn't hold — and telling the user their game doesn't exist beats
+ * telling them igdb failed.
  * @type {(doing: string) => (err: any) => Error}
  */
 const toError = (doing) => (err) => {
   console.error(`igdb failed while ${doing}: ${describeFailure(err)}`)
 
-  return errors.internal(`igdb failed while ${doing} (${describeFailure(err)})`)
+  return statusOf(err) === 404
+    ? errors.notFound('igdb')
+    : errors.internal(`igdb failed while ${doing} (${describeFailure(err)})`)
 }

--- a/src/api/utils/external_api_adapters/games/release_dates.js
+++ b/src/api/utils/external_api_adapters/games/release_dates.js
@@ -1,0 +1,36 @@
+/**
+ * @file Reading a release date out of an IGDB game.
+ *
+ * Pure and dependency-free for the same reason ./time_to_beat.js is: igdb.js
+ * cannot be required at all without Twitch credentials, so nothing in it is
+ * reachable from the test suite. That is how an unguarded `[0]` on this
+ * particular expression stayed in `retrieve` long enough to 500 on every
+ * undated game. See ./release_dates.test.js.
+ */
+
+/**
+ * The earliest date IGDB lists for a game, in seconds, or undefined when it
+ * lists none usable.
+ *
+ * Both the key and the first element need guarding: IGDB omits
+ * `release_dates` for an unannounced game, and sends it as an empty array for
+ * some others. Dates themselves are dropped when they aren't numbers, so an
+ * entry IGDB has a status but no date for can't sort its way to the front and
+ * come back as undefined.
+ *
+ * What gets sorted is the mapped-out list of dates rather than IGDB's own
+ * array, which matters because `sort` reorders in place: the previous version
+ * of this handed the response back to its caller in a different order than it
+ * arrived in.
+ *
+ * @type {(releaseDates: any) => number | undefined}
+ */
+const earliestReleaseDate = (releaseDates) =>
+  (Array.isArray(releaseDates) ? releaseDates : [])
+    .map((releaseDate) => releaseDate?.date)
+    .filter((date) => typeof date === 'number' && Number.isFinite(date))
+    .sort((a, b) => a - b)[0]
+
+module.exports = {
+  earliestReleaseDate,
+}

--- a/src/api/utils/external_api_adapters/games/release_dates.test.js
+++ b/src/api/utils/external_api_adapters/games/release_dates.test.js
@@ -1,0 +1,55 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const { earliestReleaseDate } = require('./release_dates')
+
+/** Dates as IGDB sends them: unix seconds, in no particular order. */
+const threePlatforms = [
+  { id: 2, date: 1101772800, platform: 8 },
+  { id: 1, date: 1099958400, platform: 6 },
+  { id: 3, date: 1104537600, platform: 9 },
+]
+
+test('the earliest of several release dates wins', () => {
+  assert.equal(earliestReleaseDate(threePlatforms), 1099958400)
+})
+
+test('IGDB\'s array is left in the order it arrived in', () => {
+  // `sort` reorders in place. Handing a response back rearranged is the kind
+  // of thing that is harmless until something downstream reads it again.
+  const dates = [...threePlatforms]
+  earliestReleaseDate(dates)
+
+  assert.deepEqual(dates, threePlatforms)
+})
+
+test('a game with no release dates has no date rather than throwing', () => {
+  // An unannounced game has no key at all; some others carry an empty array.
+  // The second of these is what 500'd — the optional chain covered the key
+  // and the unguarded [0] did not cover the empty array.
+  assert.equal(earliestReleaseDate(undefined), undefined)
+  assert.equal(earliestReleaseDate([]), undefined)
+  assert.equal(earliestReleaseDate(null), undefined)
+})
+
+test('entries IGDB has no date for are skipped, not sorted to the front', () => {
+  assert.equal(earliestReleaseDate([{ id: 1, platform: 6 }]), undefined)
+  assert.equal(
+    earliestReleaseDate([{ id: 1, platform: 6 }, { id: 2, date: 1099958400 }]),
+    1099958400,
+  )
+  assert.equal(earliestReleaseDate([{ date: null }, { date: '1099958400' }]), undefined)
+})
+
+test('dates sort by value, not as strings', () => {
+  // The default comparator would put 1000000000 before 999999999.
+  assert.equal(earliestReleaseDate([{ date: 1000000000 }, { date: 999999999 }]), 999999999)
+})
+
+test('a single release date is its own earliest', () => {
+  assert.equal(earliestReleaseDate([{ date: 1099958400 }]), 1099958400)
+})
+
+test('something that is not a list at all is no date', () => {
+  assert.equal(earliestReleaseDate({ date: 1099958400 }), undefined)
+})


### PR DESCRIPTION
Adding a game that IGDB has no cover for, or no release date for, or no game under the id at all, came back as a bare 500 with a `TypeError` in the logs. All three are ordinary IGDB responses rather than IGDB failing, and `search` in the same file already handles the first two correctly — this brings `retrieve` in line with it.

A missing cover is `cover?.url`, matching `search`. An empty `release_dates` is the interesting one: the existing optional chain covered the key being absent but not the array being present and empty, because the `[0]` after the `sort` was unguarded.

An unknown id now gets a 404 instead of a 500. `throwNoSuchGame` attaches `status: 404` exactly as `throwNoSuchVolume` does for a missing ISBN in `books/google.js`, and the games `toError` learns the same `statusOf(err) === 404` check that adapter's has, so `/api/works/retrieve/games/999999999` answers "not found" rather than "igdb failed while retrieving a game". It is thrown from inside `retrying`, which is safe because 404 is not in `RETRYABLE_STATUSES` and comes straight back out on the first attempt.

Picking the earliest release date moves to a new pure `games/release_dates.js` with a test, alongside `time_to_beat.js` and for the same reason: `igdb.js` cannot be required without Twitch credentials, so nothing in it is reachable from `npm test`, and that is how an unguarded `[0]` on this one expression survived in the first place. The extracted version also sorts the dates it has mapped out rather than IGDB's own array — the old expression reordered the response in place — and skips entries IGDB has a status but no date for, which the old one could sort to the front and hand back as `undefined`. `search` calls it too, which removes the same in-place sort there; its output is unchanged.

Last, the module-level credentials guard throws a real `Error` through `throwIt` rather than a bare string. It runs at require time, so it takes the cold start down before any handler exists to report it, and a thrown string leaves no stack behind.

One correction to the issue text: it says a failure that gets this far "has already been tried three times". It hasn't — a `TypeError` has no status and no code, so `isTransient` is false and `retrying` rethrows on the first attempt. The bug is the 500, not wasted attempts. Only genuinely transient failures cost three.

Closes #102

## Testing

`npm test` — 215 tests, 0 failures (was 208; the 7 new ones are `release_dates.test.js`). The adapter itself stays uncovered for the credentials reason above.
