### PR TITLE
fix: escape metadata before it reaches the list markup

### DIFF
--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -1,4 +1,4 @@
-const { html } = Utils
+const { html, escapeHtml, toSafeUrl } = Utils
 const { round } = Math
 const { apiTypeToType, statusToTitle } = Conversions
 
@@ -98,8 +98,13 @@ const edit = () =>
       // used to write a JSON copy of every entry — metadata, overrides and
       // all — into the markup, which on a long list was more bytes of DOM
       // than the visible table. `Rows.byRef` is filled in by `initFullTable`.
+      //
+      // The id goes through `JSON.stringify` and then `escapeHtml`, in that
+      // order: the browser un-escapes an attribute before the JS parser sees
+      // it, so a quote in the id has to arrive as a JS escape rather than an
+      // HTML one to still be inside the string by then.
       return html`
-        <i id="edit-${row.status}-${i}" class="fas fa-edit edit-button" onclick="window.editEntry('${row.dbRef}')"></i>
+        <i id="edit-${escapeHtml(row.status)}-${i}" class="fas fa-edit edit-button" onclick="window.editEntry(${escapeHtml(JSON.stringify(String(row.dbRef)))})"></i>
       `
     },
     cellStyle: () => ({ css: { 'width': '20px' } }),
@@ -145,7 +150,7 @@ const progress = () =>
       const seen = row.status === 'Completed'
         ? totalEps
         : progress ?? '-'
-      return `${seen}/${totalEps}`
+      return `${escapeHtml(seen)}/${escapeHtml(totalEps)}`
     }
   })
 
@@ -222,22 +227,26 @@ const titleFormatter = (_, row) => {
     ? `${originalTitle} (${englishTranslatedTitle})`
     : englishTranslatedTitle
 
-  const url = externalUrls?.[0]?.url || toWikipediaUrl(englishTranslatedTitle)
-  const cover = imageUrl || '/img/mawaru.png'
+  // Both of these are metadata: whatever TMDB or IGDB holds, or whatever the
+  // owner typed into an override. `toSafeUrl` drops any scheme we would not
+  // put in an `href` or a `src`; the title falls back to a Wikipedia search
+  // and the cover to the placeholder, exactly as a missing one does.
+  const url = toSafeUrl(externalUrls?.[0]?.url) || toWikipediaUrl(englishTranslatedTitle)
+  const cover = toSafeUrl(imageUrl) || '/img/mawaru.png'
   const anchorId = `entry-${row.dbRef}`
   // Lazily: a list is one row per work and every row carries a cover, so a
   // long one asked for a thousand full-size posters at once in order to draw
   // them sixteen pixels wide. The browser now fetches the handful that are
   // actually on screen. `.mini-thumb` fixes the size, so nothing shifts as
   // the rest arrive.
-  return `<span id="${anchorId}" class="title-with-cover"><img class="mini-thumb" src="${cover}" loading="lazy" decoding="async" alt=""><a href="${url}">${label}</span>`
+  return `<span id="${escapeHtml(anchorId)}" class="title-with-cover"><img class="mini-thumb" src="${escapeHtml(cover)}" loading="lazy" decoding="async" alt=""><a href="${escapeHtml(url)}">${escapeHtml(label)}</a></span>`
 }
 
 const englishTitleAndLastUpdatedFormatter = (_, row) => {
   const { englishTranslatedTitle } = get(row, ['englishTranslatedTitle'])
   const link = toWikipediaLink(englishTranslatedTitle, englishTranslatedTitle)
   return row.updatedDate
-    ? `${link}<i style="font-size:.85em; float: right; position: relative; top: 3px;">${statusToTitle(apiTypeToType[row.commonMetadata.entryType], row.status)} ${relativeTime(row.updatedDate)}</i>`
+    ? `${link}<i style="font-size:.85em; float: right; position: relative; top: 3px;">${escapeHtml(statusToTitle(apiTypeToType[row.commonMetadata.entryType], row.status))} ${relativeTime(row.updatedDate)}</i>`
     : link
 }
 
@@ -249,10 +258,13 @@ const listOfLinksFormatter = (prop, toLink) => (_, row) => {
 }
 
 const toWikipediaLink = (name, label) =>
-  `<a href="${toWikipediaUrl(name)}">${label ?? name}</a>`
+  `<a href="${escapeHtml(toWikipediaUrl(name))}">${escapeHtml(label ?? name)}</a>`
 
-const toWikipediaUrl = (name) => 
-  `http://en.wikipedia.org/wiki/Special:Search?search=${name}&go=Go`
+// A genre or a studio name is metadata like any other, and it is being put
+// into a query string: without `encodeURIComponent` an `&` in it silently
+// becomes another parameter, and a `"` ends the attribute it sits in.
+const toWikipediaUrl = (name) =>
+  `http://en.wikipedia.org/wiki/Special:Search?search=${encodeURIComponent(name ?? '')}&go=Go`
 
 const sortableAndLinked = (prop, toLink) => ({
   sortable: true,
@@ -278,9 +290,11 @@ const playtimeFormatter = (_, row) => {
     : rawMins < 40 ?  '&frac12'
     : '&frac34'
   const durationText = `${hours}h${minsAsHrFraction}`
-  const url = toPlaytimeUrl(row)
+  // `durationText` is ours and carries `&frac12` on purpose, so it is the one
+  // thing here that must not be escaped. The url is metadata, so it is.
+  const url = toSafeUrl(toPlaytimeUrl(row))
   return durationInMin && url
-    ? `<a href="${url}">${durationText}</a>`
+    ? `<a href="${escapeHtml(url)}">${durationText}</a>`
     : durationInMin
     ? durationText
     : '-'

--- a/src/frontend/_includes/js/utils/columns.test.js
+++ b/src/frontend/_includes/js/utils/columns.test.js
@@ -10,18 +10,41 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const source = fs.readFileSync(path.join(__dirname, "columns.js"), "utf8");
+const generalSource = fs.readFileSync(path.join(__dirname, "general.js"), "utf8");
 
-const playtimeFormatter = vm.runInContext(
-  `${source}\n;playtimeFormatter`,
-  vm.createContext({
-    Utils: { html: (strings) => strings.raw.join("") },
-    Conversions: { apiTypeToType: {}, statusToTitle: () => "" },
-    console,
-  })
-);
+// The real `Utils`, not a stub: `escapeHtml` and `toSafeUrl` are most of what
+// the formatters below are being asked about, so a stand-in for them would be
+// testing the stand-in. `URL` is a host global rather than a JS builtin, so a
+// fresh vm context has to be handed one.
+//
+// base.njk wraps each included file in its own IIFE, which is what keeps two
+// files' `const`s from colliding and what makes an assignment with no keyword
+// (`Utils = …`) the only thing that crosses between them. Loading them the
+// same way here keeps that difference visible.
+const context = vm.createContext({
+  URL,
+  console,
+  Conversions: { apiTypeToType: {}, statusToTitle: () => "" },
+});
+const load = (js, exports) =>
+  vm.runInContext(`(() => {\n${js}\n;return ${exports}\n})()`, context);
+
+load(generalSource, "undefined");
+
+const { playtimeFormatter, titleFormatter, listOfLinksFormatter, Columns } =
+  load(
+    source,
+    "({ playtimeFormatter, titleFormatter, listOfLinksFormatter, Columns })"
+  );
 
 const playtime = (commonMetadata, overrides) =>
   playtimeFormatter(null, { commonMetadata, overrides });
+
+const title = (commonMetadata, overrides) =>
+  titleFormatter(null, { dbRef: "abc", commonMetadata, overrides });
+
+const genres = (values) =>
+  listOfLinksFormatter("genres")(null, { commonMetadata: { genres: values } });
 
 test("a flat hltb apiRef links the playtime to HowLongToBeat", () => {
   assert.equal(
@@ -118,4 +141,105 @@ test("a placeholder hltb ref renders no link at all", () => {
     playtime({ duration: 600, apiRefs: [{ name: "hltb", ref: "N/A" }] }),
     "10h"
   );
+});
+
+///////////////////////////////////////////////////////////////////////////////
+// Escaping. Everything below is metadata: whatever an external API holds, or
+// whatever the owner typed into an override. A list is public, so an override
+// that reached the markup intact would run in every reader's browser.
+
+test("an ordinary title renders a closed link and the placeholder cover", () => {
+  assert.equal(
+    title({ englishTranslatedTitle: "Hollow Knight" }),
+    '<span id="entry-abc" class="title-with-cover">' +
+      '<img class="mini-thumb" src="/img/mawaru.png" loading="lazy" decoding="async" alt="">' +
+      '<a href="http://en.wikipedia.org/wiki/Special:Search?search=Hollow%20Knight&amp;go=Go">' +
+      "Hollow Knight</a></span>"
+  );
+});
+
+test("a title cannot inject markup into a list", () => {
+  const rendered = title({
+    englishTranslatedTitle: '<img src=x onerror="alert(1)">',
+  });
+  assert.ok(!rendered.includes("<img src=x"));
+  assert.ok(rendered.includes("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"));
+});
+
+test("an imageUrl override cannot break out of the src attribute", () => {
+  const rendered = title(
+    { englishTranslatedTitle: "Hollow Knight" },
+    { imageUrl: '/x.png" onerror="alert(1)' }
+  );
+  assert.ok(!rendered.includes('onerror="alert(1)'));
+  assert.ok(rendered.includes('src="/x.png&quot; onerror=&quot;alert(1)"'));
+});
+
+test("a javascript: url never reaches an href or a src", () => {
+  // Escaping alone would leave this one intact — nothing in it needs escaping.
+  const rendered = title(
+    { englishTranslatedTitle: "Hollow Knight" },
+    {
+      imageUrl: "javascript:alert(1)",
+      externalUrls: [{ url: "javascript:alert(1)" }],
+    }
+  );
+  assert.ok(!rendered.includes("javascript:"));
+  assert.ok(rendered.includes('src="/img/mawaru.png"'));
+  assert.ok(rendered.includes("en.wikipedia.org"));
+});
+
+test("an http externalUrl is still used as the title's link", () => {
+  const rendered = title({
+    englishTranslatedTitle: "Hollow Knight",
+    externalUrls: [{ url: "https://www.igdb.com/games/hollow-knight" }],
+  });
+  assert.ok(rendered.includes('href="https://www.igdb.com/games/hollow-knight"'));
+});
+
+test("a javascript: playtime link is dropped, leaving plain text", () => {
+  assert.equal(
+    playtime({
+      duration: 600,
+      externalUrls: [{ name: "hltb", url: "javascript:alert(1)" }],
+    }),
+    "10h"
+  );
+});
+
+test("a genre cannot break out of its wikipedia link", () => {
+  const rendered = genres(['"><script>alert(1)</script>']);
+  assert.ok(!rendered.includes("<script>"));
+  assert.ok(rendered.includes("&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"));
+});
+
+test("an ampersand in a name is searched for, not read as a parameter", () => {
+  assert.equal(
+    genres(["Rock & Roll"]),
+    '<a href="http://en.wikipedia.org/wiki/Special:Search?search=Rock%20%26%20Roll&amp;go=Go">' +
+      "Rock &amp; Roll</a>"
+  );
+});
+
+test("the edit button carries the row's id and nothing else", () => {
+  const rendered = Columns.edit()
+    .formatter(null, {
+      status: "Completed",
+      dbRef: "abc",
+      commonMetadata: { englishTranslatedTitle: "Hollow Knight" },
+    }, 0)
+    .trim();
+  assert.ok(!rendered.includes("Hollow Knight"));
+  assert.equal(
+    rendered,
+    '<i id="edit-Completed-0" class="fas fa-edit edit-button" ' +
+      'onclick="window.editEntry(&quot;abc&quot;)"></i>'
+  );
+});
+
+test("a quote in a dbRef stays inside the string the attribute holds", () => {
+  const rendered = Columns.edit()
+    .formatter(null, { status: "Completed", dbRef: `a"b'c` }, 0)
+    .trim();
+  assert.ok(rendered.includes(`onclick="window.editEntry(&quot;a\\&quot;b'c&quot;)"`));
 });

--- a/src/frontend/_includes/js/utils/general.js
+++ b/src/frontend/_includes/js/utils/general.js
@@ -92,6 +92,25 @@ const escapeHtml = (text) =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
 
+/**
+ * A url out of the metadata, if it is one we are willing to put in an `href`
+ * or a `src`. Escaping does nothing about a scheme — `javascript:alert(1)`
+ * comes through `escapeHtml` unchanged and still runs when clicked — so the
+ * scheme has to be checked separately, and anything that is not http(s) is
+ * dropped rather than rendered. Relative urls (`/img/mawaru.png`) resolve
+ * against the base and are kept.
+ */
+/** @type {(url: any) => string | undefined} */
+const toSafeUrl = (url) => {
+  if (!url) return undefined
+  try {
+    const { protocol } = new URL(url, 'https://memo.invalid')
+    return protocol === 'http:' || protocol === 'https:' ? String(url) : undefined
+  } catch {
+    return undefined
+  }
+}
+
 Utils = {
   html,
   css,
@@ -102,4 +121,5 @@ Utils = {
   dateTime,
   dateOnly,
   escapeHtml,
+  toSafeUrl,
 }

--- a/src/frontend/_includes/js/utils/general.test.js
+++ b/src/frontend/_includes/js/utils/general.test.js
@@ -11,7 +11,7 @@ const vm = require('node:vm')
 
 const source = fs.readFileSync(path.join(__dirname, 'general.js'), 'utf8')
 
-const { timeAgo, escapeHtml } = vm.runInThisContext(`${source}\n;Utils`)
+const { timeAgo, escapeHtml, toSafeUrl } = vm.runInThisContext(`${source}\n;Utils`)
 
 const NOW = Date.parse('2024-06-30T12:00:00.000Z')
 const ago = (milliseconds) => timeAgo(NOW - milliseconds, NOW)
@@ -55,4 +55,41 @@ test("a note's own text cannot inject markup into the history", () => {
     escapeHtml('<img src=x onerror="alert(1)"> & "quoted"'),
     '&lt;img src=x onerror=&quot;alert(1)&quot;&gt; &amp; &quot;quoted&quot;'
   )
+})
+
+test('a url we would render comes back exactly as it was written', () => {
+  // Unchanged, not normalised: a relative cover has to stay relative.
+  assert.equal(
+    toSafeUrl('https://image.tmdb.org/t/p/w500/x.jpg'),
+    'https://image.tmdb.org/t/p/w500/x.jpg'
+  )
+  assert.equal(
+    toSafeUrl('http://en.wikipedia.org/wiki/Special:Search?search=X&go=Go'),
+    'http://en.wikipedia.org/wiki/Special:Search?search=X&go=Go'
+  )
+  assert.equal(toSafeUrl('/img/mawaru.png'), '/img/mawaru.png')
+})
+
+test('a scheme we would not render is dropped rather than escaped', () => {
+  // There is nothing in `javascript:alert(1)` for `escapeHtml` to escape, so
+  // it survives that untouched and still runs. Only the scheme check stops it.
+  assert.equal(toSafeUrl('javascript:alert(1)'), undefined)
+  assert.equal(toSafeUrl('JavaScript:alert(1)'), undefined)
+  assert.equal(toSafeUrl('data:text/html,<script>alert(1)</script>'), undefined)
+  assert.equal(toSafeUrl('vbscript:msgbox(1)'), undefined)
+})
+
+test('whitespace smuggled into a scheme does not get it past the check', () => {
+  // The url parser strips tabs and newlines before it reads the scheme, so a
+  // check of our own that did not would disagree with the browser about what
+  // this is.
+  assert.equal(toSafeUrl('java\tscript:alert(1)'), undefined)
+  assert.equal(toSafeUrl('java\nscript:alert(1)'), undefined)
+  assert.equal(toSafeUrl('  javascript:alert(1)'), undefined)
+})
+
+test('a missing url is missing, not a link to nowhere', () => {
+  assert.equal(toSafeUrl(undefined), undefined)
+  assert.equal(toSafeUrl(null), undefined)
+  assert.equal(toSafeUrl(''), undefined)
 })

--- a/src/frontend/_includes/js/utils/tables.js
+++ b/src/frontend/_includes/js/utils/tables.js
@@ -1,4 +1,4 @@
-const { html } = Utils
+const { html, escapeHtml, toSafeUrl } = Utils
 
 const initTable = (selector, data, settings) =>
   $(selector).bootstrapTable({ ...settings, data })
@@ -66,9 +66,13 @@ window.includeReview = (type, entryId) => {
 
 const detailFormatter = (_, row) => {
   const anchorId = `entry-${row.dbRef}`
+  // Same treatment as the cover in `titleFormatter`: the url is metadata, so
+  // its scheme is checked before it is allowed near a `src` and it is escaped
+  // before it is allowed near an attribute.
+  const coverUrl = toSafeUrl(row.commonMetadata.imageUrl)
   const cover =
-    row.commonMetadata.imageUrl
-      ? `<img src="${row.commonMetadata.imageUrl}" class="review-cover" style="float:right;">`
+    coverUrl
+      ? `<img src="${escapeHtml(coverUrl)}" class="review-cover" style="float:right;">`
       : ''
 
   const type = Conversions.apiTypeToType[row.commonMetadata.entryType]
@@ -79,11 +83,11 @@ const detailFormatter = (_, row) => {
   return html`
     <div class="review">
       <p>
-        <b><a href="#${anchorId}"><i class="fas fa-link"></i></a> Comments:</b>
+        <b><a href="#${escapeHtml(anchorId)}"><i class="fas fa-link"></i></a> Comments:</b>
           ${cover}
-          <div id="review-${row.dbRef}">
+          <div id="review-${escapeHtml(row.dbRef)}">
           </div>
-          ${scriptTag(`includeReview('${type}', '${row.dbRef}')`)}
+          ${scriptTag(`includeReview(${JSON.stringify(String(type))}, ${JSON.stringify(String(row.dbRef))})`)}
         </p>
     </div>
   `


### PR DESCRIPTION
The table formatters built HTML by string concatenation and put metadata into it unescaped. Two sources feed those fields. The external APIs, where a TMDB title or an IGDB company name is whatever someone typed into them; and `entry.overrides`, the owner's own text, applied over the metadata client-side. Lists are public, so an override was stored script that ran in the browser of everyone who viewed that list.

Every interpolated value in `columns.js` and `tables.js` now goes through `Utils.escapeHtml`, and `toWikipediaUrl` runs the search term through `encodeURIComponent` — without it an `&` in a genre silently became a second query parameter, so "Rock & Roll" searched for "Rock".

Escaping is not enough for a url, and that is the part worth looking at. There is nothing in `javascript:alert(1)` for `escapeHtml` to change, so it came through untouched and still ran when clicked. `Utils.toSafeUrl` checks the scheme instead and drops anything that is not `http:` or `https:`, which sends a title back to its Wikipedia search and a cover back to the placeholder — the same fallbacks a missing url already had. Two decisions in it are worth arguing with: it parses with `new URL` against a base rather than matching a pattern, so that a site-relative cover like `/img/mawaru.png` still resolves and so that whitespace smuggled into a scheme is stripped the same way the browser strips it; and it returns the url as written rather than the parser's normalised form, so nothing about a working url changes.

`titleFormatter` also never closed its `<a>` — the string ended `<a href="${url}">${label}</span>` — which is fixed here.

The `edit` column already named its row rather than carrying a JSON copy of it, but the id was interpolated into a single-quoted JS string inside an `onclick`. It is now `JSON.stringify`d and then escaped, in that order: the browser un-escapes an attribute before the JS parser reads it, so a quote has to arrive as a JS escape to still be inside the string by then. The `onclick`-plus-global arrangement is unchanged — bootstrap-table destroys and rebuilds the node, so a bound event does not survive.

Reviews were already sanitised through `DOMPurify.sanitize(marked.parse(...))` and are untouched. This is the metadata path only.

`toSafeUrl` lives in `general.js` next to `escapeHtml` because both `columns.js` and `tables.js` need it and `base.njk` wraps each included file in its own IIFE, so `Utils` is the only thing that crosses between them.

## Tests

Ten new cases, following `a note's own text cannot inject markup into the history`: a title, an `imageUrl` override and a genre each failing to break out; a `javascript:` url reaching neither an `href` nor a `src`; an `http` url still being used; an `&` in a name being searched for; and the edit attribute carrying the id and nothing else. `columns.test.js` now loads the real `general.js` rather than stubbing `Utils`, since `escapeHtml` and `toSafeUrl` are most of what is being asked about — and it loads each file in its own IIFE, the way `base.njk` does, which is what keeps two files' `const`s from colliding.

`npm test`: 211 passing, 0 failing, 11 skipped (the pre-existing dependency-gated ones). The playtime and HowLongToBeat cases already in `columns.test.js` pass unchanged.

Closes #104
