### PR TITLE
fix: draw the score chart against all eleven buckets

### DIFF
--- a/src/frontend/_includes/js/components/profile/profile_stats.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.js
@@ -120,32 +120,29 @@ const GlobalStats = (stats) => initComponent({
   `
 })
 
-// This is convoluted as heck.
-// Is there a better way? lol.
+// The buckets `getTallyOfScore` counts, in the order the chart draws them —
+// top bar first. The bars and their labels are both derived from this one
+// list, because a hand-written pair of arrays drifted apart once already:
+// score 1 was missing from the data, so ApexCharts drew the unrated tally
+// against the label `1`.
+const BUCKETS = ['10', '9', '8', '7', '6', '5', '4', '3', '2', '1', 'unrated']
+
+// A tally the user has none of can be a missing key rather than a zero, so
+// every read of a bucket defaults.
 const aggregateStats = (stats) =>
-  Object.values(stats.scores)
-    .reduce((scores, current) =>
-      Object.fromEntries(
-        Object.entries(scores)
-          .map(([rating, tally]) => [rating, tally + current[rating]])
-      ))
+  Object.fromEntries(
+    BUCKETS.map((bucket) => [
+      bucket,
+      Object.values(stats.scores)
+        .reduce((tally, scoresOfType) => tally + (scoresOfType[bucket] ?? 0), 0)
+    ])
+  )
 
 
 const toChartOptions = (relevantStats) => ({
   series: [{
     name: `Scores`,
-    data: [
-      relevantStats['10'],
-      relevantStats['9'],
-      relevantStats['8'],
-      relevantStats['7'],
-      relevantStats['6'],
-      relevantStats['5'],
-      relevantStats['4'],
-      relevantStats['3'],
-      relevantStats['2'],
-      relevantStats['unrated'],
-    ]
+    data: BUCKETS.map((bucket) => relevantStats[bucket] ?? 0)
   }],
   chart: {
     type: 'bar',
@@ -161,7 +158,7 @@ const toChartOptions = (relevantStats) => ({
     enabled: false
   },
   xaxis: {
-    categories: ['10', '9', '8', '7', '6', '5', '4', '3', '2', '1', 'Unrated' ],
+    categories: BUCKETS.map((bucket) => bucket === 'unrated' ? 'Unrated' : bucket),
   }
 })
 

--- a/src/frontend/_includes/js/components/profile/profile_stats.test.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.test.js
@@ -1,0 +1,130 @@
+/**
+ * @file The frontend scripts are plain globals concatenated into a bundle
+ * rather than modules, so this loads profile_stats.js into a vm context with
+ * the globals it expects and pulls the chart builders out of the script's
+ * scope — the same trick as utils/columns.test.js.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "profile_stats.js"), "utf8");
+
+// Stubs, not the real thing: nothing under test renders any markup or talks to
+// Netlify. They exist because the file destructures all of these at load time,
+// and because its last line writes itself onto `Components.Profile`.
+//
+// base.njk wraps each included file in its own IIFE, which is what keeps two
+// files' `const`s from colliding and what makes an assignment with no keyword
+// the only thing that crosses between them. Loading it the same way here keeps
+// that difference visible.
+const context = vm.createContext({
+  Netlify: { entryTypes: [], getStats: () => {} },
+  Tables: { col: () => {} },
+  Conversions: { typeToTitle: {} },
+  Utils: { html: () => "", css: () => "" },
+  Components: {
+    initComponent: () => {},
+    WithRemoteData: () => {},
+    UI: { Tabbed: () => {} },
+    Profile: {},
+  },
+});
+
+const { BUCKETS, toChartOptions, aggregateStats } = vm.runInContext(
+  `(() => {\n${source}\n;return ({ BUCKETS, toChartOptions, aggregateStats })\n})()`,
+  context
+);
+
+/** A full tally, one entry in each bucket, so a dropped bucket is visible. */
+const oneOfEach = () =>
+  Object.fromEntries(BUCKETS.map((bucket) => [bucket, 1]));
+
+// Everything the script returns was built inside the vm's realm, against that
+// realm's `Object` and `Array`. A strict deepEqual compares prototypes, so the
+// results are copied back into this one before being asserted on.
+const categories = (stats) => [...toChartOptions(stats).xaxis.categories];
+const data = (stats) => [...toChartOptions(stats).series[0].data];
+const totals = (stats) => ({ ...aggregateStats(stats) });
+
+test("every bar has a label and every label has a bar", () => {
+  // The bug: ten data points against eleven categories. ApexCharts pairs them
+  // by index, so one short at the front slides every later bar under the wrong
+  // label.
+  const options = toChartOptions(oneOfEach());
+  assert.equal(
+    options.series[0].data.length,
+    options.xaxis.categories.length
+  );
+  assert.equal(options.xaxis.categories.length, 11);
+});
+
+test("scores run 10 down to 1, with unrated last", () => {
+  assert.deepEqual(
+    categories(oneOfEach()),
+    ["10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "Unrated"]
+  );
+});
+
+test("a score of 1 reaches the chart", () => {
+  // It was never read at all: entries scored 1 simply weren't drawn.
+  const stats = { ...oneOfEach(), 1: 7 };
+  assert.equal(data(stats)[categories(stats).indexOf("1")], 7);
+});
+
+test("the unrated tally is drawn under Unrated, not under 1", () => {
+  const stats = { ...oneOfEach(), unrated: 42 };
+  const drawn = data(stats);
+  assert.equal(drawn[categories(stats).indexOf("Unrated")], 42);
+  assert.equal(drawn[categories(stats).indexOf("1")], 1);
+  assert.equal(drawn.at(-1), 42);
+});
+
+test("a bucket the user has none of is a zero bar, not a hole", () => {
+  // The tally the API stores has all eleven keys, but a stats document written
+  // before a bucket existed — or an empty one — may not, and `undefined` in a
+  // series makes ApexCharts skip the bar and shift nothing, which is how this
+  // stays invisible.
+  assert.deepEqual(data({}), new Array(11).fill(0));
+  assert.deepEqual(
+    data({ 10: 3, unrated: 2 }),
+    [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]
+  );
+});
+
+///////////////////////////////////////////////////////////////////////////////
+// The global chart is fed from aggregateStats rather than from a tally the API
+// wrote, so it has to hold the same shape.
+
+const scoresOf = (...types) => ({
+  scores: Object.fromEntries(types.map((tally, i) => [i, tally])),
+});
+
+test("the global tally sums each bucket across the four types", () => {
+  const summed = totals(
+    scoresOf(oneOfEach(), oneOfEach(), oneOfEach(), oneOfEach())
+  );
+  assert.deepEqual(summed, Object.fromEntries(BUCKETS.map((b) => [b, 4])));
+});
+
+test("a type missing a bucket does not turn the total into NaN", () => {
+  const summed = totals(scoresOf(oneOfEach(), { 10: 2 }, {}, {}));
+  assert.equal(summed["10"], 3);
+  assert.equal(summed["1"], 1);
+  assert.equal(summed["unrated"], 1);
+  assert.ok(
+    Object.values(summed).every(Number.isFinite),
+    `NaN in the global tally: ${JSON.stringify(summed)}`
+  );
+});
+
+test("the global tally keeps all eleven buckets whatever it was given", () => {
+  // It used to take its keys from whichever type came first, so a type missing
+  // a bucket dropped that bucket from the chart entirely.
+  assert.deepEqual(
+    Object.keys(totals(scoresOf({}, {}, {}, {}))).sort(),
+    [...BUCKETS].sort()
+  );
+});


### PR DESCRIPTION
Closes #100.

The profile score histogram drew ten bars against eleven labels. `relevantStats['1']` was never read, so entries scored 1 were missing from the chart entirely, and since ApexCharts pairs `data[i]` with `categories[i]`, the unrated tally landed at index 9 and was drawn under the label **1**. Every profile has been reporting its unrated count as a pile of 1/10s.

`toChartOptions` now derives the series and the axis labels from one ordered `BUCKETS` list, rather than from two hand-written arrays that have to be kept in step. That is the part worth arguing with — the alternative was to insert the missing `relevantStats['1']` and leave the shape alone, which is a smaller diff but leaves the same trap set for the next bucket anyone adds.

Every bucket is read with `?? 0`. The tally the API writes has all eleven keys, but an empty or older stats document may not, and `undefined` in an ApexCharts series skips the bar without shifting anything after it — which is how a gap here stays invisible.

`aggregateStats`, which feeds the global chart, had the same hazard from the other direction: it took its keys from whichever type came first and summed with `tally + current[rating]`, so a type missing a bucket either dropped that bucket from the chart or turned the total into `NaN`. It now sums over `BUCKETS` with the same default, which also retires the "convoluted as heck" comment above it.

The backend was already correct — `getTallyOfScore` counts 1 through 10 plus `unrated`, and `AdditionalStats` below the chart reads the same object correctly, which is why the mean and stdev printed under a wrong-looking chart were right. Nothing there is touched.

## Tests

This file is a component in the shared global scope rather than a module, so `profile_stats.test.js` loads it into a `vm` context with stubs for the globals it destructures and pulls the builders out of the script's scope — the same trick `utils/columns.test.js` already uses, no restructure needed. One wrinkle worth knowing about: values built inside the vm carry that realm's prototypes, so a strict `deepEqual` rejects them, and the helpers copy results back across the boundary before asserting.

The guard that was missing:

- `data.length === categories.length`, and both are 11
- the labels run `10` down to `1` with `Unrated` last
- a score of 1 reaches the chart, and the unrated tally sits under `Unrated`, not under `1`
- a missing bucket is a zero bar rather than a hole
- `aggregateStats` sums across the four types, keeps all eleven buckets, and survives a type missing a bucket without producing `NaN`

`npm test`: 257 passing, 0 failing, 27 skipped. `git ls-files '*.js' | xargs -n1 node --check` is clean.
