### PR TITLE
fix: make the deploy config say what it actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ If you use `npx netlify dev` your serverless functions will also be available at
 GET http://localhost:8888/.netlify/functions/<function_file_name_without_extension>
 ```
 
+Netlify Dev serves the site on 8888 and proxies to Eleventy on 8093, the
+`targetPort` in `netlify.toml`. The `dev` script passes a matching `--port`;
+without it Eleventy takes its default of 8080 and `npx netlify dev` waits on
+8093 forever.
+
 **2. Deploying.** `main` is the only long-lived branch. Netlify publishes nil.moe from `main`
 automatically on every push, so there is no separate staging or production branch and no manual
 promotion step.
@@ -35,6 +40,11 @@ We use:
 
 - [Netlify](https://www.netlify.com) for web hosting and deployment
 - [Node and NPM](https://nodejs.org) for runtime environment and package management
+  — `NODE_VERSION` in `netlify.toml` pins the build to Node 22 across every
+  deploy context, and CI runs the same version. Netlify derives the functions
+  runtime from the build's Node version, so the two move together.
+  `AWS_LAMBDA_JS_RUNTIME` overrides the functions runtime, but only when set
+  from the Netlify UI — it is ignored in `netlify.toml`.
 - [Eleventy](https://11ty.io) for static site generation
 - A tiny inline JS pipeline with a [component-based architecture](https://medium.com/@dan.shapiro1210/understanding-component-based-architecture-3ff48ec0c238)
 - Serverless (FaaS) development pipeline with [Netlify Dev](https://www.netlify.com/products/dev) and [Netlify Functions](https://www.netlify.com/products/functions)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,21 +1,25 @@
 [build]
   command = "npm run build"
   publish = "dist"
-  NODE_ENV = "18.15.0"
+
+[build.environment]
+  # Applies to every deploy context at once — production, deploy preview and
+  # branch deploy alike. The per-context blocks this replaces covered the first
+  # two and left a branch deploy on whatever default Netlify happened to ship.
+  #
+  # This also picks the functions runtime, which Netlify derives from the
+  # build's Node version. AWS_LAMBDA_JS_RUNTIME overrides that, but only when
+  # set from the Netlify UI, CLI or API: Netlify does not read it from this
+  # file, so the nodejs18.x lines that used to sit here never applied.
+  # https://docs.netlify.com/build/functions/optional-configuration/
+  # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+  NODE_VERSION = "22"
 
 [functions]
   directory = "src/api/routes"
 
 [dev]
   command = "npm run start"
+  # Netlify Dev waits for this port specifically, so the `dev` script passes a
+  # matching `--port` rather than leaving Eleventy on its default of 8080.
   targetPort = 8093
-
-[context.production.environment]
-# https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
-# https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
-NODE_VERSION = "18"
-AWS_LAMBDA_JS_RUNTIME = "nodejs18.x"
-
-[context.deploy-preview.environment]
-NODE_VERSION = "18"
-AWS_LAMBDA_JS_RUNTIME = "nodejs18.x"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "start": "npm run dev",
-    "dev": "cross-env ELEVENTY_ENV=dev eleventy --serve",
+    "dev": "cross-env ELEVENTY_ENV=dev eleventy --serve --port=8093",
     "build": "cross-env ELEVENTY_ENV=prod eleventy",
     "test": "node --test"
   },


### PR DESCRIPTION
Closes #114.

## Two inert keys, not one

The issue caught `NODE_ENV = "18.15.0"` sitting directly under `[build]`, which takes only `command`, `publish`, `base`, `functions`, `environment` and `ignore` — so the line did nothing, and it held a version string in a variable that means `development`/`production`. Fixing it turned up a second key of exactly the same kind: `AWS_LAMBDA_JS_RUNTIME` is not read from a config file either. [Netlify's docs](https://docs.netlify.com/build/functions/optional-configuration/) are explicit that it "must be set using the Netlify UI, CLI, or API, and not with a Netlify configuration file (`netlify.toml`)". So the `nodejs18.x` pin in the two `[context.*.environment]` blocks never applied.

That changes the shape of the problem the issue described. The only key that was doing anything was `NODE_VERSION = "18"`, and `context.branch-deploy` had no block at all. Netlify derives the functions runtime from the build's Node version and falls back to its own default when that version is a Lambda runtime already deprecated — and `nodejs18.x` was deprecated on 1 September 2025. So production was not running Node 18 because the file asked for it; it was running whatever Netlify fell back to, and the file's claim was decorative.

## Which Node, and why 22

The issue suggested moving the functions to 20 or 22. Node 20 is no longer available: its Lambda runtime was [deprecated on 30 April 2026](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). That leaves 22 (deprecates April 2027) or 24 (April 2028), and 22 is what CI already tests on, so it closes the gap without moving CI at the same time.

A single `NODE_VERSION = "22"` in `[build.environment]` replaces both `[context.*.environment]` blocks. It covers every context at once, which fixes the branch-deploy gap in the same stroke, and because Netlify derives the functions runtime from it, the build and the functions now move together instead of being pinned in two places that disagreed. I removed the `AWS_LAMBDA_JS_RUNTIME` lines rather than leaving keys that do nothing, and left a comment recording where that variable actually has to be set so the knowledge isn't lost with them.

I took the upgrade rather than the fall-back option of pinning CI to 18 and filing a follow-up. Pinning CI at 18 would have matched CI to a version production demonstrably does not run, and would have put the test suite on an EOL runtime to do it.

## The dev port

`npx netlify dev` connects neither by luck nor by configuration — it does not connect. With the old config it prints `Waiting for framework port 8093` and hangs there while Eleventy binds 8080, which I reproduced locally. The `dev` script now passes `--port=8093`, writing the port down where Eleventy reads it and keeping `netlify.toml` as the one place the number appears. After the change the same run reports the port wait resolving, `Server now ready on http://localhost:8888`, and pages served through the proxy.

One correction to the docs on this: they say `command` plus `targetPort` requires `framework = "#custom"`, but netlify-cli 17.16.1 accepted the config without it, reporting `Starting Netlify Dev with custom config`. I have not added the key, since the port mismatch was the entire bug.

## What resolved itself rather than being fixed

The branch half of the issue is now moot through the remote cleanup, not through any change here. The `staging` and `production` branches that contradicted the README belonged to the old fork remote; `git branch -r` now shows `origin` carrying only `main` plus in-flight PR branches. So the README's "`main` is the only long-lived branch" is simply true, and I confirmed it rather than editing it. `.github/workflows/ci.yml` is unchanged for the same reason — `on: push: branches: [main]` is correct now that `main` is the only branch, `node-version` was already 22, and `pull_request:` still carries no filter, so PR coverage is untouched.

The README changes are the two things that were genuinely undocumented: the dev port and the proxy, and which Node version applies where, including the `AWS_LAMBDA_JS_RUNTIME` trap.

## Verification

`npm test` passes (280 tests, 0 failures) and every tracked `.js` file passes `node --check`, both after rebasing onto current `main`. `ci.yml` still parses as YAML, and `netlify.toml` is parsed by netlify-cli itself in the run above, which logs `Injected netlify.toml file env var: NODE_VERSION` — so the new `[build.environment]` block is read. `npm run build` succeeds on Node 24 locally, and CI covers 22.

**The deploy itself is not verified and needs watching on the next push to `main`.** I have no access to the Netlify dashboard, so two things are worth a glance there. First, if `AWS_LAMBDA_JS_RUNTIME` was ever set as a real UI environment variable it still overrides everything here, and it should be either cleared or set to `nodejs22.x` to agree with the build. Second, this is the first deploy where a branch deploy gets an explicit Node version at all, so that context is the one most likely to behave differently from before — differently meaning *defined*, where it previously took Netlify's shifting default.
