### PR TITLE
fix: make the list's title sort actually sort by title

### DIFF
--- a/src/frontend/_includes/js/components/list/list.js
+++ b/src/frontend/_includes/js/components/list/list.js
@@ -26,11 +26,7 @@ const List = ({ username, entryType, entries, isOwner }) => initComponent({
             component: (entries) => SubLists(
               entryType,
               isOwner,
-              [...entries]
-                .sort((a, b) =>
-                  a.commonMetadata.englishTranslatedTitle
-                    - b.commonMetadata.englishTranslatedTitle
-                )
+              entries
                 .map((entry) => ({
                   ...entry,
                   originalData: entry.commonMetadata,
@@ -42,6 +38,7 @@ const List = ({ username, entryType, entries, isOwner }) => initComponent({
                     ),
                   },
                 }))
+                .sort(byEnglishTitle)
             )}))}
       </div>
     </div>
@@ -285,6 +282,24 @@ const toStats = (entries, entryType) => {
 
   return `Total entries: ${entries.length}${entryType === 'tv' ? ` ${icon} Episodes seen: ${totalEpsSeen}` : ''} ${icon} Days spent: ${days.toFixed(2)} ${icon} Mean score: ${meanScore.toFixed(2)}`
 }
+
+/**
+ * Alphabetical by title, matching `byStatusThenScoreThenTitle` in
+ * `api/utils/export_view.js`. bootstrap-table re-sorts each sublist on score
+ * and its sort is stable, so this decides the order within a score — which in
+ * the Planned sublist is the whole of it, since the score column there is a
+ * preference almost nothing carries. It runs after the overrides are merged so
+ * that it sorts on the title the Title column actually shows.
+ *
+ * Subtracting one title from another, as this used to, is `NaN` for every
+ * pair; `sort` reads that as "these two are fine as they are" and leaves the
+ * array in the order the API returned it, i.e. most recently edited first.
+ * @type {(a: object, b: object) => number}
+ */
+const byEnglishTitle = (a, b) =>
+  // An entry can have no work, and a work can have no title.
+  String(get(a, 'englishTranslatedTitle') ?? '')
+    .localeCompare(String(get(b, 'englishTranslatedTitle') ?? ''))
 
 const get = (entry, prop) =>
   entry.commonMetadata?.[prop]

--- a/src/frontend/_includes/js/components/list/list.test.js
+++ b/src/frontend/_includes/js/components/list/list.test.js
@@ -1,0 +1,70 @@
+/**
+ * @file The frontend scripts are plain globals concatenated into a bundle
+ * rather than modules, so this loads list.js into a vm context with the
+ * globals it expects and pulls the comparator out of the script's scope.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "list.js"), "utf8");
+
+// None of these is exercised: list.js destructures them at load time and
+// assigns itself into `Components.List`, but every component that reads them
+// stays unrendered here. So they only have to exist, and the two that are
+// reached into have to be objects.
+const context = vm.createContext({
+  Utils: {},
+  Tables: {},
+  Conversions: {},
+  Components: { UI: {}, List: {} },
+});
+
+// base.njk wraps each included file in its own IIFE, which is what keeps two
+// files' `const`s from colliding. Loading it the same way here keeps that
+// difference visible.
+const { byEnglishTitle } = vm.runInContext(
+  `(() => {\n${source}\n;return ({ byEnglishTitle })\n})()`,
+  context
+);
+
+/** An entry as the sort sees it: overrides already merged into the metadata. */
+const entry = (englishTranslatedTitle) => ({
+  commonMetadata:
+    englishTranslatedTitle === undefined ? {} : { englishTranslatedTitle },
+});
+
+const sorted = (...titles) =>
+  titles
+    .map(entry)
+    .sort(byEnglishTitle)
+    .map((e) => e.commonMetadata.englishTranslatedTitle);
+
+test("a list comes out alphabetical rather than in the order it arrived", () => {
+  // The order the entries endpoint returns is `updatedDate` descending, so
+  // the input here is exactly what the old subtraction left untouched.
+  assert.deepEqual(
+    sorted("Perfect Blue", "Akira", "Blade Runner"),
+    ["Akira", "Blade Runner", "Perfect Blue"]
+  );
+});
+
+test("it compares as a reader would, not by code point", () => {
+  // `'a' < 'B'` is false and `'É' < 'Z'` is false, so both of these come out
+  // backwards from a naive `<`.
+  assert.deepEqual(sorted("Blade Runner", "akira"), ["akira", "Blade Runner"]);
+  assert.deepEqual(sorted("Zodiac", "Éclair"), ["Éclair", "Zodiac"]);
+});
+
+test("an entry whose work is missing its title sorts first, not off a cliff", () => {
+  assert.deepEqual(sorted("Akira", undefined), [undefined, "Akira"]);
+  assert.equal(byEnglishTitle({}, {}), 0);
+  assert.equal(byEnglishTitle({}, entry("Akira")) < 0, true);
+  assert.equal(byEnglishTitle(entry("Akira"), {}) > 0, true);
+});
+
+test("equal titles compare equal, so the sort stays stable across them", () => {
+  assert.equal(byEnglishTitle(entry("Akira"), entry("Akira")), 0);
+});


### PR DESCRIPTION
`List` sorted its entries with `a.commonMetadata.englishTranslatedTitle - b.commonMetadata.englishTranslatedTitle`. Subtracting two strings is `NaN`, the comparator returned `NaN` for every pair, and `Array.prototype.sort` reads `NaN` as "these two are fine as they are" — so the array came back out in the order the entries endpoint returned it, which is `updatedDate` descending. Closes #101.

**Kept rather than deleted.** The issue notes this is invisible because bootstrap-table re-sorts on `score`, and that is true for the sublists where entries have scores — there it only breaks ties. But `Columns.score(status)` renders as *Preference* for `Planned`, and almost nothing in a Planned list carries one. Every row in that sublist is therefore tied on the sort key, bootstrap-table's sort is stable, and the input order is the whole of the visible order. A list of things to watch was showing most-recently-edited first, which is not an order anyone asked for. That is enough to make it real code rather than dead code, so it is now real.

**Also moved after the override merge.** `englishTranslatedTitle` is one of the fields an owner can override (`Input('Title', 'title', 'englishTranslatedTitle')` in `add_edit_entry/external_fields.js`), and `titleFormatter` renders the merged value. Sorting before the merge filed a renamed entry under a title that appears nowhere on the page. The `.sort()` now runs on the mapped array, which also makes the defensive `[...entries]` copy redundant — `.map()` already returns a fresh array, so nothing mutates the caller's.

The comparator itself is `localeCompare` with empty-string fallbacks, matching `byStatusThenScoreThenTitle` in `src/api/utils/export_view.js`. The fallbacks cover an entry whose work is missing, per the fix in #96, and `localeCompare` rather than `<` means `akira` sorts before `Blade Runner` and `Éclair` before `Zodiac` — both of which come out backwards under a code-point compare.

Nothing downstream of the sort depends on input order: `toStats` only sums and counts, `Rows.byRef` is keyed by a `dbRef` that is unique across the page, and `initTable` hands the rows straight to bootstrap-table.

`byEnglishTitle` is a named top-level const so it can be tested. `list.test.js` loads `list.js` into a vm with stubs for the globals it destructures, the same way `utils/columns.test.js` does, and covers the alphabetical order, the code-point cases, a missing title, and an equal pair.

- `npm test` — 280 tests, 0 failures, 27 skipped (the ones needing dependencies).
- `git ls-files '*.js' | xargs -n1 node --check` — clean.
