### PR TITLE
fix: save an entry and its note in one transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ You might need to run `npx netlify login` inside the project.
 
 We currently use mongoDB, logged into via the MONGODB_URL
 
+Saving an entry writes the entry and its long note in one transaction, so a
+failure part-way leaves neither rather than one of them. Transactions need a
+replica set, which Atlas is — and Atlas is what production and a local
+`netlify dev` both talk to, since `MONGODB_URL` points at the same place from
+either. Pointed at a standalone `mongod` instead, `db.withTransaction` warns
+once and runs the writes in order without a transaction, which is what the
+code did before it existed: the save still works, but a failure between the
+two writes can leave the note stale beside a freshly saved entry.
+
 **Backups.** `src/db_maintenance/backup_database.js` takes a timestamped
 snapshot of every collection and prunes old ones to a retention policy, so
 there is a history of backups rather than one overwritten dump;

--- a/src/api/controllers/entries.js
+++ b/src/api/controllers/entries.js
@@ -4,6 +4,8 @@
 /** @typedef {import('../utils/errors').Error} Error */
 /** @typedef {import('../utils/responses').Response} Response */
 const responses = require('../utils/responses')
+const errors = require('../utils/errors')
+const { identity } = require('ramda')
 const { combine, okAsync } = require('neverthrow')
 const {
   getUserId,
@@ -14,7 +16,7 @@ const {
   toEntryType,
   toReviewCollection,
 } = require('./utils')
-const { triplet, quad, toPromise, toAsync } = require('../utils/general')
+const { triplet, quad, toPromise, toAsync, throwIt } = require('../utils/general')
 const db = require('../utils/db/')
 const { toResponse } = require('../utils/db/into_safe_values')
 const { recordRevision, discardDraft, discardHistory } = require('./revisions')
@@ -96,18 +98,36 @@ const getUserEntries = ([uid, col, limit]) => toResponse(toPromise(
 ))
 
 /** @type {([userId, body, collection]: [string, any, ValidCollection]) => Promise<Response>} */
-const createEntry = ([userId, body, collection]) => {
+const createEntry = async ([userId, body, collection]) => {
   const { review, ...entryWithoutReview } = body
   const reviewCollection = toReviewCollection(collection)
 
-  return db.create_(collection, { ...entryWithoutReview, userId, updatedDate: Date.now() })
-    .andThen((entry) => db.create_(reviewCollection, {
-      text: review,
-      entryRef: entry.ref.id,
-    }))
-    // `fromError`, not `internalError`: the latter would send the error object
-    // itself, detail and all, back as the body.
-    .match(responses.ok, responses.fromError)
+  try {
+    // An entry and its note are one thing to the person saving them, so they
+    // are one transaction. Written separately, a failure on the second left
+    // an entry no note could ever be attached to — reported to the user as a
+    // failure that had nonetheless half happened.
+    const entry = await db.withTransaction(async (session) => {
+      const created = await orThrow(db.create_(collection, {
+        ...entryWithoutReview,
+        userId,
+        updatedDate: Date.now(),
+      }, session))
+
+      await orThrow(db.create_(reviewCollection, {
+        text: review,
+        entryRef: created.ref.id,
+      }, session))
+
+      return created
+    })
+
+    // The entry, not the review it ends with: this response is the only place
+    // the caller can learn the id of what it just created.
+    return responses.ok(entry)
+  } catch (error) {
+    return failed(error)
+  }
 }
 
 /** @type {(col: ValidCollection, entry: any) => Promise<Response>} */
@@ -144,6 +164,13 @@ const updateEntry_ = async (uid, body, col, entry) => {
 
   // Recorded before anything is written, so the version this save replaces —
   // the long note included — can be read back and restored from the UI.
+  //
+  // Deliberately outside the transaction below. History is a convenience and
+  // its failure must never fail the save (see revisions.js), but a write that
+  // fails inside a transaction aborts it, which is precisely the wrong way
+  // round. The price is that a save that then rolls back leaves a version
+  // recording the state that is still current; noise on a path the user is
+  // already being shown an error on.
   await recordRevision({
     entryType: toEntryType(col),
     entry,
@@ -154,26 +181,65 @@ const updateEntry_ = async (uid, body, col, entry) => {
     ),
   })
 
-  if (reviewProvided) {
-    // Awaited so the write completes before the function returns; a
-    // serverless container can be frozen right after the response is sent.
-    await (existingReview?.ref
-      ? db.updateByRef_(reviewCollection, existingReview.ref.id, { text: review })
-      // Shouldn't be needed, but just in case.
-      : db.create_(reviewCollection, {
-          text: review,
-          entryRef: entry.ref.id,
-        }))
+  try {
+    // The entry and its note go together or not at all. Both writes are
+    // awaited inside the transaction so they complete before the function
+    // returns; a serverless container can be frozen right after the response
+    // is sent.
+    const written = await db.withTransaction(async (session) => {
+      // The entry first. Against a replica set the order does not matter —
+      // either both land or neither does — but `withTransaction` degrades to
+      // plain writes on a deployment that cannot transact, and there an entry
+      // left stale beside a fresh note is the more confusing of the two
+      // half-saves: the score and the dates say one thing, the comments
+      // another. A stale note beside a fresh entry at least looks like what
+      // it is.
+      const updated = await orThrow(db.updateByRef_(col, entry.ref.id, {
+        ...(reviewProvided ? body : entryWithoutReview),
+        updatedDate: Date.now(),
+      }, session))
+
+      if (reviewProvided) {
+        await orThrow(existingReview?.ref
+          ? db.updateByRef_(reviewCollection, existingReview.ref.id, { text: review }, session)
+          // Shouldn't be needed, but just in case.
+          : db.create_(reviewCollection, {
+              text: review,
+              entryRef: entry.ref.id,
+            }, session))
+      }
+
+      return updated
+    })
+
+    // The draft has been saved for real now, so it has nothing left to
+    // recover. Outside the transaction, and after it: a draft left behind by
+    // a save that rolled back still describes edits the user has not managed
+    // to store, which is exactly what a draft is for.
+    await discardDraft(entry.ref.id, uid)
+
+    return responses.ok(written)
+  } catch (error) {
+    return failed(error)
   }
-
-  const response = await db.updateByRef(col, entry.ref.id, {
-    ...(reviewProvided ? body : entryWithoutReview),
-    updatedDate: Date.now(),
-  })
-
-  // The draft has been saved for real now, so it has nothing left to recover.
-  await discardDraft(entry.ref.id, uid)
-
-  return response
 }
+
+/**
+ * The `_`-suffixed db helpers answer with a Result rather than throwing, and
+ * a transaction is only told to roll back by a rejected promise. This is the
+ * join between the two.
+ * @type {(result: import('neverthrow').ResultAsync<any, Error>) => Promise<any>}
+ */
+const orThrow = async (result) => (await result).match(identity, throwIt)
+
+/**
+ * A write that failed inside a transaction arrives here as whatever was
+ * thrown: an `Error` from the db helpers, or something the driver raised on
+ * the transaction itself. Either way it leaves through `fromError`, which
+ * logs what it knows and tells the caller only the class of failure — the
+ * driver's own account of one names every host it tried. See #105.
+ * @type {(error: any) => Response}
+ */
+const failed = (error) =>
+  responses.fromError(typeof error?.error === 'string' ? error : errors.db(error))
 

--- a/src/api/controllers/entries.test.js
+++ b/src/api/controllers/entries.test.js
@@ -1,0 +1,333 @@
+/**
+ * @file What saving an entry writes when one of the writes refuses, driven
+ * through the real Netlify handler against an in-memory Mongo.
+ *
+ * The fake here answers `hello` as a replica set, so `db.withTransaction`
+ * opens a real transaction and the fake rolls the store back when the
+ * callback throws. revisions.test.js's fake has no `admin` command at all, so
+ * `withTransaction` falls back to plain writes there — between the two files
+ * both halves of it are exercised.
+ *
+ * Needs the dependencies (zod parses what goes in), so it **skips itself**
+ * when they aren't installed, which is how CI runs the suite.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const Module = require('module')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('neverthrow')
+    require('zod')
+    require('ts-pattern')
+    require('ramda')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+
+///////////////////////////////////////////////////////////////////////////////
+// A Mongo small enough to keep in a variable, with a transaction that is a
+// copy of the whole thing taken on the way in and put back on the way out.
+
+const store = {}
+
+/** The one write that is going to refuse, as `{ collection, op }`. */
+let broken = null
+
+/** Only the operators the queries in this module actually use. */
+const matchesValue = (value, wanted) =>
+  wanted && typeof wanted === 'object' && !Array.isArray(wanted)
+    ? '$ne' in wanted
+      ? value !== wanted.$ne
+      : wanted.$in.includes(value)
+    : value === wanted
+
+const matches = (doc, filter = {}) =>
+  Object.entries(filter).every(([field, wanted]) =>
+    matchesValue(doc[field], wanted)
+  )
+
+const project = (doc, projection) => {
+  if (!projection) return doc
+
+  const isInclusion = Object.entries(projection).some(
+    ([field, on]) => field !== '_id' && on
+  )
+
+  return Object.fromEntries(
+    Object.entries(doc).filter(([field]) =>
+      field === '_id'
+        ? projection._id !== 0
+        : isInclusion
+          ? Boolean(projection[field])
+          : projection[field] !== 0
+    )
+  )
+}
+
+const collectionOf = (name) => (store[name] = store[name] ?? [])
+
+const refuseIfBroken = (name, op) => {
+  if (broken?.collection === name && broken?.op === op) {
+    throw new Error(`the database refused to ${op} on ${name}`)
+  }
+}
+
+const collection = (name) => ({
+  aggregate: (pipeline) => ({
+    toArray: async () =>
+      collectionOf(name).filter((doc) => matches(doc, pipeline[0].$match)),
+  }),
+  find: (filter, { projection, limit } = {}) => ({
+    toArray: async () => {
+      const found = collectionOf(name).filter((doc) => matches(doc, filter))
+      return (limit ? found.slice(0, limit) : found).map((doc) =>
+        project(doc, projection)
+      )
+    },
+  }),
+  findOne: async (filter, { projection } = {}) => {
+    const doc = collectionOf(name).find((doc) => matches(doc, filter))
+    return doc ? project(doc, projection) : null
+  },
+  insertOne: async (doc) => (
+    refuseIfBroken(name, 'insertOne'),
+    collectionOf(name).push(doc),
+    { insertedId: doc._id }
+  ),
+  updateOne: async (filter, { $set }) => {
+    refuseIfBroken(name, 'updateOne')
+    const doc = collectionOf(name).find((d) => matches(d, filter))
+    if (doc) Object.assign(doc, $set)
+    return { modifiedCount: doc ? 1 : 0 }
+  },
+  deleteOne: async (filter) => {
+    refuseIfBroken(name, 'deleteOne')
+    store[name] = collectionOf(name).filter((doc) => !matches(doc, filter))
+    return { deletedCount: 1 }
+  },
+  deleteMany: async (filter) => {
+    refuseIfBroken(name, 'deleteMany')
+    const before = collectionOf(name).length
+    store[name] = collectionOf(name).filter((doc) => !matches(doc, filter))
+    return { deletedCount: before - store[name].length }
+  },
+})
+
+const startSession = () => ({
+  withTransaction: async (work) => {
+    const before = structuredClone(store)
+    try {
+      return await work()
+    } catch (error) {
+      for (const name of Object.keys(store)) delete store[name]
+      Object.assign(store, before)
+      throw error
+    }
+  },
+  endSession: async () => {},
+})
+
+class MongoClient {
+  async connect() {}
+  db() {
+    return {
+      databaseName: 'memo',
+      collection,
+      admin: () => ({ command: async () => ({ setName: 'a-replica-set' }) }),
+    }
+  }
+  withSession(executor) {
+    return executor(startSession())
+  }
+}
+
+const loadModule = Module._load
+Module._load = function (request, ...args) {
+  if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
+  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  return loadModule.call(this, request, ...args)
+}
+
+const entries = dependenciesInstalled ? require('../routes/entries') : undefined
+const revisions = dependenciesInstalled ? require('../routes/revisions') : undefined
+
+///////////////////////////////////////////////////////////////////////////////
+
+const call = async (route, method, url, { as, body } = {}) => {
+  const response = await route.handler(
+    {
+      httpMethod: method,
+      path: `/.netlify/functions/${url}`,
+      headers: as ? { authorization: `Bearer ${as}` } : {},
+      body: body === undefined ? null : JSON.stringify(body),
+    },
+    {}
+  )
+  return {
+    statusCode: response.statusCode,
+    body: response.body ? JSON.parse(response.body) : undefined,
+  }
+}
+
+const seed = () => {
+  broken = null
+  store.filmEntries = []
+  store.filmReviews = []
+  store.entryRevisions = []
+}
+
+const seedSavedEntry = () => {
+  seed()
+  store.filmEntries = [
+    {
+      _id: 'e1',
+      userId: 'u1',
+      status: 'InProgress',
+      score: 7,
+      workRef: 'w1',
+      startedDate: 1700000000000,
+      updatedDate: 1700000000000,
+    },
+  ]
+  store.filmReviews = [{ _id: 'r1', entryRef: 'e1', text: 'the note as it was' }]
+}
+
+/** What the entry form sends when the user saves. */
+const form = (extra) => ({
+  commonMetadata: null,
+  workRef: 'w1',
+  overrides: { englishTranslatedTitle: 'Stalker', genres: null },
+  status: 'Completed',
+  score: 9,
+  startedDate: 1700000000000,
+  completedDate: 1700100000000,
+  review: 'the note as it was rewritten',
+  ...extra,
+})
+
+///////////////////////////////////////////////////////////////////////////////
+
+test('creating an entry answers with the entry, not with its note', options, async () => {
+  seed()
+
+  const { statusCode, body } = await call(entries, 'POST', 'entries/films', {
+    as: 'u1',
+    body: form({ review: 'a first note' }),
+  })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.filmEntries.length, 1)
+
+  // The id of what was just created, which is the thing the caller cannot
+  // work out for itself and had no way to read before.
+  assert.equal(body.ref.id, store.filmEntries[0]._id)
+  assert.equal(body.data.status, 'Completed')
+  assert.equal(body.data.score, 9)
+  assert.equal(body.data.userId, 'u1')
+
+  // The note is written beside it rather than returned in its place.
+  assert.equal(store.filmReviews[0].text, 'a first note')
+  assert.equal(body.data.text, undefined)
+  assert.equal(body.data.entryRef, undefined)
+})
+
+test('an entry whose note will not write is not left behind', options, async () => {
+  seed()
+  broken = { collection: 'filmReviews', op: 'insertOne' }
+
+  const { statusCode } = await call(entries, 'POST', 'entries/films', {
+    as: 'u1',
+    body: form(),
+  })
+
+  assert.equal(statusCode, 500)
+  assert.deepEqual(store.filmEntries, [])
+  assert.deepEqual(store.filmReviews, [])
+})
+
+test('a save whose note will not write leaves the entry as it was', options, async () => {
+  seedSavedEntry()
+  broken = { collection: 'filmReviews', op: 'updateOne' }
+
+  const { statusCode, body } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form(),
+  })
+
+  assert.equal(statusCode, 500)
+  assert.equal(store.filmEntries[0].status, 'InProgress')
+  assert.equal(store.filmEntries[0].score, 7)
+  assert.equal(store.filmEntries[0].updatedDate, 1700000000000)
+  assert.equal(store.filmReviews[0].text, 'the note as it was')
+
+  // A failed write inside a transaction leaves through `fromError` like every
+  // other one, so what the driver said about it stays in the log. #105.
+  assert.deepEqual(body, { error: 'DBError', message: 'the database did not answer' })
+})
+
+test('a save whose entry will not write leaves the note as it was', options, async () => {
+  seedSavedEntry()
+  broken = { collection: 'filmEntries', op: 'updateOne' }
+
+  const { statusCode } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form(),
+  })
+
+  assert.equal(statusCode, 500)
+  assert.equal(store.filmEntries[0].status, 'InProgress')
+  assert.equal(store.filmReviews[0].text, 'the note as it was')
+})
+
+test('a save that did not happen keeps the draft it would have discarded', options, async () => {
+  seedSavedEntry()
+  await call(revisions, 'PUT', 'revisions/films/e1/draft', {
+    as: 'u1',
+    body: form({ review: 'still being written' }),
+  })
+  broken = { collection: 'filmReviews', op: 'updateOne' }
+
+  await call(entries, 'PATCH', 'entries/films/e1', { as: 'u1', body: form() })
+
+  broken = null
+  const { body } = await call(revisions, 'GET', 'revisions/films/e1/draft', {
+    as: 'u1',
+  })
+  assert.equal(body.draft.snapshot.review, 'still being written')
+})
+
+test('a save that goes through writes both halves and clears the draft', options, async () => {
+  seedSavedEntry()
+  await call(revisions, 'PUT', 'revisions/films/e1/draft', {
+    as: 'u1',
+    body: form(),
+  })
+
+  const { statusCode } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form(),
+  })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.filmEntries[0].status, 'Completed')
+  assert.equal(store.filmEntries[0].score, 9)
+  assert.equal(store.filmReviews[0].text, 'the note as it was rewritten')
+
+  const drafts = store.entryRevisions.filter(({ kind }) => kind === 'draft')
+  assert.deepEqual(drafts, [])
+
+  // History is written outside the transaction, and a save that lands still
+  // records the version it replaced.
+  const history = store.entryRevisions.filter(({ kind }) => kind === 'revision')
+  assert.equal(history.length, 1)
+  assert.equal(history[0].snapshot.review, 'the note as it was')
+})

--- a/src/api/utils/db/README.md
+++ b/src/api/utils/db/README.md
@@ -9,6 +9,14 @@ The `*ByField*` functions are sugar over them for the common case.
 Anything the database can do, it should: a filter, a projection or
 a limit applied in Node is documents fetched and sent for nothing.
 
+`withTransaction` runs a group of writes so that either all of them
+land or none do — saving an entry and its long note is the one that
+needs it. A write takes the session it hands out as an optional last
+argument and a read takes it in its options; a query given neither
+runs outside the transaction, and cannot see what it has written.
+Transactions need a replica set, which Atlas is; against a standalone
+`mongod` the writes run in order without one. See db.js.
+
 Every document handed out is wrapped as `{ data, ref: { id } }` —
 the shape callers across the API read — so a projection must keep
 `_id`. `queries.js` enforces that, and holds the parts of a query

--- a/src/api/utils/db/db.js
+++ b/src/api/utils/db/db.js
@@ -1,6 +1,7 @@
 /** @typedef {import('mongodb').Db} Db */
+/** @typedef {import('mongodb').ClientSession} ClientSession */
 const { MongoClient, ServerApiVersion } = require('mongodb')
-const { throwIt } = require('../general')
+const { throwIt, warn } = require('../general')
 
 const mongoClient = new MongoClient(process.env.MONGODB_URL ?? throwIt('MONGODB_URL not set'), {
   serverApi: ServerApiVersion.v1,
@@ -19,6 +20,70 @@ const mongo = async (query) => {
   return query(mdb)
 }
 
+/**
+ * Runs `work` inside a transaction, so a group of writes either all land or
+ * none of them do. Every function this folder exports takes the session as an
+ * optional last argument, and a write made without it is not part of the
+ * transaction — it will not be rolled back with one, and inside one it will
+ * not see what the transaction has written so far.
+ *
+ * Transactions need a replica set or a sharded cluster. Atlas is a replica
+ * set, and Atlas is what production and a local `netlify dev` both talk to,
+ * so this is a real transaction wherever the app actually runs. A standalone
+ * `mongod` cannot do them at all; rather than refuse to save against one,
+ * `work` runs there with no session, which is the behaviour that predates
+ * this function — the writes happen in order, and a failure part-way leaves
+ * them half-applied. The warning below says so, once per process.
+ *
+ * @type {<T>(work: (session?: ClientSession) => Promise<T>) => Promise<T>}
+ */
+const withTransaction = async (work) => {
+  if (!(await transactionsAvailable())) return work(undefined)
+
+  /** @type {any} */
+  let result
+
+  // The driver's v4 `withTransaction` does not hand back what the callback
+  // returned, and it may run the callback more than once when the server asks
+  // for a retry, so the result is picked up from whichever run committed
+  // rather than from the call itself.
+  await mongoClient.withSession((session) =>
+    session.withTransaction(async () => {
+      result = await work(session)
+    })
+  )
+
+  return result
+}
+
 module.exports = {
   mongo,
+  withTransaction,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/** @type {boolean | undefined} */
+let available
+
+/**
+ * Asked once and remembered for the life of the container: a deployment does
+ * not become a replica set while it is being talked to.
+ * @type {() => Promise<boolean>}
+ */
+const transactionsAvailable = async () => {
+  if (available === undefined) {
+    available = await mongo(async (db) => {
+      // `hello` is the handshake every deployment answers. `setName` is only
+      // there on a replica set member, and `isdbgrid` is a mongos.
+      const hello = await db.admin().command({ hello: 1 })
+      return Boolean(hello.setName) || hello.msg === 'isdbgrid'
+    }).catch(() => false)
+
+    if (!available) {
+      warn('MongoDB is not a replica set: a save is a sequence of writes rather than a transaction.')
+    }
+  }
+
+  return available
 }

--- a/src/api/utils/db/index.js
+++ b/src/api/utils/db/index.js
@@ -8,6 +8,11 @@
  * Functions PREFIXED with `_` are unsafe (may throw) and should
  * be considered private to this module.
  *
+ * `withTransaction` groups writes so that either all of them land or none
+ * do. A write takes the session it hands out as an optional last argument, a
+ * read takes it in its `QueryOptions`, and a query given neither runs on its
+ * own — outside any transaction in progress, and blind to it.
+ *
  * Basics to make MongoDB queries:
  * https://www.mongodb.com/docs/drivers/node/current/usage-examples/
  *
@@ -19,9 +24,11 @@
 const { ResultAsync } = require('neverthrow')
 const { _findOne, _findMany, _findOneByField, _findOneByRef, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
 const { compose } = require('ramda')
+const { withTransaction } = require('./db')
 const { toResponse, toResult } = require('./into_safe_values')
 
 /** @typedef {import('./queries').QueryOptions} QueryOptions */
+/** @typedef {import('mongodb').ClientSession} ClientSession */
 
 /** @type {(collection: ValidCollection, ref: string) => Promise<Response>} */
 const findOneByRef = compose(toResponse, _findOneByRef)
@@ -55,28 +62,29 @@ const findAllUserEntriesWithMetadata_ = compose(toResult, _findAllUserEntriesWit
 /** @type {(collection: ValidCollection) => Promise<Response>} */
 const findAll = compose(toResponse, _findAllInCollection)
 
-/** @type {(collection: ValidCollection, ref: string, update: any) => Promise<Response>} */
+/** @type {(collection: ValidCollection, ref: string, update: any, session?: ClientSession) => Promise<Response>} */
 const updateByRef = compose(toResponse, _updateOneByRef)
 
-/** @type {(collection: ValidCollection, ref: string, update: any) => ResultAsync<any, Error>} */
+/** @type {(collection: ValidCollection, ref: string, update: any, session?: ClientSession) => ResultAsync<any, Error>} */
 const updateByRef_ = compose(toResult, _updateOneByRef)
 
-/** @type {(collection: ValidCollection, ref: string) => Promise<Response>} */
+/** @type {(collection: ValidCollection, ref: string, session?: ClientSession) => Promise<Response>} */
 const deleteByRef = compose(toResponse, _deleteOneByRef)
 
-/** @type {(collection: ValidCollection, ref: string) => ResultAsync<any, Error>} */
+/** @type {(collection: ValidCollection, ref: string, session?: ClientSession) => ResultAsync<any, Error>} */
 const deleteByRef_ = compose(toResult, _deleteOneByRef)
 
-/** @type {(collection: ValidCollection, field: string, value: any) => ResultAsync<any, Error>} */
+/** @type {(collection: ValidCollection, field: string, value: any, session?: ClientSession) => ResultAsync<any, Error>} */
 const deleteAllByField_ = compose(toResult, _deleteAllByField)
 
-/** @type {(collection: ValidCollection, data: ExprArg) => Promise<Response>} */
+/** @type {(collection: ValidCollection, data: ExprArg, session?: ClientSession) => Promise<Response>} */
 const create = compose(toResponse, _create)
 
-/** @type {(collection: ValidCollection, data: ExprArg) => ResultAsync<any, Error>} */
+/** @type {(collection: ValidCollection, data: ExprArg, session?: ClientSession) => ResultAsync<any, Error>} */
 const create_ = compose(toResult, _create)
 
 module.exports = {
+  withTransaction,
   findOneByRef,
   findOneByRef_,
   findAll,

--- a/src/api/utils/db/queries.js
+++ b/src/api/utils/db/queries.js
@@ -53,13 +53,18 @@ const toUserEntriesPipeline = ({ userId, workCollection, limit }) => [
  * The driver options of a `find` or a `findOne`, with the ones nobody asked
  * for left out rather than passed as `undefined`.
  *
- * @typedef {{ projection?: object, sort?: object, limit?: number }} QueryOptions
+ * `session` is how a read joins a transaction — `withTransaction` hands one
+ * out, and a read made without it cannot see what that transaction has
+ * written so far.
+ *
+ * @typedef {{ projection?: object, sort?: object, limit?: number, session?: import('mongodb').ClientSession }} QueryOptions
  * @type {(options?: QueryOptions) => QueryOptions}
  */
-const toFindOptions = ({ projection, sort, limit } = {}) => ({
+const toFindOptions = ({ projection, sort, limit, session } = {}) => ({
   ...(projection ? { projection: keepingId(projection) } : {}),
   ...(sort ? { sort } : {}),
   ...(limit ? { limit } : {}),
+  ...(session ? { session } : {}),
 })
 
 module.exports = {

--- a/src/api/utils/db/queries.test.js
+++ b/src/api/utils/db/queries.test.js
@@ -97,6 +97,16 @@ test('an exclusion projection stays an exclusion projection', () => {
   })
 })
 
+test('a session is passed through, so a read can join a transaction', () => {
+  const session = { id: 'a session' }
+
+  assert.deepEqual(toFindOptions({ session }), { session })
+  assert.deepEqual(toFindOptions({ projection: { score: 1 }, session }), {
+    projection: { score: 1 },
+    session,
+  })
+})
+
 test('a projection cannot drop the _id that becomes ref.id', () => {
   // Without `_id` the wrapper hands back `ref: { id: undefined }`, and a row
   // nothing can update or delete looks exactly like one that can.

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -3,9 +3,15 @@
  * private to this module. They must be converted to safe
  * promises or safe ResultAsyncs with toPromise or toResult
  * pefore being re-exported.
+ *
+ * Every write takes an optional `session` last, and every read takes one in
+ * its `QueryOptions`. It is the session `withTransaction` hands out, and it
+ * is what puts the query inside that transaction; without it a query runs on
+ * its own, which is what everything but the entry-saving path wants.
  */
 /** @typedef {import('../parsers').ValidCollection} ValidCollection */
 /** @typedef {import('mongodb').ObjectId} ObjectId */
+/** @typedef {import('mongodb').ClientSession} ClientSession */
 const { mongo } = require('./db')
 const { v4: uuidv4 } = require('uuid')
 const { throwIt } = require('../general')
@@ -53,31 +59,31 @@ const _findAllByFieldIn = (collection, field, values, options) =>
     ? Promise.resolve([])
     : find(collection, { [field]: { $in: values } }, options)
 
-/** @type {(collection: ValidCollection, ref: string, update: any) => Promise<object>} */
-const _updateOneByRef = (collection, ref, update) =>
+/** @type {(collection: ValidCollection, ref: string, update: any, session?: ClientSession) => Promise<object>} */
+const _updateOneByRef = (collection, ref, update, session) =>
   mongo((db) => db
     .collection(collection)
-    .updateOne({ _id: ref }, { $set: update })
+    .updateOne({ _id: ref }, { $set: update }, { session })
   )
 
-/** @type {(collection: ValidCollection, ref: string) => Promise<object>} */
-const _deleteOneByRef = (collection, ref) =>
+/** @type {(collection: ValidCollection, ref: string, session?: ClientSession) => Promise<object>} */
+const _deleteOneByRef = (collection, ref, session) =>
   mongo((db) => db
     .collection(collection)
-    .deleteOne({ _id: ref })
+    .deleteOne({ _id: ref }, { session })
   )
 
-/** @type {(collection: ValidCollection, field: string, value: any) => Promise<object>} */
-const _deleteAllByField = (collection, field, value) =>
+/** @type {(collection: ValidCollection, field: string, value: any, session?: ClientSession) => Promise<object>} */
+const _deleteAllByField = (collection, field, value, session) =>
   mongo((db) => db
     .collection(collection)
-    .deleteMany({ [field]: value })
+    .deleteMany({ [field]: value }, { session })
   )
 
-/** @type {(collection: ValidCollection, data: any) => Promise<object>} */
-const _create = (collection, data) =>
+/** @type {(collection: ValidCollection, data: any, session?: ClientSession) => Promise<object>} */
+const _create = (collection, data, session) =>
   parsers[collection](data).match(
-    (validDoc) => unsafeCreateDoc(collection, validDoc),
+    (validDoc) => unsafeCreateDoc(collection, validDoc, session),
     (err) => throwIt(err)
   )
 
@@ -156,15 +162,18 @@ const find = (collection, filter, options) =>
     .then((arr) => arr.map(toSameFormatAsFaunaDb))
   )
 
-/** @type {(collection: ValidCollection, data: any) => Promise<object>} */
-const unsafeCreateDoc = (collection, data) =>
+/** @type {(collection: ValidCollection, data: any, session?: ClientSession) => Promise<object>} */
+const unsafeCreateDoc = (collection, data, session) =>
   mongo((db) => db
     .collection(collection)
     .insertOne({
       _id: uuidv4(),
       ...data,
-    })
+    }, { session })
+    // Read back through the same session: an insert made inside a transaction
+    // is invisible to anything outside it until the transaction commits, so
+    // without this the document just created would come back as `{}`.
     .then(({ insertedId }) =>
-      findFirst(collection, { _id: insertedId })
+      findFirst(collection, { _id: insertedId }, { session })
     )
   )


### PR DESCRIPTION
Closes #115.

Saving an entry wrote the entry and its long note separately, and a failure on either left the other already written. On an edit the entry write went second, so the common failure kept the old score and dates beside the new comments; on a create the note went second, leaving an entry no note could ever attach to. Both reported the failure to the user and rolled nothing back. `createEntry` also answered `200` with the review document rather than the entry, so the endpoint that creates an entry never told the caller its id.

Both writes now happen inside `db.withTransaction`, so either both land or neither does, and `createEntry` answers with the entry. A write takes the session as an optional last argument; a read takes it in the `QueryOptions` that already carry its projection, sort and limit, which is how the driver itself treats it. `unsafeCreateDoc` reads its own insert back through the session it inserted with, which it has to: inside a transaction that document is invisible to anything outside it.

**The decisions worth arguing with.**

`recordRevision` and `discardDraft` are deliberately *outside* the transaction. History must never fail the save it is recording, which is the property `revisions.js` documents, and a write that fails inside a transaction aborts it — precisely the wrong way round. The price is that a save which then rolls back leaves a version recording the state that is still current, on a path where the user is already being shown an error. `discardDraft` runs only after a commit, which is what you want: a draft is worth keeping exactly when the save it belongs to did not happen.

Transactions need a replica set. Atlas is one, and `MONGODB_URL` points at Atlas from production and from a local `netlify dev` alike, so this is a real transaction wherever the app actually runs. Pointed at a standalone `mongod` it cannot be, so `withTransaction` warns once per process and runs the writes in order without a session rather than refusing to save — the behaviour that predates it. That fallback is why the entry is now written *before* the note: a stale note beside a fresh entry is the less confusing of the two half-saves, and it is what #115 proposed as the cheap interim fix.

A write that fails inside the transaction leaves through `responses.fromError` like every other failure, so the driver's account of it goes to the function log and the caller is told the class of failure alone. `responses.internalError` stays callerless, which is how #125 left it.

The driver here is v4, so `withSession` and `withTransaction` were read out of the installed `mongodb@4.10.0` rather than out of current docs. Two things that version does differently and this code depends on: `withSession` throws the callback's return value away — the source says as much, in a comment reading "Do not return the result of callback" — and `withTransaction` re-runs its callback on a transient error. So the result is captured in a variable from whichever run committed, rather than taken from the call.

**Tests.** `src/api/controllers/entries.test.js` drives the real Netlify handler against an in-memory Mongo whose transaction is a copy taken on the way in and put back when the callback throws, with one write rigged to refuse. Reverting just the transaction — leaving the ordering fix in place — makes two of the six fail with exactly the states #115 describes: an entry left behind with no note, and an entry gone to `Completed` beside a note that stayed as it was. The case where the *entry* write is the one that fails passes either way, which is the ordering fix earning its keep on its own. The fake reports itself as a replica set; `revisions.test.js`'s has no `admin` command at all, so between the two files both halves of `withTransaction` are covered. `queries.test.js` gains a case for the session reaching the driver options. `npm test` is 283 passing with the dependencies installed, and 250 passing / 33 skipped without them, which is how CI runs it.

**Not in this PR.** `SubmitButton` and `DeleteButton` still finish with `location.reload()`. Re-rendering from the response is the improvement #115 raises alongside this one, but it is frontend work with its own risk and belongs on its own. Returning the entry from `createEntry` is the part that unblocks it. `updateEntry`'s response body is unchanged (still the driver's `UpdateResult`) — nothing reads it today, and the PR that wants to re-render is better placed to decide what it should be.

**Rebased** on `main` over #123, which reworked these same db helpers, and #125, which reworked the error path. The session threads through the shapes those two established rather than around them: `QueryOptions` for reads, `fromError` for failures.
