### PR TITLE
fix: stop every page requesting a stylesheet the build never emits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # build artefacts
 /dist
-/src/site/_includes/css
 
 # db_maintenance backups and reports
 /src/db_maintenance/backups

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -25,7 +25,6 @@
     {# 1.12.1, matching the bootstrap-table script below. #}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.css" integrity="sha384-HyusOcKCYSnjwC8jY4YvjZAwLgeqDPWFDu2/AFf5OrZd7ykufk0gwxexoqmg5W8N" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
-    <link rel="stylesheet" href="/css/main.css">
     <style>
         {% include "css/main.css" %}
     </style>


### PR DESCRIPTION
The base layout carried both a `<link rel="stylesheet" href="/css/main.css">` and a `<style>` block inlining the same file. Only the second one does anything: `.eleventy.js` passes through `./src/frontend/img` and `./_redirects` and nothing else, and `templateFormats` is `['njk', 'md', '11ty.js']`, so `src/frontend/_includes/css/main.css` is read as a Nunjucks include and never copied into the output. The `<link>` resolved to a path no build step writes, and every page load spent a request on a 404 before rendering. This deletes the `<link>` and keeps the inline `<style>`, which is the status quo minus the 404.

Issue #103 also floats the better end state — `addPassthroughCopy` the CSS to `/css/` and drop the inline block, so the stylesheet is cacheable instead of re-sent with every HTML response. That is deliberately not done here: it is the same change in shape as #110, where the 140 KB JS bundle is inlined into every page for the same reason, and the two assets should move out of the HTML together in one PR rather than half now and half later.

Also drops the `.gitignore` entry for `/src/site/_includes/css`, a path that has not existed since the frontend moved to `src/frontend`.

Verified with `npm run build`: the built `dist/index.html` no longer mentions `/css/main.css` and still carries the rules from `main.css` inline (`.collapsible`, `.cover-tooltip`, `.detail-view`, `.mini-thumb`, `.is-collapsed` all present). `npm test` passes, 276 tests.

Closes #103
