### PR TITLE
fix: pin and hash every CDN url the page loads, and drop the dead MathJax

### DIFF
--- a/src/frontend/_includes/css/main.css
+++ b/src/frontend/_includes/css/main.css
@@ -19,6 +19,10 @@ span:lang(cn) {
 
 /* Styling for headers which collapse the subsequent element. It acts like a
  * link and uses Font-Awesome unicode to indicate whether it's collapsed.
+ * The family named here is Font Awesome 6's own. `FontAwesome` was 4.7.0's,
+ * and 4.7.0 is no longer loaded — 6 does declare that name too, as a v4
+ * shim, but there is no reason to reach an icon through a compatibility
+ * alias. Weight 900 picks the solid face, which is where these glyphs are.
 */
 .collapsible {
   color: #0e9ce0;
@@ -26,7 +30,8 @@ span:lang(cn) {
 }
 .collapsible:before {
   content: "\f106"; /* angle-up */
-  font-family: FontAwesome;
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
   margin-right: 10px;
   top: 2px;
   position: relative;
@@ -38,7 +43,8 @@ span:lang(cn) {
 .is-collapsed:before {
   color: #ccc;
   content: "\f107"; /* angle-down */
-  font-family: FontAwesome;
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
   padding-right: 5px;
 }
 .collapsible:hover {

--- a/src/frontend/_includes/js/old_main.js
+++ b/src/frontend/_includes/js/old_main.js
@@ -1,25 +1,6 @@
 ﻿/**
  * @file nil's old main file, preserved
  */
-// MathJax
-init_mathjax = function() {
-  if (window.MathJax) {
-    // MathJax loaded
-    MathJax.Hub.Config({
-      tex2jax: {
-        inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
-      },
-      displayAlign: 'left', // Change this to 'center' to center equations.
-      "HTML-CSS": {
-        styles: {'.MathJax_Display': {"margin": 0}}
-      }
-    });
-    MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
-  }
-}
-init_mathjax();
-
 // Show more/less text.
 $('.show-more').click(function(){
   var $this = $(this);

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -5,12 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>
 
+    {# Everything below comes from a CDN, so every url is pinned to an exact
+       version and carries the `integrity` hash of that version's bytes. A
+       host that starts serving something else then serves it into a page
+       holding the user's `nf_jwt`, and the browser refuses it instead. The
+       hashes are of the pinned files themselves — recompute one with
+       `curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A`
+       if you change a version, and check the page still draws: a wrong hash
+       blocks the file silently, and the whole page is drawn by these. #}
     <!-- CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap.min.css" integrity="sha384-8+rznmq/k0KZkJlZhnuPEVkbRD7tA0wcFEjY48dajGWn3Xc1MasJwS8/tJ7OEsKW" crossorigin="anonymous" referrerpolicy="no-referrer">
+    {# Font Awesome 6 only. It defines the `fa`, `fas` and `far` prefixes the
+       markup uses, so the 4.7.0 stylesheet that used to sit alongside it was
+       being overridden for every icon on the page. The one thing that did
+       still come from 4.7.0 is the `FontAwesome` font family `main.css` names
+       for the collapsible arrows; that now names this file's family. #}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha384-nRgPTkuX86pH8yjPJUAFuASXQSSl2/bBUiNV47vSYpKFxHJhbcrGnmlYpYJMeD7a" crossorigin="anonymous" referrerpolicy="no-referrer">
 
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.10.1/bootstrap-table.min.css">
+    {# 1.12.1, matching the bootstrap-table script below. #}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.css" integrity="sha384-HyusOcKCYSnjwC8jY4YvjZAwLgeqDPWFDu2/AFf5OrZd7ykufk0gwxexoqmg5W8N" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
     <link rel="stylesheet" href="/css/main.css">
     <style>
@@ -23,24 +36,19 @@
        reaches for while it is being parsed: jQuery, Ramda, and the libraries
        the first render calls into. #}
     <!-- JavaScript -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.5/purify.min.js" integrity="sha512-GaomFB92Lot7wDqZgVgLMJwQhuVUEcPHP99xmWSVE4Kq54t1jDyH7mdKDsmN8jOMSjiQq8pf7Et+OM4ml/PVMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.5/purify.min.js" integrity="sha384-WZ/cvv60fkg/bYYTqKUM6ajmPsWZkH9EdbcGFlhlMrppxqeav5I5zj5VBzTkIavz" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     {# Only the profile page's charts and the entry form's date fields, both
-       of which are drawn long after the page is. #}
-    <script defer src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/litepicker/dist/litepicker.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.25.0/ramda.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.24.0/axios.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js" integrity="sha512-hzyXu3u+VDu/7vpPjRKFp9w33Idx7pWWNazPm+aCMRu26yZXFCby1gn1JxevVv3LDwnSbyKrvLo3JNdi4Qx1ww==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    {# Straight to what `cdn.mathjax.org/mathjax/latest` has been a shim for
-       since 2017, so this is one request rather than two. It typesets
-       whatever is on the page when it loads, and at this point that is
-       nothing — `#site` is still empty — so nothing waits on it. #}
-    <script defer type="text/javascript"
-       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-    </script>
+       of which are drawn long after the page is. Both urls used to name no
+       version at all, so the code the site ran changed whenever either
+       package published. These are the versions that resolved to. #}
+    <script defer src="https://cdn.jsdelivr.net/npm/apexcharts@6.8.0" integrity="sha384-nLD6rKRJ1yssfWSVXJJaNpF3g7f2F5/5qnJ6rRBt/KjLrJ5H/ch4uI80FwqxknkC" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/litepicker@2.0.12/dist/litepicker.js" integrity="sha384-TwHJTusQtbcoEHJcrF5aeo0MHBgj8lt8onFRrG7wKk8Q/LG9EphkEsqNRiVWzIP9" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ramda/0.25.0/ramda.min.js" integrity="sha384-RNR54SeCxp1FhiUnPGrGYpNaZn5q8/Fn7tZe7I17lN8cZ1HK/3AzE4KSoFXu6bl2" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.24.0/axios.min.js" integrity="sha384-I2unte9Y12QMna3v071F1Nka0u7+32War1ddTq53DRJ7CSNfyRctw9b7oHce7hey" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js" integrity="sha384-UM1JrZIpBwVf5jj9dTKVvGiiZPZTLVoq4sfdvIe9SBumsvCuv6AHDNtEiIb5h1kU" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js" integrity="sha384-Nud2SriDt2fZ+u85IBC48Yn9p+l4AGlapnX1EGA2KrnZjYJx8sxKnw/CIxc1wU1B" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.js" integrity="sha384-ClQpQScPqQSyD6GCOejtBWJ/GwscJaHjNtqDcG3/JmeQ1VBuzQCeZy0zNBQtuhiH" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js" integrity="sha384-pF+2qz7eFoUyrCTPr8gVboYJ7fNpmJKJzl0vPX6w3XDML+Of8bMSyd6fZIRJdwo7" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     {# macro to include JS with its own const variable scope
        to not have `const` assignments pollute projectwide scope #}


### PR DESCRIPTION
Every url `base.njk` loads now names an exact version and carries the sha384 of that version's bytes, with `crossorigin="anonymous"`. Fourteen tags pull executable code and styling from third parties; two of them checked what came back. Any of those hosts serving something other than what it served yesterday serves it into a page holding the user's `nf_jwt`, and now the browser refuses it instead.

The hashes are computed from the files the pinned urls serve, not copied from anywhere: `curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A`. There is a comment above the block saying so, because a wrong hash blocks a file silently and every pixel of this site is drawn by these.

## The two sharp ones

`npm/apexcharts` and `npm/litepicker/dist/litepicker.js` named no version, so they resolved to whatever was newest at request time — the code running on the site changed whenever either package published, with no deploy and nobody watching. ApexCharts draws the profile histograms, so that was a live stability risk as much as a supply-chain one. Both are pinned to what they were resolving to as of this branch, 6.8.0 and 2.0.12, so today's behaviour is unchanged; from here a version bump is a commit.

MathJax is removed. `init_mathjax` in `old_main.js` configured the v2 `MathJax.Hub` API against `cdn.mathjax.org`, a host retired in 2017, so the call has been against a `window.MathJax` that never arrived for eight years — it has been non-functional that entire time and nothing can have come to rely on it. Nothing else in the codebase mentions MathJax, and notes are rendered by `marked` and sanitised by DOMPurify, neither of which knows what `$…$` is, so there was no path by which maths in a note could reach a typesetter even if one had loaded. If someone wants maths in notes it is worth doing deliberately, against MathJax 3 and hooked into the note render rather than fired once at head-parse time.

## Tidied on the way past

**bootstrap-table** loaded its 1.10.1 stylesheet against its 1.12.1 script. Both are 1.12.1.

**Font Awesome** loaded 4.7.0 *and* 6.0.0-beta3. 6 defines all three prefixes the markup uses — `fa`, `fas` and `far` — so 4.7.0 was already being overridden for every icon on the page, and it is dropped; 6 moves off the beta to 6.7.2, where every icon name in use still resolves. The one thing 4.7.0 genuinely provided was the `FontAwesome` font family that `main.css` names for the collapsible arrows. That now names Font Awesome 6's own family with the weight that selects the solid face. 6 does declare `FontAwesome` too, as a v4 shim, so this would have kept working either way — but there is no reason to reach an icon through a compatibility alias.

**Origins** drop from six to two. cdnjs was already serving six of these files, so Bootstrap moved there from the deprecated `maxcdn.bootstrapcdn.com`, Font Awesome's remaining copy from `stackpath.bootstrapcdn.com`, and jQuery from `ajax.googleapis.com`. What is left is cdnjs and jsDelivr — jsDelivr because ApexCharts 6 is not on cdnjs. Two protocol-relative `//cdnjs…` urls became `https://`.

## Verification

`npm run build` succeeds and `npm test` passes, 234 tests. In the built `dist`, all fourteen remote tags carry an exact version and an `integrity`, none carries a bare `//`, and nothing references `cdn.mathjax.org`.

Loaded in a browser against the built output, with an empty console: every global the page reaches for is defined — `jQuery` 1.11.1, `R`, `axios`, `marked`, `DOMPurify`, `$.fn.bootstrapTable`, `$.fn.modal`, `ApexCharts`, `Litepicker` — which is the check that matters, since a wrong hash means the global is missing. `window.MathJax` is `undefined` and `#site` still draws. ApexCharts 6.8.0 renders the profile histogram from the exact options `toChartOptions` builds: 10 bars, no exception. Both Font Awesome 6 faces load, and every icon class in the codebase resolves to `"Font Awesome 6 Free"` with non-empty content at weight 900 or 400 as the markup asks.

## Not here

The issue's `Content-Security-Policy` header is the enforceable version of all of this, and is the right follow-up. It needs the inline `<style>` and `<script>` blocks nonced or hashed first, which is entangled with the bundling in #110, so it is deliberately not attempted here.

Closes #106
