### PR TITLE
perf: ask the database for what we use, not for everything

### DIFF
--- a/src/api/controllers/export.js
+++ b/src/api/controllers/export.js
@@ -114,7 +114,9 @@ const findListEntries = async (collection, userId, limit) => {
  */
 const findReviews = async (collection, entryRefs) => {
   const found = await db
-    .findAllByFieldIn_(collection, 'entryRef', entryRefs)
+    .findAllByFieldIn_(collection, 'entryRef', entryRefs, {
+      projection: { entryRef: 1, text: 1 },
+    })
     .unwrapOr([])
 
   return new Map(

--- a/src/api/controllers/name.test.js
+++ b/src/api/controllers/name.test.js
@@ -39,8 +39,41 @@ const store = {}
 // has to say so here rather than swap the client out from under it.
 let writesFail = false
 
+/** Only the operators the queries in this module actually use. */
+const matchesValue = (value, wanted) =>
+  wanted && typeof wanted === 'object' && !Array.isArray(wanted)
+    ? '$ne' in wanted
+      ? value !== wanted.$ne
+      : wanted.$in.includes(value)
+    : value === wanted
+
 const matches = (doc, filter = {}) =>
-  Object.entries(filter).every(([field, value]) => doc[field] === value)
+  Object.entries(filter).every(([field, wanted]) =>
+    matchesValue(doc[field], wanted)
+  )
+
+/**
+ * `_id` comes back unless the projection excludes it, and an inclusion
+ * projection drops everything it doesn't name. A double that returned whole
+ * documents regardless would let a query that forgot a field still pass.
+ */
+const project = (doc, projection) => {
+  if (!projection) return doc
+
+  const isInclusion = Object.entries(projection).some(
+    ([field, on]) => field !== '_id' && on
+  )
+
+  return Object.fromEntries(
+    Object.entries(doc).filter(([field]) =>
+      field === '_id'
+        ? projection._id !== 0
+        : isInclusion
+          ? Boolean(projection[field])
+          : projection[field] !== 0
+    )
+  )
+}
 
 const collectionOf = (name) => (store[name] = store[name] ?? [])
 
@@ -49,7 +82,18 @@ const collection = (name) => ({
     toArray: async () =>
       collectionOf(name).filter((doc) => matches(doc, pipeline[0].$match)),
   }),
-  find: () => ({ toArray: async () => [...collectionOf(name)] }),
+  find: (filter, { projection, limit } = {}) => ({
+    toArray: async () => {
+      const found = collectionOf(name).filter((doc) => matches(doc, filter))
+      return (limit ? found.slice(0, limit) : found).map((doc) =>
+        project(doc, projection)
+      )
+    },
+  }),
+  findOne: async (filter, { projection } = {}) => {
+    const doc = collectionOf(name).find((doc) => matches(doc, filter))
+    return doc ? project(doc, projection) : null
+  },
   insertOne: async (doc) => (collectionOf(name).push(doc), { insertedId: doc._id }),
   updateOne: async (filter, { $set }) => {
     if (writesFail) throw new Error('write failed')

--- a/src/api/controllers/revisions.js
+++ b/src/api/controllers/revisions.js
@@ -207,20 +207,39 @@ const withOwnedEntry = (event, respond) => toPromise(
     .mapErr(responses.fromError)
 )
 
-/** @type {(entryRef: string) => Promise<any[]>} */
-const findRevisions = async (entryRef) =>
-  (await db.findAllByField_(COLLECTION, 'entryRef', entryRef).unwrapOr([]))
-    .map(({ data }) => data)
-    .filter(({ kind }) => kind === 'revision')
+/**
+ * What the version list renders. `snapshot` is the bulk of a revision and the
+ * whole point of one; the rest of the document — the entry it belongs to, its
+ * type, its owner, its `kind` — the caller already knows.
+ */
+const VERSION_FIELDS = { createdDate: 1, supersededDate: 1, snapshot: 1 }
+
+/** Pruning decides on dates alone, so it has no reason to read 50 notes. */
+const PRUNE_FIELDS = { createdDate: 1 }
+
+/** @type {(entryRef: string, projection?: object) => Promise<any[]>} */
+const findRevisions = async (entryRef, projection = VERSION_FIELDS) =>
+  (
+    await db
+      .findMany_(COLLECTION, { entryRef, kind: 'revision' }, { projection })
+      .unwrapOr([])
+  ).map(({ data }) => data)
 
 /**
- * There is one draft per entry per user. `_findAllByField` only filters on a
- * single field, so the user is filtered out here.
+ * There is one draft per entry per user, which is two fields to ask on. Asking
+ * on `entryRef` alone meant reading every revision of the entry — up to 50
+ * snapshots, each carrying a full copy of the note — to keep one document.
  * @type {(entryRef: string, userId: string) => Promise<any | undefined>}
  */
-const findDraft = async (entryRef, userId) =>
-  (await db.findAllByField_(COLLECTION, 'entryRef', entryRef).unwrapOr([]))
-    .find(({ data }) => data.kind === 'draft' && data.userId === userId)
+const findDraft = async (entryRef, userId) => {
+  const found = await db
+    .findOne_(COLLECTION, { entryRef, userId, kind: 'draft' })
+    .unwrapOr({})
+
+  // A miss is `{}` from the db module, and every caller here tests the draft
+  // for truthiness before reaching into it.
+  return found?.ref?.id ? found : undefined
+}
 
 /** @type {(collection: ValidCollection, entryRef: string) => Promise<any | undefined>} */
 const findReview = async (collection, entryRef) =>
@@ -231,7 +250,7 @@ const findReview = async (collection, entryRef) =>
   )?.data
 
 const pruneRevisions = async (entryRef) => {
-  const revisions = await findRevisions(entryRef)
+  const revisions = await findRevisions(entryRef, PRUNE_FIELDS)
   for (const id of revisionsToPrune(revisions)) {
     await db.deleteByRef_(COLLECTION, id).unwrapOr(undefined)
   }

--- a/src/api/controllers/revisions.test.js
+++ b/src/api/controllers/revisions.test.js
@@ -35,8 +35,41 @@ process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
 
 const store = {}
 
+/** Only the operators the queries in this module actually use. */
+const matchesValue = (value, wanted) =>
+  wanted && typeof wanted === 'object' && !Array.isArray(wanted)
+    ? '$ne' in wanted
+      ? value !== wanted.$ne
+      : wanted.$in.includes(value)
+    : value === wanted
+
 const matches = (doc, filter = {}) =>
-  Object.entries(filter).every(([field, value]) => doc[field] === value)
+  Object.entries(filter).every(([field, wanted]) =>
+    matchesValue(doc[field], wanted)
+  )
+
+/**
+ * `_id` comes back unless the projection excludes it, and an inclusion
+ * projection drops everything it doesn't name. A double that returned whole
+ * documents regardless would let a query that forgot a field still pass.
+ */
+const project = (doc, projection) => {
+  if (!projection) return doc
+
+  const isInclusion = Object.entries(projection).some(
+    ([field, on]) => field !== '_id' && on
+  )
+
+  return Object.fromEntries(
+    Object.entries(doc).filter(([field]) =>
+      field === '_id'
+        ? projection._id !== 0
+        : isInclusion
+          ? Boolean(projection[field])
+          : projection[field] !== 0
+    )
+  )
+}
 
 const collectionOf = (name) => (store[name] = store[name] ?? [])
 
@@ -45,7 +78,18 @@ const collection = (name) => ({
     toArray: async () =>
       collectionOf(name).filter((doc) => matches(doc, pipeline[0].$match)),
   }),
-  find: () => ({ toArray: async () => [...collectionOf(name)] }),
+  find: (filter, { projection, limit } = {}) => ({
+    toArray: async () => {
+      const found = collectionOf(name).filter((doc) => matches(doc, filter))
+      return (limit ? found.slice(0, limit) : found).map((doc) =>
+        project(doc, projection)
+      )
+    },
+  }),
+  findOne: async (filter, { projection } = {}) => {
+    const doc = collectionOf(name).find((doc) => matches(doc, filter))
+    return doc ? project(doc, projection) : null
+  },
   insertOne: async (doc) => (collectionOf(name).push(doc), { insertedId: doc._id }),
   updateOne: async (filter, { $set }) => {
     const doc = collectionOf(name).find((d) => matches(d, filter))

--- a/src/api/controllers/stats.js
+++ b/src/api/controllers/stats.js
@@ -35,17 +35,29 @@ module.exports = {
 /** @type {ValidCollection[]} */
 const entryCollections = ['gameEntries', 'tvShowEntries', 'filmEntries', 'bookEntries']
 
+/**
+ * Which entries count is the filter's business, so a score is the whole of
+ * what a tally reads off one. Everything else on the document — the dates,
+ * the overrides, the workRef — was four lists fetched in full to arrive at
+ * forty numbers.
+ */
+const TALLY_FIELDS = { score: 1 }
+
 /** @type {(userDocument: any) => ResultAsync<Response, Error>} */
 const refreshStats = (userDocument) => {
   /** @type {ResultAsync<[ValidCollection, any][], Error>} */
   const entries = combine(
     entryCollections
       .flatMap((col) =>
-        db.findAllByField_(col, 'userId', userDocument.data.userId)
-          .map((data) => data
-            .filter((doc) => doc.data.status !== 'Planned' )
-            .map((doc) => [col, doc])
-          )
+        db.findMany_(
+          col,
+          // Planned entries are the ones with nothing to score yet, and
+          // `$ne` matches an entry with no status at all, as the filter it
+          // replaces did.
+          { userId: userDocument.data.userId, status: { $ne: 'Planned' } },
+          { projection: TALLY_FIELDS }
+        )
+          .map((data) => data.map((doc) => [col, doc]))
       )
   )
 

--- a/src/api/utils/db/README.md
+++ b/src/api/utils/db/README.md
@@ -1,3 +1,16 @@
 This folder's index exports SAFE (non-throwing) functions that
 are an abstraction over mongoDB to make interacting with
 mongoDB safe and more ergonomic.
+
+`findOne_` and `findMany_` take a filter document and an options
+object — `{ projection, sort, limit }` — so a query can name more
+than one field and can ask for only the fields the caller reads.
+The `*ByField*` functions are sugar over them for the common case.
+Anything the database can do, it should: a filter, a projection or
+a limit applied in Node is documents fetched and sent for nothing.
+
+Every document handed out is wrapped as `{ data, ref: { id } }` —
+the shape callers across the API read — so a projection must keep
+`_id`. `queries.js` enforces that, and holds the parts of a query
+that can be tested without a database; `shapes.js` holds what the
+results are turned into. Both are pure, both have tests.

--- a/src/api/utils/db/index.js
+++ b/src/api/utils/db/index.js
@@ -17,9 +17,11 @@
 /** @typedef {import('../parsers').ValidCollection} ValidCollection */
 /** @typedef {import('../errors').Error} Error */
 const { ResultAsync } = require('neverthrow')
-const { _findOneByField, _findOneByRef, _findAllByField, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
+const { _findOne, _findMany, _findOneByField, _findOneByRef, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
 const { compose } = require('ramda')
 const { toResponse, toResult } = require('./into_safe_values')
+
+/** @typedef {import('./queries').QueryOptions} QueryOptions */
 
 /** @type {(collection: ValidCollection, ref: string) => Promise<Response>} */
 const findOneByRef = compose(toResponse, _findOneByRef)
@@ -33,13 +35,18 @@ const findOneByField = compose(toResponse, _findOneByField)
 /** @type {(collection: ValidCollection, field: string, value: any) => ResultAsync<any, Error>} */
 const findOneByField_ = compose(toResult, _findOneByField)
 
-/** @type {(collection: ValidCollection, field: string, value: any, limit?: number) => Promise<Response>} */
-const findAllByField = compose(toResponse, _findAllByField)
+/**
+ * The general form of the two above: a filter of as many fields as the caller
+ * needs, and `{ projection, sort, limit }` for the parts of the work the
+ * database can do and the caller shouldn't.
+ * @type {(collection: ValidCollection, filter: object, options?: QueryOptions) => ResultAsync<any, Error>}
+ */
+const findOne_ = compose(toResult, _findOne)
 
-/** @type {(collection: ValidCollection, field: string, value: any, limit?: number) => ResultAsync<any, Error>} */
-const findAllByField_ = compose(toResult, _findAllByField)
+/** @type {(collection: ValidCollection, filter: object, options?: QueryOptions) => ResultAsync<any, Error>} */
+const findMany_ = compose(toResult, _findMany)
 
-/** @type {(collection: ValidCollection, field: string, values: any[]) => ResultAsync<any, Error>} */
+/** @type {(collection: ValidCollection, field: string, values: any[], options?: QueryOptions) => ResultAsync<any, Error>} */
 const findAllByFieldIn_ = compose(toResult, _findAllByFieldIn)
 
 /** @type {(collection: ValidCollection, userId: string, limit?: number) => ResultAsync<any, Error>} */
@@ -73,8 +80,8 @@ module.exports = {
   findOneByRef,
   findOneByRef_,
   findAll,
-  findAllByField,
-  findAllByField_,
+  findOne_,
+  findMany_,
   findAllByFieldIn_,
   findOneByField,
   findOneByField_,

--- a/src/api/utils/db/queries.js
+++ b/src/api/utils/db/queries.js
@@ -1,0 +1,85 @@
+/**
+ * @file The queries this module sends, without the database.
+ *
+ * `db.js` builds a MongoClient at require time and throws without
+ * `MONGODB_URL`, so nothing in unsafe_functions.js can be reached from
+ * `node --test`. What a query *asks for* is worth testing even so — a `$limit`
+ * on the wrong side of a `$lookup` still returns the right rows, it just joins
+ * four hundred documents to return five — so the describing lives here, pure
+ * and dependency-free, and the queries call it. See queries.test.js, and
+ * shapes.js for the other half of the same split.
+ */
+
+/**
+ * A whole list in one query: the user's entries, newest first, joined to the
+ * works they point at.
+ *
+ * The order and the limit are stages rather than something the caller does to
+ * the results, and they come *before* the `$lookup` so that a limited request
+ * joins the metadata onto the entries it is going to return instead of onto
+ * all of them. The profile page asks for five rows of each list; sorted and
+ * sliced afterwards, that was four full lists joined and sent to render twenty
+ * rows.
+ *
+ * A missing `updatedDate` sorts last. `_id` only breaks ties, of which there
+ * are a great many — a bulk import stamps a whole list with one millisecond —
+ * and it breaks them the same way every time, which sorting in Node did not:
+ * that left entries stamped the same millisecond in whatever order the
+ * database happened to return them, so a limit would have taken a different
+ * five on every request.
+ *
+ * @type {(args: { userId: string, workCollection: string, limit?: number }) => object[]}
+ */
+const toUserEntriesPipeline = ({ userId, workCollection, limit }) => [
+  { $match: { userId } },
+  { $sort: { updatedDate: -1, _id: 1 } },
+  ...(limit ? [{ $limit: limit }] : []),
+  {
+    $lookup: {
+      from: workCollection,
+      localField: 'workRef',
+      foreignField: '_id',
+      as: 'work',
+    },
+  },
+  // Nobody reads either of these from a list, and they are not small:
+  // `review` is the whole note, which the reviews endpoint serves when a row
+  // is actually opened, and `userId` is an auth0 id repeated once per entry
+  // for anyone who asks for the list.
+  { $project: { review: 0, userId: 0 } },
+]
+
+/**
+ * The driver options of a `find` or a `findOne`, with the ones nobody asked
+ * for left out rather than passed as `undefined`.
+ *
+ * @typedef {{ projection?: object, sort?: object, limit?: number }} QueryOptions
+ * @type {(options?: QueryOptions) => QueryOptions}
+ */
+const toFindOptions = ({ projection, sort, limit } = {}) => ({
+  ...(projection ? { projection: keepingId(projection) } : {}),
+  ...(sort ? { sort } : {}),
+  ...(limit ? { limit } : {}),
+})
+
+module.exports = {
+  toUserEntriesPipeline,
+  toFindOptions,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Every document handed out of this module is wrapped by
+ * `toSameFormatAsFaunaDb`, which reads `_id` to build the `ref.id` that
+ * callers update and delete by. A projection that dropped it would hand back
+ * rows nothing can act on, and only as a missing field rather than as an
+ * error. An inclusion projection keeps `_id` on its own, so this has only to
+ * undo an explicit exclusion.
+ */
+const keepingId = (projection) =>
+  projection._id === 0 || projection._id === false
+    ? Object.fromEntries(
+        Object.entries(projection).filter(([field]) => field !== '_id')
+      )
+    : projection

--- a/src/api/utils/db/queries.test.js
+++ b/src/api/utils/db/queries.test.js
@@ -1,0 +1,109 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const { toUserEntriesPipeline, toFindOptions } = require('./queries')
+
+const stageNames = (pipeline) => pipeline.map((stage) => Object.keys(stage)[0])
+
+const stage = (pipeline, name) =>
+  pipeline.find((stage) => Object.keys(stage)[0] === name)?.[name]
+
+const filmsOf = (userId, limit) =>
+  toUserEntriesPipeline({ userId, workCollection: 'films', limit })
+
+test('a list is matched, ordered and joined, in that order', () => {
+  assert.deepEqual(stageNames(filmsOf('u1')), [
+    '$match',
+    '$sort',
+    '$lookup',
+    '$project',
+  ])
+})
+
+test('a limited list limits before the join, not after it', () => {
+  const pipeline = filmsOf('u1', 5)
+
+  assert.deepEqual(stageNames(pipeline), [
+    '$match',
+    '$sort',
+    '$limit',
+    '$lookup',
+    '$project',
+  ])
+  // The point of the whole thing: five works joined rather than four hundred.
+  assert.equal(stage(pipeline, '$limit'), 5)
+})
+
+test('an unlimited list has no $limit stage at all', () => {
+  // `undefined` is what `parseInt('') || undefined` gives for a request that
+  // asked for no limit, and `{ $limit: undefined }` is an error from the
+  // server rather than a stage that does nothing.
+  assert.equal(stage(filmsOf('u1', undefined), '$limit'), undefined)
+  assert.equal(stage(filmsOf('u1', 0), '$limit'), undefined)
+})
+
+test('only the asking user\'s entries are matched', () => {
+  assert.deepEqual(stage(filmsOf('u1'), '$match'), { userId: 'u1' })
+})
+
+test('newest first, with a stable tiebreak', () => {
+  assert.deepEqual(stage(filmsOf('u1'), '$sort'), { updatedDate: -1, _id: 1 })
+})
+
+test('the join names the work collection it was given', () => {
+  assert.deepEqual(stage(filmsOf('u1'), '$lookup'), {
+    from: 'films',
+    localField: 'workRef',
+    foreignField: '_id',
+    as: 'work',
+  })
+  assert.equal(
+    toUserEntriesPipeline({ userId: 'u1', workCollection: 'games' }).find(
+      (stage) => stage.$lookup
+    ).$lookup.from,
+    'games'
+  )
+})
+
+test('a list carries neither the notes nor the owner it does not render', () => {
+  assert.deepEqual(stage(filmsOf('u1'), '$project'), { review: 0, userId: 0 })
+})
+
+test('the pipeline is built fresh, so a caller cannot mutate the next one', () => {
+  const first = filmsOf('u1', 5)
+  first[0].$match.userId = 'someone else'
+
+  assert.deepEqual(stage(filmsOf('u2', 5), '$match'), { userId: 'u2' })
+})
+
+test('options nobody asked for are left out rather than sent as undefined', () => {
+  assert.deepEqual(toFindOptions(), {})
+  assert.deepEqual(toFindOptions({}), {})
+  assert.deepEqual(toFindOptions({ limit: 0 }), {})
+})
+
+test('a projection, a sort and a limit are passed through', () => {
+  assert.deepEqual(
+    toFindOptions({ projection: { score: 1 }, sort: { _id: 1 }, limit: 1 }),
+    { projection: { score: 1 }, sort: { _id: 1 }, limit: 1 }
+  )
+})
+
+test('an exclusion projection stays an exclusion projection', () => {
+  // Mixing inclusions and exclusions is an error from the server, so `_id`
+  // must not be added to one of these.
+  assert.deepEqual(toFindOptions({ projection: { snapshot: 0 } }), {
+    projection: { snapshot: 0 },
+  })
+})
+
+test('a projection cannot drop the _id that becomes ref.id', () => {
+  // Without `_id` the wrapper hands back `ref: { id: undefined }`, and a row
+  // nothing can update or delete looks exactly like one that can.
+  assert.deepEqual(toFindOptions({ projection: { _id: 0, score: 1 } }), {
+    projection: { score: 1 },
+  })
+  assert.deepEqual(toFindOptions({ projection: { _id: false, score: 1 } }), {
+    projection: { score: 1 },
+  })
+})

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -11,6 +11,24 @@ const { v4: uuidv4 } = require('uuid')
 const { throwIt } = require('../general')
 const parsers = require('../parsers/')
 const { toSameFormatAsFaunaDb, toEntryWithMetadata } = require('./shapes')
+const { toUserEntriesPipeline, toFindOptions } = require('./queries')
+
+/** @typedef {import('./queries').QueryOptions} QueryOptions */
+
+/**
+ * A whole filter document, so a query can name more than one field, and the
+ * options to go with it. `findDraft` is the reason: one draft per entry per
+ * user is two fields, and asking on one of them meant reading every revision
+ * of the entry — up to 50 snapshots, each carrying a full copy of the note —
+ * to keep the one document that matched both.
+ * @type {(collection: ValidCollection, filter: object, options?: QueryOptions) => Promise<object>}
+ */
+const _findOne = (collection, filter, options) =>
+  findFirst(collection, filter, options)
+
+/** @type {(collection: ValidCollection, filter: object, options?: QueryOptions) => Promise<object>} */
+const _findMany = (collection, filter, options) =>
+  find(collection, filter, options)
 
 /** @type {(collection: ValidCollection, field: string, value: any) => Promise<object>} */
 const _findOneByField = (collection, field, value) =>
@@ -22,22 +40,18 @@ const _findOneByRef = (collection, ref) =>
 
 /** @type {(collection: ValidCollection) => Promise<object>} */
 const _findAllInCollection = (collection) =>
-  findAll(collection, {})
-
-/** @type {(collection: ValidCollection, field: string, value: any) => Promise<object>} */
-const _findAllByField = (collection, field, value) =>
-  findAll(collection, { [field]: value })
+  find(collection, {})
 
 /**
  * One query for many values of the same field, rather than one query per
  * value. A whole list's reviews are 400-odd `entryRef`s, and 400 round trips
  * is the difference between a response and a function timeout.
- * @type {(collection: ValidCollection, field: string, values: any[]) => Promise<object>}
+ * @type {(collection: ValidCollection, field: string, values: any[], options?: QueryOptions) => Promise<object>}
  */
-const _findAllByFieldIn = (collection, field, values) =>
+const _findAllByFieldIn = (collection, field, values, options) =>
   values.length === 0
     ? Promise.resolve([])
-    : findAll(collection, { [field]: { $in: values } })
+    : find(collection, { [field]: { $in: values } }, options)
 
 /** @type {(collection: ValidCollection, ref: string, update: any) => Promise<object>} */
 const _updateOneByRef = (collection, ref, update) =>
@@ -90,30 +104,7 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
 
   const results = await mongo((db) => db
     .collection(collection)
-    .aggregate([
-      { $match: { userId } },
-      // The order the caller used to sort into after the fact. A missing
-      // `updatedDate` sorts last here too. `_id` only breaks ties, of which
-      // there are a great many — a bulk import stamps a whole list with one
-      // millisecond — and it breaks them the same way every time, which the
-      // sort it replaces did not: that one left entries stamped the same
-      // millisecond in whatever order the database happened to return them.
-      { $sort: { updatedDate: -1, _id: 1 } },
-      ...(limit ? [{ $limit: limit }] : []),
-      {
-        $lookup: {
-          from: workCollection,
-          localField: 'workRef',
-          foreignField: '_id',
-          as: 'work',
-        },
-      },
-      // Nobody reads either of these from a list, and they are not small:
-      // `review` is the whole note, which the reviews endpoint serves when a
-      // row is actually opened, and `userId` is an auth0 id repeated once per
-      // entry for anyone who asks for the list.
-      { $project: { review: 0, userId: 0 } },
-    ])
+    .aggregate(toUserEntriesPipeline({ userId, workCollection, limit }))
     .toArray()
     .then((arr) => arr.map((row) => toEntryWithMetadata(row, entryType)))
   )
@@ -122,10 +113,11 @@ const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
 }
 
 module.exports = {
+  _findOne,
+  _findMany,
   _findOneByField,
   _findOneByRef,
   _findAllInCollection,
-  _findAllByField,
   _findAllByFieldIn,
   _findAllUserEntriesWithMetadata,
   _updateOneByRef,
@@ -136,19 +128,30 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/** @type {(collection: ValidCollection, filter: {}) => Promise<object>} */
-const findFirst = (collection, filter) =>
-  find(collection, filter).then((results) => results[0] ?? {})
-
-/** @type {(collection: ValidCollection, filter: {}) => Promise<object>} */
-const findAll = (collection, filter) =>
-  find(collection, filter)
-
-/** @type {(collection: ValidCollection, filter: {}) => Promise<object>} */
-const find = (collection, filter) =>
+/**
+ * One document, asked for as one document rather than read out of the whole
+ * matching set — which for the `users`-by-`username` lookup that runs on
+ * almost every request meant the user collection, to keep `[0]`.
+ * @type {(collection: ValidCollection, filter: {}, options?: QueryOptions) => Promise<object>}
+ */
+const findFirst = (collection, filter, options) =>
   mongo((db) => db
     .collection(collection)
-    .aggregate([{ $match: filter }])
+    .findOne(filter, toFindOptions(options))
+    // Absent stays `{}` rather than becoming `null`: callers test `?.data` or
+    // `?.ref` on what comes back, and some of them spread it.
+    .then((dcmt) => (dcmt ? toSameFormatAsFaunaDb(dcmt) : {}))
+  )
+
+/**
+ * `aggregate([{ $match: filter }])` returns the same documents, but a pipeline
+ * is the wrong thing to hand a limit or a projection to.
+ * @type {(collection: ValidCollection, filter: {}, options?: QueryOptions) => Promise<object>}
+ */
+const find = (collection, filter, options) =>
+  mongo((db) => db
+    .collection(collection)
+    .find(filter, toFindOptions(options))
     .toArray()
     .then((arr) => arr.map(toSameFormatAsFaunaDb))
   )


### PR DESCRIPTION
Four query shapes in `src/api/utils/db/unsafe_functions.js` did in Node what the query itself could do, and each of them fetched documents in order to throw them away. Closes #107.

**`find` ran an aggregation to do a find.** `aggregate([{ $match: filter }])` returns the same rows as `find(filter)`, but a pipeline is the wrong thing to hand a projection or a limit to, which is part of why neither existed. **`findFirst` read the whole matching set to keep `[0]`** — every `findOneByField_` went through it, including the `users`-by-`username` lookup that runs on almost every request. Both are now the driver call they were describing: `find` and `findOne`.

**Nothing could filter on two fields.** `findDraft` asked for every revision of an entry — up to 50 snapshots, each carrying a full copy of the note — and picked the one with `kind: 'draft'` in Node. `findOne_` and `findMany_` take a filter document and `{ projection, sort, limit }`, so that is now one query returning one document. The readers that pulled whole entries to read one or two fields off them project instead: `refreshStats` asks for `score` and lets `status: { $ne: 'Planned' }` do the filtering it was doing in JS, `findRevisions` asks for the three fields the version list renders, and pruning — which decides on dates alone — no longer reads 50 notes to sort them by `createdDate`.

**The list pipeline moves to a pure module.** `$sort` and `$limit` already sat before the `$lookup` on `main`; what was missing was any way to see that from a test, since `db.js` builds a MongoClient at require time and throws without `MONGODB_URL`. `queries.js` holds `toUserEntriesPipeline` and `toFindOptions`, dependency-free beside `shapes.js`, and `queries.test.js` covers the thing worth covering: that the limit sits before the join, where it makes Mongo join five works rather than four hundred to render the profile's five rows, and that an unlimited request emits no `$limit` stage rather than `{ $limit: undefined }`.

Worth arguing with:

- **The two in-memory Mongo doubles change.** They modelled the driver as the db module happened to call it rather than as it behaves — `find` ignored its filter and returned the whole collection, `findOne` didn't exist — so nothing that started calling either could pass. They now honour filter, projection and limit, which also means those 16 tests would catch a query that forgot a field rather than quietly getting the whole document. The two copies stay two copies; deduplicating them is a separate change.
- **A projection can't drop `_id`.** Everything handed out of this module is wrapped as `{ data, ref: { id: doc._id } }` and callers across the API update and delete by `ref.id`, so `toFindOptions` strips an explicit `_id: 0` rather than handing back rows nothing can act on. An exclusion projection is left as an exclusion projection — `_id` is not added to one — since mixing the two is an error from the server.
- **`status: { $ne: 'Planned' }` matches an entry with no status at all**, exactly as the `!== 'Planned'` filter it replaces did.
- `findAllByField_` and `findAllByField` are gone. The single `(field, value)` pair is the limitation the issue names, both callers moved to `findMany_`, and `findOneByField_`/`findOneByRef_` stay as the sugar over the common case.

`_findAllUserEntriesWithMetadata` keeps its `emptyWork` fallback from #96 untouched — the pipeline moved as-is, and `toEntryWithMetadata` and its tests are unchanged.

Verified with `npm test` (246 tests, no failures), and separately with the dependencies installed on local disk so the 16 database-backed tests that CI skips actually run — they pass too, driving the real handlers through the rewritten module: drafts stored, read back and replaced, the history cap, the rename path. The db plumbing that no test can reach (ramda's `compose` arity, the options reaching the driver, `{}` for a miss, the fauna shape surviving a projection) was checked against a fake driver in a throwaway script.
