### PR TITLE
fix: make renaming a user actually write the name

### DIFF
--- a/src/api/controllers/name.js
+++ b/src/api/controllers/name.js
@@ -2,8 +2,8 @@
 /** @typedef {import('@netlify/functions').HandlerEvent} Event */
 /** @typedef {import('../utils/responses').Response} Response */
 /** @typedef {import('../utils/errors').Error} Error */
-const { combine, ResultAsync } = require('neverthrow')
-const { findOneByField_, findOneByField, updateByRef, create } = require('../utils/db')
+const { combine, okAsync, ResultAsync } = require('neverthrow')
+const { findOneByField_, findOneByField, updateByRef_, create_ } = require('../utils/db')
 const { pair, toPromise } = require('../utils/general')
 const responses = require('../utils/responses')
 const { getUserId, getReqBody, getSegment } = require('./utils')
@@ -42,18 +42,27 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/** @type {([userId, req]: [string, any]) => ResultAsync<Response, Error>} */
+/**
+ * The write is chained rather than fired off, so the 200 means the name was
+ * actually taken: a serverless container can be frozen the moment the
+ * response is sent, and an unawaited write never lands.
+ *
+ * Two people claiming one name at the same moment still both pass this
+ * check — the read and the write are separate round trips. A unique index
+ * on `users.username` is what settles that; see #108.
+ * @type {([userId, req]: [string, any]) => ResultAsync<Response, Error>}
+ */
 const assignNameIfNotTaken = ([userId, { newName }]) =>
   findOneByField_('users', 'username', newName)
-    .map(({ data }) => data
-        ? responses.ok(feErrors.nameTaken(newName))
-        : (assignName(userId, newName), responses.ok())
+    .andThen(({ data }) => data
+        ? okAsync(responses.ok(feErrors.nameTaken(newName)))
+        : assignName(userId, newName).map(() => responses.ok())
     )
 
-/** @type {(userId: string, newName: string) => ResultAsync<Response, Error>} */
+/** @type {(userId: string, newName: string) => ResultAsync<any, Error>} */
 const assignName = (userId, newName) =>
   findOneByField_('users', 'userId', userId)
-    .map(({ ref }) => ref
-      ? updateByRef('users', ref, { data: { username: newName } })
-      : create('users', { userId, username: newName })
+    .andThen(({ ref }) => ref
+      ? updateByRef_('users', ref.id, { username: newName })
+      : create_('users', { userId, username: newName })
     )

--- a/src/api/controllers/name.test.js
+++ b/src/api/controllers/name.test.js
@@ -1,0 +1,173 @@
+/**
+ * @file Claiming a username, driven through the real Netlify handler against
+ * an in-memory Mongo.
+ *
+ * The point of these is that a 200 from `POST /api/name` means the name was
+ * written — the previous version answered 200 while writing nothing — so they
+ * assert on the store, not just on the status code. That needs the actual
+ * dependencies, so the file **skips itself** when they aren't installed
+ * (which is how CI runs the suite).
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const Module = require('module')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('neverthrow')
+    require('zod')
+    require('ts-pattern')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+
+///////////////////////////////////////////////////////////////////////////////
+// A Mongo small enough to keep in a variable, and an auth check that takes
+// the token at its word — neither is what these tests are about.
+
+const store = {}
+
+// The connection is made once and held, so a test that wants a write to fail
+// has to say so here rather than swap the client out from under it.
+let writesFail = false
+
+const matches = (doc, filter = {}) =>
+  Object.entries(filter).every(([field, value]) => doc[field] === value)
+
+const collectionOf = (name) => (store[name] = store[name] ?? [])
+
+const collection = (name) => ({
+  aggregate: (pipeline) => ({
+    toArray: async () =>
+      collectionOf(name).filter((doc) => matches(doc, pipeline[0].$match)),
+  }),
+  find: () => ({ toArray: async () => [...collectionOf(name)] }),
+  insertOne: async (doc) => (collectionOf(name).push(doc), { insertedId: doc._id }),
+  updateOne: async (filter, { $set }) => {
+    if (writesFail) throw new Error('write failed')
+    const doc = collectionOf(name).find((d) => matches(d, filter))
+    if (doc) Object.assign(doc, $set)
+    return { modifiedCount: doc ? 1 : 0 }
+  },
+  deleteOne: async (filter) => {
+    store[name] = collectionOf(name).filter((doc) => !matches(doc, filter))
+    return { deletedCount: 1 }
+  },
+})
+
+class MongoClient {
+  async connect() {}
+  db() {
+    return { databaseName: 'memo', collection }
+  }
+}
+
+const loadModule = Module._load
+Module._load = function (request, ...args) {
+  if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
+  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  return loadModule.call(this, request, ...args)
+}
+
+const name = dependenciesInstalled ? require('../routes/name') : undefined
+
+///////////////////////////////////////////////////////////////////////////////
+
+const call = async (method, url, { as, body } = {}) => {
+  const response = await name.handler(
+    {
+      httpMethod: method,
+      path: `/.netlify/functions/${url}`,
+      headers: as ? { authorization: `Bearer ${as}` } : {},
+      body: body === undefined ? null : JSON.stringify(body),
+    },
+    {}
+  )
+  return {
+    statusCode: response.statusCode,
+    body: response.body ? JSON.parse(response.body) : undefined,
+  }
+}
+
+const seed = () => {
+  store.users = [{ _id: 'a1', userId: 'u1', username: 'oldname' }]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+test('renaming writes the new name, flat, on the existing document', options, async () => {
+  seed()
+
+  const { statusCode } = await call('POST', 'name', {
+    as: 'u1',
+    body: { newName: 'newname' },
+  })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.users.length, 1)
+  assert.equal(store.users[0].username, 'newname')
+  // Not `{ data: { username } }` — nothing reads a nested copy.
+  assert.equal('data' in store.users[0], false)
+})
+
+test('the rename is read back by the route that answers with it', options, async () => {
+  seed()
+  await call('POST', 'name', { as: 'u1', body: { newName: 'newname' } })
+
+  const { body } = await call('GET', 'name', { as: 'u1' })
+
+  assert.equal(body.username, 'newname')
+})
+
+test('a first-time user gets a document created', options, async () => {
+  store.users = []
+
+  const { statusCode } = await call('POST', 'name', {
+    as: 'u2',
+    body: { newName: 'brandnew' },
+  })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.users.length, 1)
+  assert.equal(store.users[0].userId, 'u2')
+  assert.equal(store.users[0].username, 'brandnew')
+})
+
+test('a taken name is refused and changes nothing', options, async () => {
+  seed()
+  store.users.push({ _id: 'a2', userId: 'u2', username: 'taken' })
+
+  const { body } = await call('POST', 'name', {
+    as: 'u1',
+    body: { newName: 'taken' },
+  })
+
+  assert.equal(body.error, 'NameTaken')
+  assert.equal(store.users[0].username, 'oldname')
+})
+
+test('a write that fails is not answered with a 200', options, async () => {
+  seed()
+
+  writesFail = true
+
+  try {
+    const { statusCode } = await call('POST', 'name', {
+      as: 'u1',
+      body: { newName: 'newname' },
+    })
+
+    assert.equal(statusCode, 500)
+    assert.equal(store.users[0].username, 'oldname')
+  } finally {
+    writesFail = false
+  }
+})


### PR DESCRIPTION
`POST /api/name` answered 200 and wrote nothing whenever the caller already had a user document. `assignName` was still speaking FaunaDB in three ways, all of which `bio.js` — same job, same collection — already gets right.

- The ref passed to `updateByRef` was the whole `{ id }` object `toSameFormatAsFaunaDb` builds, so `_updateOneByRef` filtered on `{ _id: { id: "…" } }` and matched nothing. It is `ref.id` now.
- The update document set a nested `data.username` that nothing reads. It is the flat `{ username }` the rest of the code expects.
- The write was fired off inside a `.map()` and never awaited, so even with the two shapes fixed a serverless container could be frozen before it landed. It is chained with `andThen` now, which also means a write that fails comes back as a 500 rather than a 200 over a name nobody took.

The check-then-write race is deliberately left alone and carries a comment instead: the "is this taken" read and the write are separate round trips, so two people claiming one name at the same moment both pass the check. Closing that needs a unique index on `users.username`, which is #108.

`name.test.js` drives the real handler against the in-memory Mongo that `revisions.test.js` set up, and asserts on the store rather than on the status code — the bug was that the two disagreed. Three of its five cases fail against `main`. It skips itself when the dependencies aren't installed, as that file does.

Closes #98
