### PR TITLE
feat(db_maintenance): give the collections their indexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,14 +78,24 @@ scripts came to only work when run from one particular folder.
 `src/db_maintenance/scripts/` operates on production data with real users'
 entries. In order:
 
-1. **Snapshot first** with `scripts/backup_database.js`, and verify it —
-   manifest counts, file counts and live `countDocuments()` should agree
-   across every collection.
+1. **Snapshot first, always, no exceptions.** Take a fresh snapshot with
+   `scripts/backup_database.js` immediately before every `--apply`, and
+   verify it — manifest counts, file counts and live `countDocuments()`
+   should agree across every collection. There is no write small enough,
+   safe-looking enough or reversible-looking enough to skip this: a snapshot
+   costs seconds and is the only thing standing between a mistake and a
+   restore. It applies to writes that touch no documents at all — an index
+   build, a collection setting — because the reason to have the snapshot is
+   that you were wrong about what the run would do.
    `scripts/restore_backup.js --from=<snapshot> --only=<collection>` matches
    on `_id` only.
 2. **Dry run, and read the output.** Every script here is a dry run unless
    given `--apply`. Keep it that way in new ones.
-3. **Ask a human before the first `--apply`**, showing them the dry run.
+3. **`--apply` against production is authorised**, given steps 1, 2 and 4.
+   Say which snapshot you took and what the dry run said. Anything a restore
+   from that snapshot would not undo — dropping a collection or an index,
+   changing credentials, writing to a database other than `memo` — is still
+   a human's call, so ask first.
 4. **Verify afterwards**: no entry pointing at a work that doesn't exist, and
    entry counts unchanged.
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ until the user presses the button. The API is
 `GET|PUT|DELETE /api/revisions/:type/:dbRef/draft`.
 
 At most 50 versions are kept per entry, and every lookup is by `entryRef`, so
-give the collection an index once it has grown:
-`db.entryRevisions.createIndex({ entryRef: 1 })`.
+the collection needs an index on it — `findDraft` runs on every autosave,
+every 2.5 seconds while the form is open, against 50 full snapshots per entry.
+`src/db_maintenance/scripts/ensure_indexes.js` creates that index along with
+every other one the site's queries need, and is safe to re-run.
 
 The history, collapsed — one row per save, with the fields it touched:
 

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -50,6 +50,46 @@ Two ways to override it, in the order they win:
   copy, so neither has to be moved to meet the other. Never copy the `.env`
   to solve this — point at it instead.
 
+## Indexes
+
+`scripts/ensure_indexes.js` creates the indexes the site's queries need. It is
+a **dry run unless you pass `--apply`**, and re-running it is a no-op:
+`createIndexes` is idempotent for an identical spec, and these specs are named
+the way MongoDB names them by default (`entryRef_1`), so an index made by hand
+at the mongosh prompt is recognised rather than collided with.
+
+```
+node scripts/ensure_indexes.js           # what exists, what is missing
+node scripts/ensure_indexes.js --apply
+```
+
+Flags: `--only=users,entryRevisions` (collection names, not the `films,books`
+types the other scripts take), `--json=path`.
+
+Which indexes, and why each one, is declared in `index_plan.js` — every entry
+names the queries that want it, because an index nobody can name a query for
+is an index to delete. They are all single ascending fields: every query the
+site makes goes through `findOneByField` / `findAllByField`, which is an
+equality match on one field, and `_id` is indexed by MongoDB already.
+
+- **`users.username` is unique**, which closes the check-then-write race in
+  the rename path — `assignName` reads the name and writes it in two round
+  trips, so two people claiming one name at the same moment both pass the
+  read. A unique index refuses to build over existing duplicates, so the
+  script looks for them first and prints the colliding documents instead of
+  letting the driver throw. The dry run tells you whether it would succeed;
+  if it wouldn't, that one index is skipped and the rest are still created.
+  Two users with no username at all count as duplicates — MongoDB indexes a
+  missing field as null.
+- **`apiRefs` is an array**, so its index is a *multikey* index. That is
+  correct, not something to fix: `findCachedWork` asks
+  `{ apiRefs: "igdb__1234" }`, an equality match against one element, which
+  is exactly what multikey serves.
+
+Indexes are metadata — the script writes no documents and touches no user
+data, so it needs no backup. It is a dry run by default anyway, because
+building an index on a live collection costs I/O.
+
 ## Auditing and backfilling metadata
 
 `scripts/audit_database.js` is read-only, needs no API keys, and reports every
@@ -227,9 +267,10 @@ Useful flags: `--dir=path`, `--from=name|path`, `--only=a,b`, `--prune`,
 ## Tests
 
 The parts that decide what to write (`work_metadata_merge.js`,
-`game_playtime_plan.js`), what to delete (`work_dedupe_plan.js`) and which
-snapshots a retention policy keeps (`backup_plan.js`) are pure and
-dependency-free, and are covered by `node --test`:
+`game_playtime_plan.js`), what to delete (`work_dedupe_plan.js`), which
+snapshots a retention policy keeps (`backup_plan.js`) and which indexes are
+missing (`index_plan.js`) are pure and dependency-free, and are covered by
+`node --test`:
 
 ```
 npm test

--- a/src/db_maintenance/index_plan.js
+++ b/src/db_maintenance/index_plan.js
@@ -1,0 +1,210 @@
+/**
+ * @file The indexes the database is supposed to have, and the comparison that
+ * decides which of them are missing. Pure and dependency-free, so it can be
+ * unit tested without a database — see index_plan.test.js.
+ *
+ * The I/O lives in scripts/ensure_indexes.js.
+ *
+ * Every query the site makes goes through `_findOneByField` /
+ * `_findAllByField` in ../api/utils/db/unsafe_functions.js, which is an
+ * equality `$match` on one field. Each entry below names a field one of those
+ * calls is given. Nothing here is a sort or a range, so every index is a
+ * single ascending field, and `_id` is already indexed by MongoDB itself.
+ */
+
+/** The four of each, in the order the rest of the folder lists them. */
+const ENTRY_COLLECTIONS = [
+  "filmEntries",
+  "tvShowEntries",
+  "gameEntries",
+  "bookEntries",
+];
+const REVIEW_COLLECTIONS = [
+  "filmReviews",
+  "tvShowReviews",
+  "gameReviews",
+  "bookReviews",
+];
+const WORK_COLLECTIONS = ["films", "tvShows", "games", "books"];
+
+/**
+ * @typedef {{
+ *   collection: string,
+ *   key: Record<string, 1 | -1>,
+ *   options?: { unique?: boolean },
+ *   why: string,
+ * }} DesiredIndex
+ *
+ * `why` is printed by the dry run. An index nobody can name a query for is an
+ * index to delete, so every one of these has to be able to say what it is for.
+ * @type {DesiredIndex[]}
+ */
+const DESIRED_INDEXES = [
+  {
+    collection: "users",
+    key: { username: 1 },
+    // Unique closes the check-then-write race in the rename path: assignName
+    // reads the name and writes it in two round trips, so two people claiming
+    // one name at the same moment both pass the read. See #98 and name.js.
+    options: { unique: true },
+    why: "findIdOfName, getUserStats, getUserFromName, setOwnName — almost every request",
+  },
+  {
+    collection: "users",
+    key: { userId: 1 },
+    why: "findOwnName, setBio, assignName",
+  },
+  ...ENTRY_COLLECTIONS.map((collection) => ({
+    collection,
+    key: { userId: 1 },
+    why: "every list load, every profile load, /api/export, refreshStats",
+  })),
+  ...ENTRY_COLLECTIONS.map((collection) => ({
+    collection,
+    key: { workRef: 1 },
+    why: "the local side of the $lookup in _findAllUserEntriesWithMetadata",
+  })),
+  ...REVIEW_COLLECTIONS.map((collection) => ({
+    collection,
+    key: { entryRef: 1 },
+    why: "getReview on every expanded row, findReviews in the export",
+  })),
+  {
+    collection: "entryRevisions",
+    key: { entryRef: 1 },
+    why: "every history read, every draft read, every save; findDraft runs on every autosave, once every 2.5s while an edit form is open",
+  },
+  // `apiRefs` is an array, so this is a **multikey** index — one index entry
+  // per element. That is correct and is not something to "fix": findCachedWork
+  // asks `{ apiRefs: "igdb__1234" }`, an equality match against one element,
+  // which is exactly what multikey serves.
+  ...WORK_COLLECTIONS.map((collection) => ({
+    collection,
+    key: { apiRefs: 1 },
+    why: "findCachedWork, on every works/retrieve",
+  })),
+];
+
+/**
+ * MongoDB's own default name for a key, `field_1` joined with `_`. Naming
+ * these explicitly rather than letting the server name them means a hand-made
+ * `db.entryRevisions.createIndex({ entryRef: 1 })` — the thing the README used
+ * to ask for — is recognised as the same index rather than collided with.
+ * @type {(key: Record<string, number>) => string}
+ */
+const indexName = (key) =>
+  Object.entries(key)
+    .map(([field, direction]) => `${field}_${direction}`)
+    .join("_");
+
+/**
+ * The only option any index here sets. Comparing a normalised pair of these
+ * rather than the whole option object keeps a server-supplied default (`v`,
+ * `ns`) from reading as a difference.
+ * @type {(options?: { unique?: boolean }) => { unique: boolean }}
+ */
+const comparableOptions = (options) => ({ unique: options?.unique === true });
+
+const sameKey = (a, b) =>
+  JSON.stringify(Object.entries(a ?? {})) ===
+  JSON.stringify(Object.entries(b ?? {}));
+
+const sameOptions = (a, b) =>
+  JSON.stringify(comparableOptions(a)) === JSON.stringify(comparableOptions(b));
+
+/**
+ * Sorts each desired index into one of three buckets against what the database
+ * already has. `createIndexes` is idempotent for an identical spec, so
+ * `satisfied` is what makes a re-run a no-op.
+ *
+ * `conflicting` is the case that would otherwise surface as a driver error:
+ * MongoDB refuses to build an index whose name or key collides with an
+ * existing one that isn't identical — the same key under a different name, or
+ * the same name with different options (a non-unique `username_1` where we
+ * want a unique one). Neither can be fixed by creating anything, so they are
+ * reported for a human to drop by hand rather than thrown.
+ *
+ * @typedef {{ name: string, key: Record<string, number>, unique?: boolean }} ExistingIndex
+ * @typedef {{ create: DesiredIndex[], satisfied: DesiredIndex[], conflicting: (DesiredIndex & { existing: ExistingIndex, reason: string })[] }} IndexPlan
+ * @type {(desired: DesiredIndex[], existingByCollection: Record<string, ExistingIndex[]>) => IndexPlan}
+ */
+const planIndexes = (desired, existingByCollection) => {
+  const plan = { create: [], satisfied: [], conflicting: [] };
+
+  for (const index of desired) {
+    const name = indexName(index.key);
+    const existing = existingByCollection[index.collection] ?? [];
+
+    const byName = existing.find((e) => e.name === name);
+    const byKey = existing.find((e) => sameKey(e.key, index.key));
+    const match = byName ?? byKey;
+
+    if (!match) {
+      plan.create.push(index);
+    } else if (
+      match.name === name &&
+      sameKey(match.key, index.key) &&
+      sameOptions(match, index.options)
+    ) {
+      plan.satisfied.push(index);
+    } else {
+      plan.conflicting.push({ ...index, existing: match, reason: reasonFor(index, match, name) });
+    }
+  }
+
+  return plan;
+};
+
+/**
+ * Groups documents by the value of `field`, keeping only the values more than
+ * one document carries. A unique index cannot be built over one of these, so
+ * this is what the script checks before asking for one.
+ *
+ * A missing field is grouped under `null`, because that is how MongoDB indexes
+ * it: two users with no username at all collide on a unique index exactly as
+ * two users named "nil" do.
+ *
+ * @type {(documents: object[], field: string) => { value: unknown, ids: unknown[] }[]}
+ */
+const duplicateValues = (documents, field) => {
+  const groups = new Map();
+  for (const document of documents) {
+    const raw = document?.[field];
+    const value = raw === undefined ? null : raw;
+    const key = JSON.stringify(value);
+    if (!groups.has(key)) groups.set(key, { value, ids: [] });
+    groups.get(key).ids.push(document?._id);
+  }
+  return [...groups.values()].filter(({ ids }) => ids.length > 1);
+};
+
+/** The indexes whose creation a duplicate check has to clear first. */
+/** @type {(desired: DesiredIndex[]) => DesiredIndex[]} */
+const uniqueIndexes = (desired) =>
+  desired.filter(({ options }) => options?.unique === true);
+
+module.exports = {
+  ENTRY_COLLECTIONS,
+  REVIEW_COLLECTIONS,
+  WORK_COLLECTIONS,
+  DESIRED_INDEXES,
+  indexName,
+  planIndexes,
+  duplicateValues,
+  uniqueIndexes,
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+const reasonFor = (index, match, name) => {
+  if (match.name !== name) {
+    return `${match.name} already indexes the same key under a different name`;
+  }
+  if (!sameKey(match.key, index.key)) {
+    return `${name} exists over a different key, ${JSON.stringify(match.key)}`;
+  }
+  return (
+    `${name} exists with ${match.unique === true ? "" : "no "}unique option, ` +
+    `but ${index.options?.unique === true ? "" : "no "}unique is wanted`
+  );
+};

--- a/src/db_maintenance/index_plan.test.js
+++ b/src/db_maintenance/index_plan.test.js
@@ -1,0 +1,204 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DESIRED_INDEXES,
+  indexName,
+  planIndexes,
+  duplicateValues,
+  uniqueIndexes,
+} = require("./index_plan");
+
+/** What `db.collection(name).indexes()` hands back, trimmed to what we read. */
+const existing = (name, key, unique) => ({
+  v: 2,
+  name,
+  key,
+  ...(unique ? { unique: true } : {}),
+});
+
+const desired = (collection, key, options) => ({
+  collection,
+  key,
+  ...(options ? { options } : {}),
+  why: "a test",
+});
+
+test("an index is named the way MongoDB would name it", () => {
+  assert.equal(indexName({ entryRef: 1 }), "entryRef_1");
+  assert.equal(indexName({ userId: 1, updatedDate: -1 }), "userId_1_updatedDate_-1");
+});
+
+test("every desired index names a collection, a key and a reason", () => {
+  for (const index of DESIRED_INDEXES) {
+    assert.equal(typeof index.collection, "string");
+    assert.ok(Object.keys(index.key).length > 0, `${index.collection} has an empty key`);
+    assert.ok(index.why, `${indexName(index.key)} on ${index.collection} has no reason`);
+  }
+});
+
+test("the list covers every field the issue names, and no field twice", () => {
+  const names = DESIRED_INDEXES.map(
+    (index) => `${index.collection}.${indexName(index.key)}`
+  );
+
+  assert.deepEqual([...new Set(names)].sort(), names.slice().sort());
+  for (const expected of [
+    "users.username_1",
+    "users.userId_1",
+    "filmEntries.userId_1",
+    "tvShowEntries.userId_1",
+    "gameEntries.userId_1",
+    "bookEntries.userId_1",
+    "filmEntries.workRef_1",
+    "tvShowEntries.workRef_1",
+    "gameEntries.workRef_1",
+    "bookEntries.workRef_1",
+    "filmReviews.entryRef_1",
+    "tvShowReviews.entryRef_1",
+    "gameReviews.entryRef_1",
+    "bookReviews.entryRef_1",
+    "entryRevisions.entryRef_1",
+    "films.apiRefs_1",
+    "tvShows.apiRefs_1",
+    "games.apiRefs_1",
+    "books.apiRefs_1",
+  ]) {
+    assert.ok(names.includes(expected), `${expected} is not in the list`);
+  }
+});
+
+test("users.username is the only unique index, and it is unique", () => {
+  assert.deepEqual(
+    uniqueIndexes(DESIRED_INDEXES).map((index) => index.collection),
+    ["users"]
+  );
+  assert.deepEqual(uniqueIndexes(DESIRED_INDEXES)[0].key, { username: 1 });
+});
+
+test("a database with no indexes needs every one of them created", () => {
+  const plan = planIndexes(DESIRED_INDEXES, {});
+
+  assert.equal(plan.create.length, DESIRED_INDEXES.length);
+  assert.deepEqual(plan.satisfied, []);
+  assert.deepEqual(plan.conflicting, []);
+});
+
+test("a collection missing from the report is a collection with no indexes", () => {
+  // `indexes()` on a collection that doesn't exist yet throws rather than
+  // returning [], so the script leaves it out entirely.
+  const plan = planIndexes([desired("entryRevisions", { entryRef: 1 })], {});
+
+  assert.equal(plan.create.length, 1);
+});
+
+test("re-running over the indexes it created is a no-op", () => {
+  const plan = planIndexes(
+    [
+      desired("users", { username: 1 }, { unique: true }),
+      desired("entryRevisions", { entryRef: 1 }),
+    ],
+    {
+      users: [
+        existing("_id_", { _id: 1 }),
+        existing("username_1", { username: 1 }, true),
+      ],
+      entryRevisions: [
+        existing("_id_", { _id: 1 }),
+        existing("entryRef_1", { entryRef: 1 }),
+      ],
+    }
+  );
+
+  assert.deepEqual(plan.create, []);
+  assert.deepEqual(plan.conflicting, []);
+  assert.equal(plan.satisfied.length, 2);
+});
+
+test("the hand-made index the README asked for is recognised, not recreated", () => {
+  const plan = planIndexes([desired("entryRevisions", { entryRef: 1 })], {
+    entryRevisions: [existing("entryRef_1", { entryRef: 1 })],
+  });
+
+  assert.deepEqual(plan.create, []);
+  assert.equal(plan.satisfied.length, 1);
+});
+
+test("a non-unique username index is a conflict, not something to create", () => {
+  const plan = planIndexes([desired("users", { username: 1 }, { unique: true })], {
+    users: [existing("username_1", { username: 1 })],
+  });
+
+  assert.deepEqual(plan.create, []);
+  assert.deepEqual(plan.satisfied, []);
+  assert.equal(plan.conflicting.length, 1);
+  assert.match(plan.conflicting[0].reason, /no unique option/);
+});
+
+test("the same key under someone else's name is a conflict", () => {
+  const plan = planIndexes([desired("entryRevisions", { entryRef: 1 })], {
+    entryRevisions: [existing("by_entry", { entryRef: 1 })],
+  });
+
+  assert.equal(plan.conflicting.length, 1);
+  assert.match(plan.conflicting[0].reason, /different name/);
+});
+
+test("our name over a different key is a conflict", () => {
+  const plan = planIndexes([desired("users", { userId: 1 })], {
+    users: [existing("userId_1", { userId: 1, username: 1 })],
+  });
+
+  assert.equal(plan.conflicting.length, 1);
+  assert.match(plan.conflicting[0].reason, /different key/);
+});
+
+test("indexes on other collections don't satisfy this one", () => {
+  const plan = planIndexes([desired("bookEntries", { userId: 1 })], {
+    filmEntries: [existing("userId_1", { userId: 1 })],
+  });
+
+  assert.equal(plan.create.length, 1);
+});
+
+test("a field no two documents share has no duplicates", () => {
+  const users = [
+    { _id: "a", username: "nil" },
+    { _id: "b", username: "tam" },
+  ];
+
+  assert.deepEqual(duplicateValues(users, "username"), []);
+});
+
+test("duplicates are reported with every document that holds one", () => {
+  const users = [
+    { _id: "a", username: "nil" },
+    { _id: "b", username: "tam" },
+    { _id: "c", username: "nil" },
+    { _id: "d", username: "nil" },
+  ];
+
+  assert.deepEqual(duplicateValues(users, "username"), [
+    { value: "nil", ids: ["a", "c", "d"] },
+  ]);
+});
+
+test("two documents missing the field collide on it just as two equal ones do", () => {
+  // MongoDB indexes a missing field as null, so a unique index fails to build
+  // over these — reporting them as `null` is what stops that being a surprise.
+  const users = [
+    { _id: "a" },
+    { _id: "b", username: null },
+    { _id: "c", username: "nil" },
+  ];
+
+  assert.deepEqual(duplicateValues(users, "username"), [
+    { value: null, ids: ["a", "b"] },
+  ]);
+});
+
+test("values of different types are not conflated", () => {
+  const documents = [{ _id: "a", ref: 1 }, { _id: "b", ref: "1" }];
+
+  assert.deepEqual(duplicateValues(documents, "ref"), []);
+});

--- a/src/db_maintenance/scripts/ensure_indexes.js
+++ b/src/db_maintenance/scripts/ensure_indexes.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * @file Creates the indexes the site's queries need (issue #108).
+ *
+ * Nothing in the repository created an index, so every query was a collection
+ * scan. Which indexes are wanted, and why each of them is, is declared in
+ * ../index_plan.js; this script reads what the database already has, compares
+ * the two, and creates the difference.
+ *
+ * **Re-running is a no-op.** `createIndexes` is idempotent for an identical
+ * spec, and the specs here are named the way MongoDB names them by default
+ * (`entryRef_1`), so an index made by hand at the mongosh prompt is recognised
+ * as the same index rather than collided with. The dry run says which ones
+ * already exist and which ones it would create.
+ *
+ * Indexes are metadata: this writes no documents and touches no user data, so
+ * it needs no backup. It is still a dry run unless you pass --apply, because
+ * building an index on a live collection costs I/O and, in the one case below,
+ * can fail.
+ *
+ * **The one that can fail is `users.username`, which is unique** — it closes
+ * the check-then-write race in the rename path (#98). A unique index refuses
+ * to build if duplicate values already exist, so the duplicates are looked for
+ * first and reported by hand; the dry run tells you whether the unique index
+ * would succeed before you commit to it. Two users with no username at all
+ * count as duplicates: MongoDB indexes a missing field as null.
+ *
+ * Environment (../.env): MONGODB_URL. No API keys needed.
+ *
+ * Usage:
+ *   node scripts/ensure_indexes.js
+ *   node scripts/ensure_indexes.js --apply
+ *   node scripts/ensure_indexes.js --only=entryRevisions,users
+ *
+ * Flags:
+ *   --apply             actually create the indexes (default: dry run)
+ *   --only=a,b          restrict to these collections (default: all of them)
+ *   --json=path         write a machine-readable report
+ */
+require("../env");
+const fs = require("fs");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const { parseArgs } = require("../work_collections");
+const {
+  DESIRED_INDEXES,
+  indexName,
+  planIndexes,
+  duplicateValues,
+  uniqueIndexes,
+} = require("../index_plan");
+
+const args = parseArgs(process.argv);
+
+const options = {
+  apply: args.apply === true,
+  only:
+    args.only === undefined || args.only === true
+      ? undefined
+      : String(args.only).split(","),
+  json: typeof args.json === "string" ? args.json : undefined,
+};
+
+let client;
+
+const main = async () => {
+  const desired = options.only
+    ? DESIRED_INDEXES.filter((index) => options.only.includes(index.collection))
+    : DESIRED_INDEXES;
+
+  if (desired.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Collections with indexes: ` +
+        `${[...new Set(DESIRED_INDEXES.map((i) => i.collection))].join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    options.apply
+      ? "APPLY MODE: missing indexes will be created."
+      : "DRY RUN: nothing will be created. Re-run with --apply to commit."
+  );
+
+  if (!process.env.MONGODB_URL) {
+    throw new Error("MONGODB_URL is not set. See the README in this folder.");
+  }
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const plan = planIndexes(desired, await readExistingIndexes(db, desired));
+  const blockers = await findUniqueBlockers(db, plan.create);
+
+  printPlan(plan, blockers);
+
+  const created = options.apply
+    ? await createIndexes(db, plan.create, blockers)
+    : [];
+
+  if (options.json) {
+    fs.writeFileSync(
+      options.json,
+      JSON.stringify({ ...plan, blockers, created }, null, 2)
+    );
+    console.log(`\nFull report written to ${options.json}`);
+  }
+
+  if (plan.conflicting.length > 0 || blockers.length > 0) process.exitCode = 1;
+
+  await client.close();
+};
+
+/**
+ * What each collection already has, keyed by collection name. A collection
+ * that doesn't exist yet is left out rather than recorded as empty — `.indexes()`
+ * throws on one — which the planner reads as "has nothing", the same answer.
+ * @type {(db: import('mongodb').Db, desired: object[]) => Promise<Record<string, object[]>>}
+ */
+const readExistingIndexes = async (db, desired) => {
+  const names = [...new Set(desired.map((index) => index.collection))];
+  const live = new Set(
+    (await db.listCollections({}, { nameOnly: true }).toArray()).map(
+      ({ name }) => name
+    )
+  );
+
+  const existing = {};
+  for (const name of names) {
+    if (!live.has(name)) {
+      console.warn(`Warning: ${name} is not a collection in this database.`);
+      continue;
+    }
+    existing[name] = await db.collection(name).indexes();
+  }
+  return existing;
+};
+
+/**
+ * The duplicates that would make a unique index fail to build. Only the
+ * indexes we are about to create are checked — an existing unique index has
+ * already proved there are none.
+ *
+ * The values themselves are usernames, which are public, so printing them is
+ * how a human finds the two accounts to reconcile. Nothing else here is
+ * unique, so nothing private is read.
+ *
+ * @type {(db: import('mongodb').Db, create: object[]) => Promise<object[]>}
+ */
+const findUniqueBlockers = async (db, create) => {
+  const blockers = [];
+  for (const index of uniqueIndexes(create)) {
+    const [field] = Object.keys(index.key);
+    const documents = await db
+      .collection(index.collection)
+      .find({}, { projection: { [field]: 1 } })
+      .toArray();
+    const duplicates = duplicateValues(documents, field);
+    if (duplicates.length > 0) {
+      blockers.push({ collection: index.collection, field, duplicates });
+    }
+  }
+  return blockers;
+};
+
+/**
+ * An index blocked by duplicates is skipped; the rest are still worth having,
+ * including the other indexes on the same collection — duplicate usernames say
+ * nothing about `users.userId`.
+ */
+const isBlocked = (index, blockers) =>
+  blockers.some(
+    (blocker) =>
+      blocker.collection === index.collection &&
+      blocker.field === Object.keys(index.key)[0]
+  );
+
+const createIndexes = async (db, create, blockers) => {
+  const created = [];
+  for (const index of create) {
+    if (isBlocked(index, blockers)) continue;
+    const name = indexName(index.key);
+    await db
+      .collection(index.collection)
+      .createIndexes([{ key: index.key, name, ...(index.options ?? {}) }]);
+    console.log(`  created ${index.collection}.${name}`);
+    created.push({ collection: index.collection, name });
+  }
+  console.log(`\nCreated ${created.length} index(es).`);
+  return created;
+};
+
+const printPlan = (plan, blockers) => {
+  console.log(
+    `\n${plan.satisfied.length} index(es) already exist, ` +
+      `${plan.create.length} would be created, ` +
+      `${plan.conflicting.length} conflict.`
+  );
+
+  if (plan.satisfied.length > 0) {
+    console.log("\nAlready there:");
+    for (const index of plan.satisfied) {
+      console.log(`  ${index.collection}.${indexName(index.key)}`);
+    }
+  }
+
+  if (plan.create.length > 0) {
+    console.log(`\n${options.apply ? "Creating" : "Would create"}:`);
+    for (const index of plan.create) {
+      const unique = index.options?.unique === true ? " (unique)" : "";
+      const blocked = isBlocked(index, blockers) ? "  [BLOCKED, see below]" : "";
+      console.log(
+        `  ${index.collection}.${indexName(index.key)}${unique}${blocked}`
+      );
+      console.log(`      for ${index.why}`);
+    }
+  }
+
+  if (plan.conflicting.length > 0) {
+    console.log(
+      "\nConflicts — an index already there is close enough to collide with " +
+        "the one wanted, and creating anything cannot fix it. Drop the " +
+        "existing one and re-run:"
+    );
+    for (const index of plan.conflicting) {
+      console.log(`  ${index.collection}.${indexName(index.key)}: ${index.reason}`);
+      console.log(
+        `      db.${index.collection}.dropIndex("${index.existing.name}")`
+      );
+    }
+  }
+
+  for (const { collection, field, duplicates } of blockers) {
+    const total = duplicates.reduce((sum, d) => sum + d.ids.length, 0);
+    console.log(
+      `\nA unique index on ${collection}.${field} cannot be built: ` +
+        `${duplicates.length} value(s) are held by ${total} documents. ` +
+        "Reconcile these first — the index is skipped until you do."
+    );
+    for (const { value, ids } of duplicates) {
+      const label = value === null ? "(no value)" : JSON.stringify(value);
+      console.log(`  ${label}: ${ids.join(", ")}`);
+    }
+  }
+
+  if (!options.apply && plan.create.length > 0) {
+    console.log(
+      "\nNothing was written. Re-run with --apply once the above looks right."
+    );
+  }
+};
+
+main().catch(async (error) => {
+  console.error(error);
+  process.exitCode = 1;
+  await client?.close();
+});


### PR DESCRIPTION
Closes #108.

`grep -rn createIndex src/` found one hit and it was a sentence in `README.md` asking a human to run a command by hand some day, so every query the site makes is a collection scan. This adds `scripts/ensure_indexes.js`, which creates the lot, and replaces that sentence with a pointer at it.

**These indexes are now on production** — see "Applied" at the bottom.

Which indexes and why is `index_plan.js`, a pure module beside `backup_plan.js` and friends, with the I/O in `scripts/`. Every entry names the queries that want it — an index nobody can name a query for is an index to delete — and every one is a single ascending field, because every query the site makes goes through `findOneByField` / `findAllByField` in `unsafe_functions.js`, which is an equality `$match` on one field. That is 19 indexes: `users.username` and `users.userId`, `userId` and `workRef` on the four `*Entries`, `entryRef` on the four `*Reviews` and on `entryRevisions`, and `apiRefs` on the four work collections.

`entryRevisions` is the one that compounds. It holds up to 50 documents per entry, each a full snapshot including the note, and `findDraft` scans all of it on every autosave — every 2.5 seconds while an edit form is open.

**Re-running is a no-op.** `createIndexes` is idempotent for an identical spec, and these specs are named the way MongoDB names them by default (`entryRef_1`), so the hand-made index the README asked for is recognised as the same index rather than collided with. The planner also reports the cases where an index exists but isn't identical — the same key under a different name, or `username_1` without `unique` — because creating anything cannot fix those, and the driver error they would otherwise produce says less than the `dropIndex` line the script prints.

`users.username` is `{ unique: true }`, which closes the check-then-write race #98 left in the rename path: `assignName` reads the name and writes it in two round trips, so two people claiming one name at the same moment both pass the read. A unique index refuses to build over existing duplicates, so the script looks for them first and prints the colliding documents instead of throwing. Two users with no username at all count — MongoDB indexes a missing field as null. When it can't be built, that one index is skipped and the other 18 are still created, and the run exits non-zero.

`apiRefs` is an array, so its index is multikey. That is what `findCachedWork`'s `{ apiRefs: "igdb__1234" }` equality match wants; there's a comment saying so next to it, so nobody "fixes" it later.

Dry run unless `--apply`, per the folder's rule. The dry run says what already exists against what it would create, whether the unique index would succeed, and why each index is wanted. Flags: `--apply`, `--only=users,entryRevisions` (collection names here, not the `films,books` types the other scripts take), `--json=path`.

The second commit is `CLAUDE.md`. The snapshot step and the approval step had grown into one rule that could be read as "once a human has said yes, you are past the snapshot too". They are now separate: a fresh verified snapshot before **every** `--apply`, with no exception for a write that looks small or looks reversible — including one that touches no documents at all, like an index build, since the reason to hold a snapshot is that you were wrong about what the run would do. `--apply` against production is authorised on that basis, and what still needs a human is named and narrower: anything a restore from that snapshot would not undo.

## Applied

Snapshot `snapshot-2026-08-13T06-12-47-140Z` first, verified: 13 collections, 11,797 documents, no checksum problems, every manifest count equal to a live `countDocuments()`. Then the dry run — 19 to create, 0 already there, 0 conflicts, no duplicate usernames (there are 6 users) — and then `--apply`, which created all 19.

After: the re-run reports 19 already there and 0 to create, so it is idempotent against the real database and not just the tests. Every collection holds exactly `_id_` plus what this added, no strays. Document counts are unchanged in all 13 collections. `explain()` on the actual queries now gives `IXSCAN` on all of them — multikey on `films.apiRefs`, and `EXPRESS_IXSCAN` on `users.username`, MongoDB 8's fast path for an equality on a unique index.

One thing the dry run turned up that the issue didn't: **`entryRevisions` did not exist in production**. The feature had never written a revision, so there was no collection. Creating the index created it, and it is there and empty with `entryRef_1` on it, which means the index is in place before the first draft rather than after the collection has grown. Worth knowing when reading the issue's "up to 50 documents per entry": that growth is ahead of us, not behind.
