### PR TITLE
fix: stop error responses handing the caller the driver's own words

### DIFF
--- a/src/api/controllers/entries.js
+++ b/src/api/controllers/entries.js
@@ -105,7 +105,9 @@ const createEntry = ([userId, body, collection]) => {
       text: review,
       entryRef: entry.ref.id,
     }))
-    .match(responses.ok, responses.internalError)
+    // `fromError`, not `internalError`: the latter would send the error object
+    // itself, detail and all, back as the body.
+    .match(responses.ok, responses.fromError)
 }
 
 /** @type {(col: ValidCollection, entry: any) => Promise<Response>} */

--- a/src/api/controllers/export.js
+++ b/src/api/controllers/export.js
@@ -150,16 +150,19 @@ const toLimit = (event) =>
   parseInt(event.queryStringParameters?.limit ?? '') || undefined
 
 /**
- * `responses.ok` stringifies but sends no content type, which leaves this
- * arriving as `text/plain`, and a reader deciding how to parse a body
- * deserves to be told. Not indented: it costs a quarter of the response and
- * every reader of this — browsers included — formats JSON itself.
+ * Stringified here rather than by `responses.ok` because the byte budget
+ * below has to weigh the body before it is sent, and a `Response` does not
+ * say how big it is. `responses.ok` would set the same content type — it is
+ * the same constant — but not the CORS header this route also needs.
+ *
+ * Not indented: it costs a quarter of the response and every reader of this,
+ * browsers included, formats JSON itself.
  * @type {(body: object, username: string) => Response}
  */
 const asJson = (body, username) =>
   safeJSONStringify(body).match(
-    (text) => withinBudget('application/json; charset=utf-8', text, username),
-    (error) => (warn(error), responses.internalError(errors.internal(error)))
+    (text) => withinBudget(responses.JSON_CONTENT_TYPE, text, username),
+    (error) => responses.fromError(errors.internal(error))
   )
 
 /**

--- a/src/api/controllers/name.js
+++ b/src/api/controllers/name.js
@@ -3,7 +3,7 @@
 /** @typedef {import('../utils/responses').Response} Response */
 /** @typedef {import('../utils/errors').Error} Error */
 const { combine, okAsync, ResultAsync } = require('neverthrow')
-const { findOneByField_, findOneByField, updateByRef_, create_ } = require('../utils/db')
+const { findOneByField_, updateByRef_, create_ } = require('../utils/db')
 const { pair, toPromise } = require('../utils/general')
 const responses = require('../utils/responses')
 const { getUserId, getReqBody, getSegment } = require('./utils')
@@ -20,9 +20,21 @@ const findOwnName = (event) => toPromise(
     .mapErr(() => responses.ok({}))
 )
 
-/** @type {(event: Event) => Promise<Response>} */
-const getUserIdFromName = (event) =>
-  findOneByField('users', 'username', getSegment(0, event))
+/**
+ * GET /api/name/:username
+ *
+ * Whether that name is taken, and nothing else. The list page asks this
+ * before it draws a list and only looks at whether an answer came back — the
+ * whole user document, `userId` included, used to come back with it. See
+ * #105, and user.js for the same projection on the profile route.
+ * @type {(event: Event) => Promise<Response>}
+ */
+const getUserIdFromName = (event) => toPromise(
+  findOneByField_('users', 'username', getSegment(0, event))
+    .map(({ data }) => data ? { data: { username: data.username } } : {})
+    .map(responses.ok)
+    .mapErr(responses.fromError)
+)
 
 /** @type {(event: Event) => Promise<Response>} */
 const setOwnName = (event) => toPromise(

--- a/src/api/controllers/user.js
+++ b/src/api/controllers/user.js
@@ -1,13 +1,38 @@
+/**
+ * @file The public half of a user document.
+ *
+ * The profile page wants a name and a biography. The document also holds
+ * `userId` — the auth0 `sub` every ownership check is written against — and
+ * a stats blob, and answering with the whole thing published the first to
+ * anyone who asked for a profile. Ownership is settled against a verified
+ * JWT rather than against this value, so it was never a way in; it was an
+ * internal identifier handed out for no reason. See #105.
+ */
 /** @typedef {import('@netlify/functions').HandlerContext} Context */
 /** @typedef {import('@netlify/functions').HandlerEvent} Event */
 /** @typedef {import('../utils/responses').Response} Response */
 /** @typedef {import('../utils/errors').Error} Error */
-const { findOneByField } = require('../utils/db')
+const { findOneByField_ } = require('../utils/db')
+const responses = require('../utils/responses')
+const { toPromise } = require('../utils/general')
 const { getSegment } = require('./utils')
 
-/** @type {(event: Event) => Promise<Response>} */
-const getUserFromName = (event) =>
-  findOneByField('users', 'username', getSegment(0, event))
+/**
+ * GET /api/user/:username
+ *
+ * A name nobody has taken still answers 200 with an empty body, which is what
+ * the profile page turns into its own 404.
+ * @type {(event: Event) => Promise<Response>}
+ */
+const getUserFromName = (event) => toPromise(
+  findOneByField_('users', 'username', getSegment(0, event))
+    .map(({ data }) => data
+      ? { data: { username: data.username, biography: data.biography } }
+      : {}
+    )
+    .map(responses.ok)
+    .mapErr(responses.fromError)
+)
 
 module.exports = {
   getUserFromName,

--- a/src/api/controllers/utils.js
+++ b/src/api/controllers/utils.js
@@ -31,7 +31,7 @@ const getUrlSegments = (event) =>
 /** @type {(event: Event) => Result<any, Error>} */
 const getReqBody = Result.fromThrowable(
   (event) => JSON.parse(event.body),
-  (err) => errors.req(String(err)),
+  (err) => errors.req(err, 'the request body is not valid JSON'),
 )
 
 /** @type {(name: string) => ResultAsync<string, Error>} */

--- a/src/api/utils/db/into_safe_values.js
+++ b/src/api/utils/db/into_safe_values.js
@@ -26,12 +26,16 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/** @type {(err: any) => Response} */
-const dbErrToResponse = (err) => {
-  const response = match(err.name)
-    .with('BadRequest', () => responses.badRequest)
-    .with('NotFound', () => responses.notFound)
-    .otherwise(() => responses.internalError)
-
-  return response(errors.db(err?.description))
-}
+/**
+ * The driver's error becomes the error's `detail`, which `fromError` logs and
+ * does not send: a failed topology description names every host in the
+ * replica set, and reads here are unauthenticated. #105.
+ * @type {(err: any) => Response}
+ */
+const dbErrToResponse = (err) =>
+  responses.fromError(
+    match(err?.name)
+      .with('BadRequest', () => errors.req(err))
+      .with('NotFound', () => errors.notFound(err))
+      .otherwise(() => errors.db(err))
+  )

--- a/src/api/utils/errors.js
+++ b/src/api/utils/errors.js
@@ -1,12 +1,37 @@
 /**
  * @file This file exports simple Error constructors
  * to standardize projectwide error shapes.
+ *
+ * An error carries two things, written for two different readers. `detail` is
+ * whatever we happen to have — a driver exception and its stack, a validation
+ * dump — and it goes to the function log and nowhere else. `message` is the
+ * one line the caller is told, and it only exists when there is something
+ * worth telling them; `responses.fromError` supplies a stock one otherwise.
+ *
+ * `detail` comes first and `message` second so that the careless call —
+ * `.mapErr(errors.db)`, `errors.internal(err)` — puts what it was handed in
+ * the slot that never leaves the building. Publishing has to be deliberate.
+ * See #105.
  */
-/** @typedef {{ error: string, context?: any }} Error */
-/** @typedef {(context?: any) => Error} ErrorCreator */
+/** @typedef {{ error: string, detail?: string, message?: string }} Error */
+/** @typedef {(detail?: any, message?: string) => Error} ErrorCreator */
+
+/**
+ * An Error's stack rather than its `toString`, because the log is the only
+ * place it is going and the log is where a stack earns its keep.
+ * @type {(detail: any) => string | undefined}
+ */
+const toDetailText = (detail) =>
+  detail === undefined ? undefined
+    : detail instanceof Error ? (detail.stack ?? String(detail))
+    : String(detail)
 
 /** @type {(name: string) => ErrorCreator} */
-const error = (name) => (context) => ({ error: name, context: String(context) })
+const error = (name) => (detail, message) => ({
+  error: name,
+  detail: toDetailText(detail),
+  message,
+})
 
 /** @type {Object.<string, ErrorCreator>} */
 module.exports = {

--- a/src/api/utils/external_api_adapters/books/google.js
+++ b/src/api/utils/external_api_adapters/books/google.js
@@ -7,7 +7,7 @@
 const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const axios = require('axios').default
-const { retrying, describeFailure, statusOf } = require('../retry')
+const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
 
 const { GOOGLE_API_KEY } = process.env
 
@@ -88,12 +88,19 @@ const throwNoSuchVolume = (ref) => {
  * gets this far has already been retried and is worth logging with the status
  * that caused it — the message that used to reach the user said only that
  * there was a "problem".
+ *
+ * The whole of it goes to the log and only the class of failure to the
+ * caller, who is owed enough to know whether to try again and nothing about
+ * how this is wired up. #105.
  * @type {(doing: string) => (err: any) => Error}
  */
-const toError = (doing) => (err) => {
-  console.error(`Google Books failed while ${doing}: ${describeFailure(err)}`)
-
-  return statusOf(err) === 404
-    ? errors.notFound('Google Books')
-    : errors.internal(`Google Books failed while ${doing} (${describeFailure(err)})`)
-}
+const toError = (doing) => (err) =>
+  statusOf(err) === 404
+    ? errors.notFound(
+        `Google Books has no such book (${doing}): ${describeFailure(err)}`,
+        'no such book',
+      )
+    : errors.internal(
+        `Google Books failed while ${doing}: ${describeFailure(err)}`,
+        publicFailure('Google Books', err),
+      )

--- a/src/api/utils/external_api_adapters/films/tmdb.js
+++ b/src/api/utils/external_api_adapters/films/tmdb.js
@@ -9,7 +9,7 @@ const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const { match } = require('ts-pattern')
 const { throwIt } = require('../../general')
-const { retrying, describeFailure, statusOf } = require('../retry')
+const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
 
 const { TMDB_API_KEY } = process.env
 
@@ -74,10 +74,12 @@ module.exports = {
  * @type {(err: any) => Error}
  */
 const toError = (err) => match(statusOf(err))
-  .with(404, () => errors.notFound('tmdb'))
-  .with(401, () => errors.unauthorized('tmdb'))
-  .with(408, () => errors.internal('tmdb timed out'))
-  .otherwise(() => {
-    console.error(`tmdb failed: ${describeFailure(err)}`)
-    return errors.internal(`tmdb failed (${describeFailure(err)})`)
-  })
+  .with(404, () => errors.notFound(undefined, 'no such film'))
+  .with(401, () => errors.unauthorized(describeFailure(err), publicFailure('tmdb', err)))
+  .with(408, () => errors.internal(undefined, 'tmdb timed out'))
+  // Everything tmdb said goes to the log; the caller gets the class of the
+  // failure, which is the part that is theirs to act on. #105.
+  .otherwise(() => errors.internal(
+    `tmdb failed: ${describeFailure(err)}`,
+    publicFailure('tmdb', err),
+  ))

--- a/src/api/utils/external_api_adapters/games/igdb.js
+++ b/src/api/utils/external_api_adapters/games/igdb.js
@@ -25,7 +25,7 @@ const {
 } = require('./time_to_beat')
 const { earliestReleaseDate } = require('./release_dates')
 const { throwIt } = require('../../general')
-const { retrying, describeFailure, statusOf } = require('../retry')
+const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
 
 const { TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET } = process.env
 if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET) {
@@ -234,15 +234,22 @@ const throwNoSuchGame = (ref) => {
  * what it actually was. It used to arrive as the string "Something went
  * terribly wrong...", which told nobody anything.
  *
+ * Said twice, because the two readers want different things: the whole of it
+ * to the log, and to the caller the class of failure alone — enough to know
+ * whether trying again is worth it, and no account of our internals. #105.
+ *
  * A 404 is the exception: it is an answer rather than a failure — an id
  * IGDB doesn't hold — and telling the user their game doesn't exist beats
  * telling them igdb failed.
  * @type {(doing: string) => (err: any) => Error}
  */
-const toError = (doing) => (err) => {
-  console.error(`igdb failed while ${doing}: ${describeFailure(err)}`)
-
-  return statusOf(err) === 404
-    ? errors.notFound('igdb')
-    : errors.internal(`igdb failed while ${doing} (${describeFailure(err)})`)
-}
+const toError = (doing) => (err) =>
+  statusOf(err) === 404
+    ? errors.notFound(
+        `igdb has no such game (${doing}): ${describeFailure(err)}`,
+        'no such game',
+      )
+    : errors.internal(
+        `igdb failed while ${doing}: ${describeFailure(err)}`,
+        publicFailure('igdb', err),
+      )

--- a/src/api/utils/external_api_adapters/retry.js
+++ b/src/api/utils/external_api_adapters/retry.js
@@ -83,6 +83,37 @@ const describeFailure = (err) => {
 }
 
 /**
+ * An errno-style code — `ETIMEDOUT`, `EAI_AGAIN` — as opposed to the numbers
+ * and the free-text labels other clients also put on `code`.
+ */
+const ERRNO_CODE = /^[A-Z][A-Z0-9_]*$/
+
+/**
+ * `describeFailure` written for a stranger: what to tell the person whose
+ * search just failed, in terms that say whether trying again is worth it and
+ * nothing beyond that.
+ *
+ * The class of the failure may go out — an HTTP status, an errno-style code —
+ * because "HTTP 503" tells the caller to try again in a minute and "HTTP 401"
+ * tells them not to bother. `err.message` may not: it is free text somebody
+ * else's client library wrote, and it is where the hostnames, the urls with
+ * keys in them and the driver's account of its own internals live. See #105.
+ *
+ * @type {(who: string, err: any) => string}
+ */
+const publicFailure = (who, err) => {
+  const status = statusOf(err)
+  const failure = [
+    status === undefined ? undefined : `HTTP ${status}`,
+    ERRNO_CODE.test(err?.code) ? err.code : undefined,
+  ]
+    .filter((part) => part)
+    .join(' ')
+
+  return failure ? `${who} failed (${failure})` : `${who} failed`
+}
+
+/**
  * Calls `attempt` until it succeeds, until a failure looks permanent, or
  * until the attempts run out — whichever comes first, rethrowing the last
  * failure. `attempt` is a thunk and not a promise so that each try is a fresh
@@ -118,6 +149,7 @@ module.exports = {
   backoffMs,
   describeFailure,
   isTransient,
+  publicFailure,
   retrying,
   statusOf,
 }

--- a/src/api/utils/external_api_adapters/retry.test.js
+++ b/src/api/utils/external_api_adapters/retry.test.js
@@ -7,6 +7,7 @@ const {
   backoffMs,
   describeFailure,
   isTransient,
+  publicFailure,
   retrying,
   statusOf,
 } = require('./retry')
@@ -143,4 +144,37 @@ test('failures describe themselves rather than stringifying to {}', () => {
   assert.equal(describeFailure(networkError('ECONNRESET')), 'ECONNRESET socket hang up')
   assert.equal(describeFailure('Something terrible happened'), 'Something terrible happened')
   assert.equal(describeFailure(undefined), 'undefined')
+})
+
+test('what a stranger is told is the class of the failure and no more', () => {
+  // The status is the useful half: it says whether trying again is worth it.
+  assert.equal(publicFailure('tmdb', axiosError(503)), 'tmdb failed (HTTP 503)')
+  assert.equal(publicFailure('igdb', gotError(502)), 'igdb failed (HTTP 502)')
+  assert.equal(publicFailure('tmdb', tmdbError(429)), 'tmdb failed (HTTP 429)')
+  assert.equal(publicFailure('igdb', networkError('ETIMEDOUT')), 'igdb failed (ETIMEDOUT)')
+  // A failure that named no class at all still gets a sentence.
+  assert.equal(publicFailure('igdb', new TypeError('items is undefined')), 'igdb failed')
+  assert.equal(publicFailure('tmdb', undefined), 'tmdb failed')
+})
+
+test('nothing a client library wrote in prose reaches the caller', () => {
+  // `describeFailure` carries `err.message` because a log wants it. That is
+  // also where a url with a key in it, or a hostname, ends up — so the public
+  // description is built from the status and the code alone. #105.
+  const chatty = Object.assign(
+    new Error('connect ECONNREFUSED api.igdb.com:443 (client_id=abc123)'),
+    { code: 'ECONNREFUSED', response: { status: 500 } },
+  )
+
+  const said = publicFailure('igdb', chatty)
+
+  assert.equal(said, 'igdb failed (HTTP 500 ECONNREFUSED)')
+  assert.equal(said.includes('api.igdb.com'), false)
+  assert.equal(said.includes('abc123'), false)
+})
+
+test('a code that is not an errno is not passed on either', () => {
+  // node-themoviedb puts a `0` on `code`, and other clients put labels there.
+  assert.equal(publicFailure('tmdb', { code: 0, errorCode: 404 }), 'tmdb failed (HTTP 404)')
+  assert.equal(publicFailure('tmdb', { code: 'auth failed for user nil' }), 'tmdb failed')
 })

--- a/src/api/utils/external_api_adapters/tv_shows/tmdb.js
+++ b/src/api/utils/external_api_adapters/tv_shows/tmdb.js
@@ -13,7 +13,7 @@ const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const { match } = require('ts-pattern')
 const { throwIt } = require('../../general')
-const { retrying, describeFailure, statusOf } = require('../retry')
+const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
 
 const { TMDB_API_KEY } = process.env
 
@@ -81,10 +81,12 @@ module.exports = {
  * @type {(err: any) => Error}
  */
 const toError = (err) => match(statusOf(err))
-  .with(404, () => errors.notFound('tmdb'))
-  .with(401, () => errors.unauthorized('tmdb'))
-  .with(408, () => errors.internal('tmdb timed out'))
-  .otherwise(() => {
-    console.error(`tmdb failed: ${describeFailure(err)}`)
-    return errors.internal(`tmdb failed (${describeFailure(err)})`)
-  })
+  .with(404, () => errors.notFound(undefined, 'no such tv show'))
+  .with(401, () => errors.unauthorized(describeFailure(err), publicFailure('tmdb', err)))
+  .with(408, () => errors.internal(undefined, 'tmdb timed out'))
+  // Everything tmdb said goes to the log; the caller gets the class of the
+  // failure, which is the part that is theirs to act on. #105.
+  .otherwise(() => errors.internal(
+    `tmdb failed: ${describeFailure(err)}`,
+    publicFailure('tmdb', err),
+  ))

--- a/src/api/utils/parsers/utils.js
+++ b/src/api/utils/parsers/utils.js
@@ -7,9 +7,18 @@
 const { Result } = require('neverthrow')
 const errors = require('../errors')
 
-/** @type {<T>(parser: ZodType, x: T) => Result<T, Error>} */
+/**
+ * Zod's account of what was wrong goes to the log rather than to the caller.
+ * It names our own field layout issue by issue, and the same `validate` runs
+ * over documents read back out of the database as over request bodies — so
+ * what it has to say is not always about anything the caller sent. #105.
+ * @type {<T>(parser: ZodType, x: T) => Result<T, Error>}
+ */
 const validate = (parser, x) =>
-  Result.fromThrowable(parser.parse, (e) => errors.req(JSON.stringify(e)))(x)
+  Result.fromThrowable(
+    parser.parse,
+    (e) => errors.req(e, 'the request body is not valid'),
+  )(x)
 
 module.exports = {
   validate

--- a/src/api/utils/responses.js
+++ b/src/api/utils/responses.js
@@ -6,29 +6,75 @@
 const { match } = require('ts-pattern')
 const { safeJSONStringify, warn } = require('./general')
 
-/** @typedef {{ statusCode: number, body?: any }} Response */
+/** @typedef {{ statusCode: number, headers?: Object.<string, string>, body?: any }} Response */
 
 /** @typedef {(body?: any) => Response} ResponseCreator */
+
+/**
+ * Everything built here is JSON. Without a content type Netlify serves it as
+ * `text/plain`, and a reader deciding how to parse a body deserves to be told.
+ */
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8'
+
+/**
+ * What the caller is told when the error carries no message of its own: the
+ * class of failure and not one word more. The driver's own account of it —
+ * the hosts it tried, the topology it gave up on, the stack — is what #105 is
+ * about, and it goes to the log in `fromError` instead.
+ */
+const STOCK_MESSAGES = {
+  DBError: 'the database did not answer',
+  RequestError: 'the request could not be read',
+  UnauthorizedError: 'not authorized',
+  NotFound: 'not found',
+  InternalError: 'something went wrong',
+}
 
 /** @type {(statusCode: number) => ResponseCreator} */
 const response = (statusCode) => (body) =>
   safeJSONStringify(body).match(
-    (body) => ({ statusCode, body }),
-    (err) => (warn(err), { statusCode: 500 }),
+    (text) => asJson(statusCode, text),
+    (err) => (warn(err), asJson(500)),
   )
 
-/** @type {(error: Error) => Response} */
-const fromError = (error) => match(error.error)
-  .with('DBError', () => response(500)(error.context))
-  .with('RequestError', () => response(400)(error.context))
-  .with('UnauthorizedError', () => response(401)(error.context))
-  // A URL naming something that doesn't exist — an unknown entry type, say —
-  // is the caller's mistake, not a server fault.
-  .with('NotFound', () => response(404)(error.context))
-  .with('InternalError', () => response(500)(error.context))
-  .otherwise(() => response(500)(error.context))
+/**
+ * Reads are unauthenticated, so anyone can make a request fail and read what
+ * comes back. Everything an error knows is logged here — this is the one
+ * place an error becomes a response, so it is the one place that can promise
+ * each is accounted for exactly once — and the caller gets `message` and the
+ * name of the class, both of which are ours to publish.
+ * @type {(error: Error) => Response}
+ */
+const fromError = (error) => {
+  if (error?.detail) console.error(`${error.error}: ${error.detail}`)
 
+  const body = {
+    error: error?.error,
+    message: error?.message
+      ?? STOCK_MESSAGES[error?.error]
+      ?? STOCK_MESSAGES.InternalError,
+  }
+
+  return match(error?.error)
+    .with('DBError', () => response(500)(body))
+    .with('RequestError', () => response(400)(body))
+    .with('UnauthorizedError', () => response(401)(body))
+    // A URL naming something that doesn't exist — an unknown entry type, say —
+    // is the caller's mistake, not a server fault.
+    .with('NotFound', () => response(404)(body))
+    .with('InternalError', () => response(500)(body))
+    .otherwise(() => response(500)(body))
+}
+
+/**
+ * `fromError` is how a failure becomes a response. The bare constructors take
+ * whatever body they are given and send it, which is fine for a body written
+ * on purpose and is how an error object came to be serialised into a 500 —
+ * `internalError` has no callers left for that reason.
+ */
 module.exports = {
+  JSON_CONTENT_TYPE,
+  STOCK_MESSAGES,
   ok: response(200),
   badRequest: response(400),
   unauthorized: response(401),
@@ -37,3 +83,12 @@ module.exports = {
   internalError: response(500),
   fromError,
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+/** @type {(statusCode: number, body?: string) => Response} */
+const asJson = (statusCode, body) => ({
+  statusCode,
+  headers: { 'content-type': JSON_CONTENT_TYPE },
+  ...(body === undefined ? {} : { body }),
+})

--- a/src/api/utils/responses.test.js
+++ b/src/api/utils/responses.test.js
@@ -1,0 +1,179 @@
+/**
+ * @file What an error response says, and what it refuses to say.
+ *
+ * Reads are unauthenticated, so a stranger can make any of these happen at
+ * will and read what comes back. The rule these hold to: the class of the
+ * failure and anything the caller can act on may go out; the driver's account
+ * of itself — hosts, topology, credentials, stack — may not, and goes to the
+ * function log instead. See #105.
+ *
+ * `responses.js` pulls in ts-pattern and neverthrow, so this file **skips
+ * itself** when the dependencies aren't installed (which is how CI runs the
+ * suite), the same way name.test.js and revisions.test.js do.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('neverthrow')
+    require('ts-pattern')
+    require('ramda')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+const responses = dependenciesInstalled ? require('./responses') : undefined
+const errors = dependenciesInstalled ? require('./errors') : undefined
+const intoSafeValues = dependenciesInstalled ? require('./db/into_safe_values') : undefined
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A Mongo failure of the kind that actually reaches this code: the driver
+ * names every host it tried and dumps the topology it gave up on.
+ */
+const HOSTS = 'memo-shard-00-01.9x8y7.mongodb.net:27017'
+const topologyError = () =>
+  Object.assign(
+    new Error(
+      `Server selection timed out after 30000 ms, Topology description: ` +
+      `{ servers: { '${HOSTS}' => ServerDescription { error: MongoNetworkError } } }`
+    ),
+    { name: 'MongoServerSelectionError' },
+  )
+
+/** Runs `f` with console.error captured rather than printed. */
+const capturingLogs = async (f) => {
+  const lines = []
+  const realError = console.error
+  console.error = (line) => lines.push(String(line))
+  try {
+    return [await f(), lines]
+  } finally {
+    console.error = realError
+  }
+}
+
+const bodyOf = (response) => JSON.parse(response.body)
+
+///////////////////////////////////////////////////////////////////////////////
+
+test('a driver failure is not what the caller is handed', options, async () => {
+  const [response] = await capturingLogs(() =>
+    responses.fromError(errors.db(topologyError()))
+  )
+
+  assert.equal(response.statusCode, 500)
+  assert.equal(response.body.includes(HOSTS), false)
+  assert.equal(response.body.includes('Topology'), false)
+  assert.equal(response.body.includes('MongoServerSelectionError'), false)
+  assert.deepEqual(bodyOf(response), {
+    error: 'DBError',
+    message: responses.STOCK_MESSAGES.DBError,
+  })
+})
+
+test('the same failure is written to the log in full', options, async () => {
+  const [, lines] = await capturingLogs(() =>
+    responses.fromError(errors.db(topologyError()))
+  )
+
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].includes(HOSTS), true)
+  assert.equal(lines[0].startsWith('DBError:'), true)
+})
+
+test('the careless single-argument call publishes nothing', options, async () => {
+  // `.mapErr(errors.internal)` and `errors.db(err)` are how a caught exception
+  // gets into an error, so the first parameter is the one that stays inside.
+  const [response] = await capturingLogs(() =>
+    responses.fromError(errors.internal(topologyError()))
+  )
+
+  assert.equal(response.body.includes(HOSTS), false)
+  assert.equal(bodyOf(response).message, responses.STOCK_MESSAGES.InternalError)
+})
+
+test('a message meant for the caller is sent as written', options, async () => {
+  const [response] = await capturingLogs(() =>
+    responses.fromError(errors.notFound(topologyError(), 'no such game'))
+  )
+
+  assert.equal(response.statusCode, 404)
+  assert.deepEqual(bodyOf(response), { error: 'NotFound', message: 'no such game' })
+  assert.equal(response.body.includes(HOSTS), false)
+})
+
+test('an error with nothing to log is not logged', options, async () => {
+  const [response, lines] = await capturingLogs(() =>
+    responses.fromError(errors.notFound(undefined, 'no such tv show'))
+  )
+
+  assert.deepEqual(lines, [])
+  assert.equal(bodyOf(response).message, 'no such tv show')
+})
+
+test('each class of error keeps its status', options, async () => {
+  const statusOf = async (error) =>
+    (await capturingLogs(() => responses.fromError(error)))[0].statusCode
+
+  assert.equal(await statusOf(errors.db()), 500)
+  assert.equal(await statusOf(errors.req()), 400)
+  assert.equal(await statusOf(errors.unauthorized()), 401)
+  assert.equal(await statusOf(errors.notFound()), 404)
+  assert.equal(await statusOf(errors.internal()), 500)
+  assert.equal(await statusOf({ error: 'SomethingNew' }), 500)
+})
+
+test('an unrecognised error still says something', options, async () => {
+  const [response] = await capturingLogs(() =>
+    responses.fromError({ error: 'SomethingNew' })
+  )
+
+  assert.equal(bodyOf(response).message, responses.STOCK_MESSAGES.InternalError)
+})
+
+test('every response says how to read its body', options, () => {
+  const contentType = (response) => response.headers['content-type']
+
+  assert.equal(contentType(responses.ok({ username: 'nil' })), responses.JSON_CONTENT_TYPE)
+  assert.equal(contentType(responses.notFound()), responses.JSON_CONTENT_TYPE)
+  assert.equal(contentType(responses.payloadTooLarge({ error: 'too big' })), responses.JSON_CONTENT_TYPE)
+})
+
+test('a body that cannot be stringified is a 500 and not a crash', options, () => {
+  const circular = {}
+  circular.self = circular
+
+  const response = responses.ok(circular)
+
+  assert.equal(response.statusCode, 500)
+  assert.equal(response.body, undefined)
+})
+
+test('a rejected query answers without quoting the driver', options, async () => {
+  const [response, lines] = await capturingLogs(() =>
+    intoSafeValues.toResponse(Promise.reject(topologyError()))
+  )
+
+  assert.equal(response.statusCode, 500)
+  assert.equal(response.body.includes(HOSTS), false)
+  assert.equal(lines.some((line) => line.includes(HOSTS)), true)
+})
+
+test('a query rejecting with a 4xx keeps its status', options, async () => {
+  const notFound = Object.assign(new Error('nothing there'), { name: 'NotFound' })
+
+  const [response] = await capturingLogs(() =>
+    intoSafeValues.toResponse(Promise.reject(notFound))
+  )
+
+  assert.equal(response.statusCode, 404)
+})


### PR DESCRIPTION
Error responses handed the caller whatever the driver said. `errors.js` stringified its argument into `context` and `responses.fromError` sent that `context` as the body, and `toResult` wires every database rejection through `errors.db` — so a Mongo failure, a topology description naming each host in the replica set, an auth failure, a timeout, was serialised into a public 500. Reads are unauthenticated, so anyone could collect them by making requests fail.

An error now carries two fields written for two different readers. `detail` is whatever we have in hand — a driver exception and its stack, a validation dump — and `fromError` writes it to `console.error`, where Netlify's function log already collects it. `message` is the one line the caller is told, and it only exists when there is something worth telling them; `fromError` falls back to a stock message for the class of error otherwise. The body is now `{ error, message }` at a stable shape; nothing on the frontend read these bodies (`Http.makeRequest` maps a failed request to its status code and drops the body), so nothing there changes.

**`detail` is the first parameter and `message` the second**, which is the decision most worth arguing with. It is the other way round from how these read, but it means the careless call — `.mapErr(errors.db)`, `errors.internal(err)`, which is exactly how the leak got in — puts what it was handed in the slot that never leaves the building. Publishing has to be deliberate.

The adapters say it twice, since what they know is genuinely useful to the person adding a game and much less useful pointed at the internet. The whole failure goes to the log; the caller gets the class of it alone, from `publicFailure` in `retry.js` — the companion to `describeFailure`, and the one place the policy lives. A status and an errno-style code may go out, because "HTTP 503" tells the caller to try again in a minute and "HTTP 401" tells them not to bother. `err.message` may not: it is free text somebody else's client library wrote, and it is where the hostnames and the urls with keys in them live. A 404 stays an answer rather than a failure and says "no such game" / "no such book" / "no such film".

Two call sites were building a 500 out of the error object itself rather than going through `fromError` (`entries.js`, `export.js`); both now go through it, and `responses.internalError` has no callers left as a result. It is still exported — a sibling branch may want it — but a 500 body should come from `fromError` from here on.

Folded in, from the same issue:

- `getUserFromName` and `getUserIdFromName` answered with the whole `users` document, `userId` — the auth0 `sub` — included. Both now project to what the frontend reads: `{ username, biography }` for the profile page, `{ username }` for the list page, which only checks whether an answer came back at all. A name nobody has taken still answers 200 with an empty body, which is what both pages turn into their own 404. `getUserIdFromName` no longer returns an id and hasn't for a while; renaming it would reach into the frontend, so it kept its name.
- `responses.response` now sets `application/json; charset=utf-8`. `export.js` still stringifies its own body, because the 6 MB budget has to weigh it before it is sent and a `Response` doesn't say how big it is, and because that route adds a CORS header the default constructors have no business setting; what it no longer does is repeat the content-type literal. The `text/markdown` path and the 413 are untouched apart from the 413 now carrying the JSON content type it always should have.
- Zod's account of a bad body no longer goes out either. That one costs the caller something real — it named which field was wrong — but the same `validate` runs over documents read back out of the database as over request bodies, so what it has to say is not reliably about anything the caller sent. It is in the log.

`responses.js` pulls in `ts-pattern`, so `responses.test.js` follows the convention `name.test.js` and `revisions.test.js` already use and skips itself when the dependencies aren't installed. The parts that can run everywhere do: `publicFailure` is dependency-free, so its tests — including a failure whose message carries a hostname and an api key — run in CI with the rest.

`npm test` is 248 passing, 0 failing: 27 skipped without an install, none skipped against a local `npm ci`. `git ls-files '*.js' | xargs -n1 node --check` is clean.

Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
