### PR TITLE
refactor: one table for the type/collection mapping, not seven

### DIFF
--- a/src/api/controllers/reviews.js
+++ b/src/api/controllers/reviews.js
@@ -3,18 +3,14 @@
 const { getSegment } = require('./utils')
 const responses = require('../utils/responses')
 const db = require('../utils/db/')
+const workTypes = require('../utils/work_types')
 
 /** @type {(event: Event) => Promise<Response>} */
 const getReview = async (event) => {
   const entryType = getSegment(0, event)
   const entryId = getSegment(1, event)
 
-  const collection = {
-    films: 'filmReviews',
-    books: 'bookReviews',
-    tv: 'tvShowReviews',
-    games: 'gameReviews',
-  }[entryType]
+  const collection = workTypes.byType(entryType)?.reviews
 
   return collection != null
     ? db.findOneByField(collection, 'entryRef', entryId)

--- a/src/api/controllers/utils.js
+++ b/src/api/controllers/utils.js
@@ -3,9 +3,9 @@
 /** @typedef {import('../errors').Error} Error */
 /** @typedef {import('../utils/parsers').ValidCollection} ValidCollection */
 const { Result, ResultAsync, err, ok } = require('neverthrow')
-const { match } = require('ts-pattern')
 const errors = require('../utils/errors')
 const db = require('../utils/db')
+const workTypes = require('../utils/work_types')
 const { validateExists } = require('../utils/general')
 const { JWT } = require("jose")
 
@@ -40,28 +40,23 @@ const findIdOfName = (name) =>
     .map(result => result?.data?.userId)
 
 /**
- * The `:type` URL segment every entry-scoped route starts with.
+ * The `:type` URL segment every entry-scoped route starts with. A segment
+ * naming no type is a 404 here rather than an `undefined` collection that
+ * fails somewhere in the driver.
  * @type {(segment: string) => Result<ValidCollection, Error>}
  */
-const toEntryCollection = (segment) =>
-  match(segment)
-    .with('films', () => ok('filmEntries'))
-    .with('books', () => ok('bookEntries'))
-    .with('tv', () => ok('tvShowEntries'))
-    .with('games', () => ok('gameEntries'))
-    .otherwise(() => err(errors.notFound()))
+const toEntryCollection = (segment) => {
+  const workType = workTypes.byType(segment)
+  return workType ? ok(workType.entries) : err(errors.notFound())
+}
 
 /**
  * The inverse of toEntryCollection, for the code that has a collection in
  * hand rather than a URL.
  * @type {(entryCollection: ValidCollection) => string | undefined}
  */
-const toEntryType = (entryCollection) => ({
-  filmEntries: 'films',
-  bookEntries: 'books',
-  tvShowEntries: 'tv',
-  gameEntries: 'games',
-}[entryCollection])
+const toEntryType = (entryCollection) =>
+  workTypes.byEntryCollection(entryCollection)?.type
 
 /**
  * An entry's review lives in the collection of the same name, with
@@ -69,7 +64,7 @@ const toEntryType = (entryCollection) => ({
  * @type {(entryCollection: ValidCollection) => ValidCollection}
  */
 const toReviewCollection = (entryCollection) =>
-  /** @type any */ (entryCollection.replace('Entries', 'Reviews'))
+  /** @type any */ (workTypes.byEntryCollection(entryCollection)?.reviews)
 
 module.exports = {
   getUserId,

--- a/src/api/controllers/works.js
+++ b/src/api/controllers/works.js
@@ -5,11 +5,11 @@
 const { toPromise } = require('../utils/general')
 const { getUrlSegments } = require('./utils')
 const { Result, ok, err, ResultAsync, okAsync } = require('neverthrow')
-const { match } = require('ts-pattern')
 const errors = require('../utils/errors')
 const responses = require('../utils/responses')
 const adapters = require('../utils/external_api_adapters')
 const db = require('../utils/db')
+const workTypes = require('../utils/work_types')
 
 /** @type {(event: Event) => Promise<Response>} */
 const searchForWork = (event) =>
@@ -20,15 +20,11 @@ const retrieveWork = (event) => {
   const type = getUrlSegments(event)[1]
   const apiRefId = getUrlSegments(event)[2]
 
-  // Hardcoded for now, but ideally shouldnt be.
-  // The Google Books adapter caches books under `ISBN__`; `google__` is also
-  // accepted because some book documents are stored under that name.
-  const apiNames = {
-    films: ['tmdb'],
-    books: ['ISBN', 'google'],
-    tv: ['tmdb'],
-    games: ['igdb'],
-  }[type]
+  // Every prefix that names this work, tried in turn — not every prefix it
+  // may carry, since the id in the url belongs to one API. The Google Books
+  // adapter caches books under `ISBN__`; `google__` is also accepted because
+  // some book documents are stored under that name, and both mean the ISBN.
+  const apiNames = workTypes.byType(type)?.identityPrefixes
 
   if (!apiNames) return Promise.resolve(responses.notFound())
 
@@ -53,13 +49,8 @@ module.exports = {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// Does this exist somewhere else?? >_>
-const typeToCollection = (type) => ({
-  films: 'films',
-  books: 'books',
-  tv: 'tvShows',
-  games: 'games',
-}[type])
+/** @type {(type: string) => string | undefined} */
+const typeToCollection = (type) => workTypes.byType(type)?.works
 
 /**
  * Tries each apiRef in turn and stops at the first cached work.
@@ -100,7 +91,11 @@ const createWork = (event) =>
     }))
 
 
-/** @type {(event: Event) => Result<Adapter, Error>} */
-const getAdapter = (event) => match(getUrlSegments(event)[1])
-  .with('films', 'tv', 'games', 'books', (type) => ok(adapters[type]))
-  .otherwise(() => err(errors.notFound()))
+/**
+ * The adapters are keyed by `:type` segment, so a known type has one.
+ * @type {(event: Event) => Result<Adapter, Error>}
+ */
+const getAdapter = (event) => {
+  const type = getUrlSegments(event)[1]
+  return workTypes.byType(type) ? ok(adapters[type]) : err(errors.notFound())
+}

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -18,6 +18,7 @@ const { throwIt } = require('../general')
 const parsers = require('../parsers/')
 const { toSameFormatAsFaunaDb, toEntryWithMetadata } = require('./shapes')
 const { toUserEntriesPipeline, toFindOptions } = require('./queries')
+const workTypes = require('../work_types')
 
 /** @typedef {import('./queries').QueryOptions} QueryOptions */
 
@@ -95,18 +96,8 @@ const _create = (collection, data, session) =>
  * @type {(collection: 'filmEntries' | 'gameEntries' | 'tvShowEntries' | 'bookEntries', userId: string, limit?: number) => Promise<object>}
  */
 const _findAllUserEntriesWithMetadata = async (collection, userId, limit) => {
-  const workCollection = {
-    filmEntries: 'films',
-    gameEntries: 'games',
-    tvShowEntries: 'tvShows',
-    bookEntries: 'books',
-  }[collection]
-  const entryType = {
-    filmEntries: 'Film',
-    gameEntries: 'Game',
-    tvShowEntries: 'TVShow',
-    bookEntries: 'Book',
-  }[collection]
+  const { works: workCollection, entryType } =
+    workTypes.byEntryCollection(collection) ?? {}
 
   const results = await mongo((db) => db
     .collection(collection)

--- a/src/api/utils/export_view.js
+++ b/src/api/utils/export_view.js
@@ -11,10 +11,13 @@
  *
  * Deliberately pure and dependency-free (no zod, no ramda, no database), so
  * it is covered by `node --test` without an install — see export_view.test.js.
+ * `work_types` is pure for the same reason, so importing it costs nothing.
  */
 
+const { TYPES } = require('./work_types')
+
 /** The `:type` segment of a list url, in the order the lists are exported. */
-const ENTRY_TYPES = ['films', 'tv', 'games', 'books']
+const ENTRY_TYPES = TYPES
 
 const TYPE_TITLES = {
   films: 'Films',

--- a/src/api/utils/work_types.js
+++ b/src/api/utils/work_types.js
@@ -1,0 +1,128 @@
+/**
+ * @file The one description of what a work type is made of: the `:type`
+ * segment its urls start with, the three collections that hold it, the
+ * `entryType` its documents carry, and the apiRef prefixes its works are
+ * cached under.
+ *
+ * This mapping used to be written out by hand wherever it was needed — as a
+ * ts-pattern match in `controllers/utils.js`, as object literals in
+ * `controllers/reviews.js`, `controllers/works.js` and `db/unsafe_functions.js`,
+ * and once as `collection.replace('Entries', 'Reviews')`. Adding a type meant
+ * finding all of them, and a missed one failed at a different depth depending
+ * on which it was: a clean 404 from one, `undefined` and a Mongo error from
+ * the next.
+ *
+ * Deliberately pure and dependency-free (no neverthrow, no ts-pattern, no
+ * database), so it is covered by `node --test` without an install — see
+ * work_types.test.js. The callers that need a `Result` wrap these lookups;
+ * they don't return one.
+ */
+
+/** @typedef {import('./parsers').ValidCollection} ValidCollection */
+
+/**
+ * @typedef {{
+ *   type: string,
+ *   works: ValidCollection,
+ *   entries: ValidCollection,
+ *   reviews: ValidCollection,
+ *   entryType: string,
+ *   apiRefPrefixes: string[],
+ *   identityPrefixes: string[],
+ * }} WorkType
+ */
+
+/**
+ * In the order the lists are exported, which is the order the site presents
+ * them in.
+ *
+ * `apiRefPrefixes` lists every prefix a cached work of this type may
+ * legitimately carry, most canonical first. `identityPrefixes` is the subset
+ * of those that actually names the work, and so the only ones a lookup by
+ * external id may use — they are not always the same list.
+ *
+ * @type {WorkType[]}
+ */
+const WORK_TYPES = [
+  {
+    type: 'films',
+    works: 'films',
+    entries: 'filmEntries',
+    reviews: 'filmReviews',
+    entryType: 'Film',
+    apiRefPrefixes: ['tmdb'],
+    identityPrefixes: ['tmdb'],
+  },
+  {
+    type: 'tv',
+    works: 'tvShows',
+    entries: 'tvShowEntries',
+    reviews: 'tvShowReviews',
+    entryType: 'TVShow',
+    apiRefPrefixes: ['tmdb'],
+    identityPrefixes: ['tmdb'],
+  },
+  {
+    type: 'games',
+    works: 'games',
+    entries: 'gameEntries',
+    reviews: 'gameReviews',
+    entryType: 'Game',
+    // `hltb` is a legacy secondary ref: the adapter used to add it alongside
+    // `igdb`, and 775 games still carry one. HowLongToBeat's API is gone so no
+    // new ones are written, but the pages are still worth linking to. Only
+    // `igdb` can be used to re-retrieve the work.
+    apiRefPrefixes: ['igdb', 'hltb'],
+    // An hltb id identifies a HowLongToBeat page, not the game, and plenty of
+    // games share the placeholder `hltb__N/A`. Only igdb establishes identity,
+    // so only igdb may be looked up by.
+    identityPrefixes: ['igdb'],
+  },
+  {
+    type: 'books',
+    works: 'books',
+    entries: 'bookEntries',
+    reviews: 'bookReviews',
+    entryType: 'Book',
+    // The Google Books adapter caches books under `ISBN__`; `google__` is also
+    // accepted because some book documents are stored under that name. Both
+    // name the same ISBN.
+    apiRefPrefixes: ['ISBN', 'google'],
+    // Both name the same ISBN, so either establishes identity.
+    identityPrefixes: ['ISBN', 'google'],
+  },
+]
+
+/** The `:type` url segments, in the same order. */
+const TYPES = WORK_TYPES.map((workType) => workType.type)
+
+/**
+ * The type a `:type` url segment names, or undefined if it names none. The
+ * callers decide what an unknown segment costs — `controllers/utils.js` turns
+ * it into a 404.
+ * @type {(type: string) => WorkType | undefined}
+ */
+const byType = (type) => BY_TYPE[type]
+
+/**
+ * The same row, for the code that has an entry collection in hand rather than
+ * a url.
+ * @type {(entryCollection: string) => WorkType | undefined}
+ */
+const byEntryCollection = (entryCollection) => BY_ENTRY_COLLECTION[entryCollection]
+
+module.exports = {
+  WORK_TYPES,
+  TYPES,
+  byType,
+  byEntryCollection,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/** @type {(field: keyof WorkType) => Record<string, WorkType>} */
+const indexBy = (field) =>
+  Object.fromEntries(WORK_TYPES.map((workType) => [workType[field], workType]))
+
+const BY_TYPE = indexBy('type')
+const BY_ENTRY_COLLECTION = indexBy('entries')

--- a/src/api/utils/work_types.test.js
+++ b/src/api/utils/work_types.test.js
@@ -1,0 +1,85 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const { WORK_TYPES, TYPES, byType, byEntryCollection } = require('./work_types')
+
+test('every type round-trips segment -> entry collection -> segment', () => {
+  for (const type of TYPES) {
+    const entryCollection = byType(type)?.entries
+    assert.ok(entryCollection, `no entry collection for ${type}`)
+    assert.equal(byEntryCollection(entryCollection)?.type, type)
+  }
+})
+
+test('an unknown segment, and an unknown collection, are simply absent', () => {
+  assert.equal(byType('albums'), undefined)
+  assert.equal(byType(''), undefined)
+  // Not an entry collection, so it must not answer to one — the works and the
+  // reviews live in their own collections.
+  assert.equal(byEntryCollection('films'), undefined)
+  assert.equal(byEntryCollection('filmReviews'), undefined)
+})
+
+test('the four types the site has, under the collections it stores them in', () => {
+  assert.deepEqual(TYPES, ['films', 'tv', 'games', 'books'])
+
+  assert.deepEqual(byType('tv'), {
+    type: 'tv',
+    works: 'tvShows',
+    entries: 'tvShowEntries',
+    reviews: 'tvShowReviews',
+    entryType: 'TVShow',
+    apiRefPrefixes: ['tmdb'],
+    identityPrefixes: ['tmdb'],
+  })
+})
+
+test('a review collection is its entry collection with Entries swapped out', () => {
+  // The rule the string surgery in controllers/utils.js used to encode. It
+  // holds for all four, which is why the table can be trusted to replace it.
+  for (const workType of WORK_TYPES) {
+    assert.equal(workType.reviews, workType.entries.replace('Entries', 'Reviews'))
+  }
+})
+
+test('nothing is named twice, so the lookups cannot collide', () => {
+  for (const field of ['type', 'works', 'entries', 'reviews', 'entryType']) {
+    const values = WORK_TYPES.map((workType) => workType[field])
+    assert.equal(new Set(values).size, values.length, `duplicate ${field}`)
+  }
+})
+
+test('every row is complete', () => {
+  for (const workType of WORK_TYPES) {
+    for (const field of ['type', 'works', 'entries', 'reviews', 'entryType']) {
+      assert.equal(typeof workType[field], 'string', `${workType.type} has no ${field}`)
+    }
+    assert.ok(workType.apiRefPrefixes.length > 0, `${workType.type} has no apiRefPrefixes`)
+    assert.ok(workType.identityPrefixes.length > 0, `${workType.type} has no identityPrefixes`)
+  }
+})
+
+test('the legacy and secondary apiRef prefixes are still carried', () => {
+  // 775 games carry an `hltb` ref alongside their `igdb` one, and some books
+  // are cached under `google__` rather than `ISBN__`. Dropping either from the
+  // table would make those works uncacheable.
+  assert.deepEqual(byType('games')?.apiRefPrefixes, ['igdb', 'hltb'])
+  assert.deepEqual(byType('books')?.apiRefPrefixes, ['ISBN', 'google'])
+})
+
+test('only the prefixes that name the work establish identity', () => {
+  // The distinction the works controller looks a work up by. An hltb id is a
+  // page id, not a game id, so `hltb` is carried but never looked up by —
+  // whereas `google__` and `ISBN__` both mean the same ISBN.
+  assert.deepEqual(byType('games')?.identityPrefixes, ['igdb'])
+  assert.deepEqual(byType('books')?.identityPrefixes, ['ISBN', 'google'])
+
+  for (const workType of WORK_TYPES) {
+    for (const prefix of workType.identityPrefixes) {
+      assert.ok(
+        workType.apiRefPrefixes.includes(prefix),
+        `${workType.type} identifies by ${prefix} but never carries it`
+      )
+    }
+  }
+})

--- a/src/db_maintenance/index_plan.js
+++ b/src/db_maintenance/index_plan.js
@@ -10,22 +10,17 @@
  * equality `$match` on one field. Each entry below names a field one of those
  * calls is given. Nothing here is a sort or a range, so every index is a
  * single ascending field, and `_id` is already indexed by MongoDB itself.
+ *
+ * The collection names come from ../api/utils/work_types.js, which is pure
+ * too, so this file stays testable without an install.
  */
 
+const { WORK_TYPES } = require("../api/utils/work_types");
+
 /** The four of each, in the order the rest of the folder lists them. */
-const ENTRY_COLLECTIONS = [
-  "filmEntries",
-  "tvShowEntries",
-  "gameEntries",
-  "bookEntries",
-];
-const REVIEW_COLLECTIONS = [
-  "filmReviews",
-  "tvShowReviews",
-  "gameReviews",
-  "bookReviews",
-];
-const WORK_COLLECTIONS = ["films", "tvShows", "games", "books"];
+const ENTRY_COLLECTIONS = WORK_TYPES.map((workType) => workType.entries);
+const REVIEW_COLLECTIONS = WORK_TYPES.map((workType) => workType.reviews);
+const WORK_COLLECTIONS = WORK_TYPES.map((workType) => workType.works);
 
 /**
  * @typedef {{

--- a/src/db_maintenance/scripts/audit_database.js
+++ b/src/db_maintenance/scripts/audit_database.js
@@ -66,9 +66,7 @@ const main = async () => {
 const auditCollection = async (db, collection) => {
   const works = await db.collection(collection.works).find().toArray();
   const entries = await db.collection(collection.entries).find().toArray();
-  const reviews = await db.collection(toReviewCollection(collection))
-    .find()
-    .toArray();
+  const reviews = await db.collection(collection.reviews).find().toArray();
 
   const workIds = new Set(works.map((w) => w._id));
   const entryIds = new Set(entries.map((e) => e._id));
@@ -158,11 +156,6 @@ const auditCollection = async (db, collection) => {
   printSummary(collection, result);
   return result;
 };
-
-/** An entry's review lives in the collection of the same name, with
- * `Entries` swapped for `Reviews` — the API's rule, in `controllers/utils.js`. */
-const toReviewCollection = (collection) =>
-  collection.entries.replace("Entries", "Reviews");
 
 const hasRetrieveRef = (collection, work) =>
   Array.isArray(work.apiRefs) &&

--- a/src/db_maintenance/work_collections.js
+++ b/src/db_maintenance/work_collections.js
@@ -1,80 +1,66 @@
 /**
  * @file Shared description of the work/entry collections, used by the
- * audit and backfill scripts. Keep this in sync with
- * ../api/utils/parsers/ and ../api/utils/external_api_adapters/.
+ * audit and backfill scripts.
+ *
+ * The collection names, the entry types and the apiRef prefixes come from
+ * ../api/utils/work_types.js, which the API itself reads — so there is now
+ * something to import rather than something to keep in sync. What is added
+ * here is what only these scripts need. Keep the adapter modules in step with
+ * ../api/utils/external_api_adapters/.
  */
 
+const { WORK_TYPES } = require("../api/utils/work_types");
+
 /**
- * `apiRefPrefixes` lists every prefix a cached work may legitimately carry.
- * `retrievePrefix` is the one the adapter's `retrieve(ref)` expects.
+ * The script-only half of a descriptor, by type.
+ *
+ * `retrievePrefix` is the apiRef prefix the adapter's `retrieve(ref)` expects
+ * — always one of the shared row's `identityPrefixes`.
  * `stringArrayFields` / `numberFields` are the metadata fields we expect the
  * adapter to fill, and that the audit checks for corruption.
  */
-const COLLECTIONS = [
-  {
-    type: "films",
-    works: "films",
-    entries: "filmEntries",
-    entryType: "Film",
+const SCRIPT_FIELDS = {
+  films: {
     adapterModule: "../api/utils/external_api_adapters/films/tmdb",
-    apiRefPrefixes: ["tmdb"],
-    identityPrefixes: ["tmdb"],
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration"],
     defaultDelayMs: 300,
   },
-  {
-    type: "tv",
-    works: "tvShows",
-    entries: "tvShowEntries",
-    entryType: "TVShow",
+  tv: {
     adapterModule: "../api/utils/external_api_adapters/tv_shows/tmdb",
-    apiRefPrefixes: ["tmdb"],
-    identityPrefixes: ["tmdb"],
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration", "episodes"],
     defaultDelayMs: 300,
   },
-  {
-    type: "games",
-    works: "games",
-    entries: "gameEntries",
-    entryType: "Game",
+  games: {
     adapterModule: "../api/utils/external_api_adapters/games/igdb",
-    // `hltb` is a legacy secondary ref: the adapter used to add it alongside
-    // `igdb`, and 775 games still carry one. HowLongToBeat's API is gone so
-    // no new ones are written, but the pages are still worth linking to.
-    // Only `igdb` can be used to re-retrieve the work.
-    apiRefPrefixes: ["igdb", "hltb"],
-    // An hltb id identifies a HowLongToBeat page, not the game, and plenty of
-    // games share the placeholder `hltb__N/A`. Only igdb establishes identity.
-    identityPrefixes: ["igdb"],
     retrievePrefix: "igdb",
     stringArrayFields: ["genres", "platforms", "studios", "publishers"],
     numberFields: ["releaseYear", "duration"],
     // IGDB caps at 4 requests a second, and a retrieve costs three of them.
     defaultDelayMs: 1000,
   },
-  {
-    type: "books",
-    works: "books",
-    entries: "bookEntries",
-    entryType: "Book",
+  books: {
     adapterModule: "../api/utils/external_api_adapters/books/google",
-    // The adapter caches books under `ISBN__`; some documents carry
-    // `google__` instead, naming the same ISBN.
-    apiRefPrefixes: ["ISBN", "google"],
-    // Both name the same ISBN, so either establishes identity.
-    identityPrefixes: ["ISBN", "google"],
     retrievePrefix: "ISBN",
     stringArrayFields: ["genres", "authors", "publishers"],
     numberFields: ["releaseYear", "duration"],
     // The unauthenticated Google Books API rate limits aggressively.
     defaultDelayMs: 1000,
   },
-];
+};
+
+/**
+ * The shared rows with the script-only fields over them, in the shared order.
+ * Carries `reviews` too, so nothing here has to derive a review collection
+ * from an entry one by hand.
+ */
+const COLLECTIONS = WORK_TYPES.map((workType) => ({
+  ...workType,
+  ...SCRIPT_FIELDS[workType.type],
+}));
 
 /** Fields every work is expected to carry, whatever its type. */
 const COMMON_FIELDS = [


### PR DESCRIPTION
Closes #111.

The mapping between a url segment (`films`), a work collection (`films`), an entry collection (`filmEntries`), a review collection (`filmReviews`) and an entry type (`Film`) was written out by hand in eight places, in five shapes — a ts-pattern match, four object literals, and once as `collection.replace('Entries', 'Reviews')`. None of them was wrong. The cost was that adding a type meant finding all of them, and a missed one failed at a different depth depending on which it was: a clean 404 out of `toEntryCollection`, `undefined` and a Mongo error further in out of `typeToCollection`.

`src/api/utils/work_types.js` now holds one row per type — `type`, `works`, `entries`, `reviews`, `entryType`, `apiRefPrefixes`, `identityPrefixes` — and two lookups, `byType` and `byEntryCollection`, that everything else derives from. It is pure and dependency-free, so `node --test` covers it with no install, no database and no keys. That is why it returns plain values rather than a `Result`: reaching for neverthrow would have put it on the wrong side of the rule. `toEntryCollection` keeps its `Result` and its `errors.notFound()` by wrapping the lookup, so every call site changed by an import rather than a rewrite, and the four existing names and signatures are untouched.

`db_maintenance/work_collections.js` imports those rows instead of restating them — which is what its "Keep this in sync with ../api/utils/parsers/" header was asking for, an instruction that only existed because there was nothing to import. What stays there is the half only the scripts need: the adapter module, `retrievePrefix`, the field lists the audit checks, and the per-API delays. The load-bearing comments came across with the data they describe: `hltb` as a legacy secondary ref on 775 games, and books cached under both `ISBN__` and `google__`.

## The one place that needed care

The works controller's `apiNames` is a lookup by external id, not a list of what a work may carry, and for games those differ: `apiRefPrefixes` is `['igdb', 'hltb']` but the id in `/api/works/games/<id>` is an igdb id. Handing it `apiRefPrefixes` would have made it also probe `hltb__<that igdb id>` and match a different game, since an hltb id names a HowLongToBeat page rather than a game. `work_collections.js` already drew that line as `identityPrefixes`, so that field came across too and the controller reads it. The resulting lists are identical to the ones it had.

## What stayed hand-written

`stats.js` keeps its `entryCollections` list. Its order is load-bearing — `([games, tv, films, books]) => ({ games, tv, films, books })` destructures positionally, and that object is written to every user's `stats.scores` — so converting it to descriptor order would file films' tallies under `games` on the next refresh. That is a behaviour change, not a mechanical one, and it belongs with the work already open on that file.

`parsers/index.js` keys a different zod schema per collection, so there is nothing to derive; it needs the names, not the mapping. The `'filmEntries' | 'gameEntries' | ...` union in `unsafe_functions.js` is a type annotation that narrows the parameter, and is what makes the destructure typecheck.

The frontend is untouched, as the issue asks: `entryTypes` in `utils/netlify.js`, `lists` in `components/router.js` and `Conversions.apiTypeToType` share one global scope with no module system, and unifying across that boundary is a separate job.

## Also folded in

`ENTRY_TYPES` in `export_view.js` and the three collection lists in `index_plan.js` now come from the table. Both modules are deliberately pure and separately tested, and `work_types` is pure for the same reason, so importing it keeps them that way.

## Verification

`npm test` — 295 tests, 0 failures — and `git ls-files '*.js' | xargs -n1 node --check` clean. The new `work_types.test.js` is 8 tests: every type round-trips segment → entry collection → segment, an unknown segment and an unknown collection are both simply absent, no two rows share a name, every row is complete, the review-collection naming rule the old string surgery encoded still holds for all four, and the legacy/secondary prefixes and the identity-prefix distinction are pinned.

Because that rule is the point of the module, I also checked it the hard way: copied `src/` to a tree with no `node_modules` at all and ran `work_types.test.js`, `export_view.test.js` and `index_plan.test.js` there — 40/40 pass.

Rebased onto `main` after #124 merged; the `unsafe_functions.js` edits sit alongside its session work without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
