### PR TITLE
refactor: one TMDB adapter, configured twice

### DIFF
--- a/src/api/utils/external_api_adapters/films/tmdb.js
+++ b/src/api/utils/external_api_adapters/films/tmdb.js
@@ -1,85 +1,17 @@
+/**
+ * @file The film half of the TMDB adapter: which endpoints a film lives on.
+ * The rest is ../tmdb_adapter.js, and what a film response maps to is
+ * ../tmdb_mapping.js's `FILM_MAPPING`.
+ */
 /** @typedef {import('../types').Adapter} Adapter */
-/** @typedef {import('../types').SearchFunction} SearchFunction */
-/** @typedef {import('../types').SearchResult} SearchResult */
-/** @typedef {import('../types').FilmRetrieveFunction} FilmRetrieveFunction */
-/** @typedef {import('../../errors').Error} Error */
 /** @typedef {import('../../parsers/films').Film} Film */
-const tmdb = require('node-themoviedb')
-const { ResultAsync } = require('neverthrow')
-const errors = require('../../errors')
-const { match } = require('ts-pattern')
-const { throwIt } = require('../../general')
-const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
-
-const { TMDB_API_KEY } = process.env
-
-const tmdbClient = new tmdb(TMDB_API_KEY ?? throwIt('TMDB_API_KEY is not set.'))
-
-/** @type SearchFunction */
-const search = (titleSearch) => ResultAsync.fromPromise(
-  retrying(() => tmdbClient.search.movies({ query: { query: titleSearch } }))
-    .then(({ data }) =>
-      data.results.map((result) => ({
-        title: result.title,
-        year: result.release_date?.substring(0,4) || undefined,
-        ref: String(result.id),
-        imageUrl: result.poster_path
-          ? 'https://www.themoviedb.org/t/p/w116_and_h174_face' + result.poster_path
-          : undefined
-      }))
-    ),
-  toError
-)
-
-/** @type FilmRetrieveFunction */
-const retrieve = (ref) => ResultAsync.fromPromise(
-  retrying(() => Promise.all([
-    tmdbClient.movie.getDetails({ pathParameters: { movie_id: ref } }),
-    tmdbClient.movie.getCredits({ pathParameters: { movie_id: ref } })
-  ]))
-    .then(([{ data }, { data: credits }]) => ({
-      entryType: 'Film',
-      originalTitle: data.original_title,
-      englishTranslatedTitle: data.title,
-      releaseYear: parseInt(data.release_date.substring(0, 4)),
-      duration: data.runtime || undefined,
-      imageUrl: data.poster_path ? 'https://www.themoviedb.org/t/p/w300_and_h450_bestv2' + data.poster_path : undefined,
-      genres: data.genres.map(g => g.name),
-      directors: credits.crew.filter((person) => person.job === 'Director').map(p => p.name),
-      actors: [...credits.cast]
-        // @ts-ignore (library typing is wrong)
-        .sort((a, b) => b.popularity - a.popularity)
-        .slice(0, 10)
-        // @ts-ignore (library typing is wrong)
-        .filter((person) => person.popularity > 6)
-        .map((person) => person.name),
-      apiRefs: [`tmdb__${ref}`],
-      externalUrls: [{ name: 'tmdb', url: `https://www.themoviedb.org/movie/${ref}` }],
-    })),
-  toError,
-)
+const { tmdbAdapter } = require('../tmdb_adapter')
+const { FILM_MAPPING } = require('../tmdb_mapping')
 
 /** @type Adapter */
-module.exports = {
-  search,
-  retrieve
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-/**
- * `statusOf` rather than `err.errorCode`, because node-themoviedb only wraps
- * the statuses it has a class for and throws `got`'s own error through for
- * the rest — including the 5xx that `retrying` has just given up on.
- * @type {(err: any) => Error}
- */
-const toError = (err) => match(statusOf(err))
-  .with(404, () => errors.notFound(undefined, 'no such film'))
-  .with(401, () => errors.unauthorized(describeFailure(err), publicFailure('tmdb', err)))
-  .with(408, () => errors.internal(undefined, 'tmdb timed out'))
-  // Everything tmdb said goes to the log; the caller gets the class of the
-  // failure, which is the part that is theirs to act on. #105.
-  .otherwise(() => errors.internal(
-    `tmdb failed: ${describeFailure(err)}`,
-    publicFailure('tmdb', err),
-  ))
+module.exports = tmdbAdapter({
+  mapping: FILM_MAPPING,
+  search: (client, query) => client.search.movies({ query: { query } }),
+  details: (client, movie_id) => client.movie.getDetails({ pathParameters: { movie_id } }),
+  credits: (client, movie_id) => client.movie.getCredits({ pathParameters: { movie_id } }),
+})

--- a/src/api/utils/external_api_adapters/tmdb_adapter.js
+++ b/src/api/utils/external_api_adapters/tmdb_adapter.js
@@ -1,0 +1,96 @@
+/**
+ * @file The TMDB adapter, written once.
+ *
+ * films/tmdb.js and tv_shows/tmdb.js were 83 and 90 lines that differed in
+ * about twelve, `toError` included — byte for byte, comment and all. What is
+ * actually per-type is ./tmdb_mapping.js's two mappings and the three client
+ * calls each file hands `tmdbAdapter` below.
+ *
+ * The client is built here, at require time, which is why neither this module
+ * nor anything requiring it can be reached by the test suite. The mapping is
+ * next door and dependency-free for that reason.
+ */
+/** @typedef {import('./types').Adapter} Adapter */
+/** @typedef {import('./types').SearchFunction} SearchFunction */
+/** @typedef {import('./types').SearchResult} SearchResult */
+/** @typedef {import('./tmdb_mapping').Mapping} Mapping */
+/** @typedef {import('../errors').Error} Error */
+const tmdb = require('node-themoviedb')
+const { ResultAsync } = require('neverthrow')
+const errors = require('../errors')
+const { match } = require('ts-pattern')
+const { throwIt } = require('../general')
+const { retrying, describeFailure, publicFailure, statusOf } = require('./retry')
+const { toSearchResults, toWork } = require('./tmdb_mapping')
+
+const { TMDB_API_KEY } = process.env
+
+const tmdbClient = new tmdb(TMDB_API_KEY ?? throwIt('TMDB_API_KEY is not set.'))
+
+/**
+ * The three endpoints a media type answers on. Each takes the client rather
+ * than closing over it so that a caller names the method and its path
+ * parameter and nothing else — `movie_id` and `tv_id` are the same id under
+ * two names.
+ *
+ * @typedef {object} Endpoints
+ * @property {(client: any, query: string) => Promise<any>} search
+ * @property {(client: any, ref: string) => Promise<any>} details
+ * @property {(client: any, ref: string) => Promise<any>} credits
+ */
+
+/**
+ * An adapter for one TMDB media type. `retrieve` asks for the details and the
+ * credits together and retries the pair, because a work needs both and half of
+ * one is not worth returning.
+ * @type {(config: Endpoints & { mapping: Mapping }) => Adapter}
+ */
+const tmdbAdapter = ({ mapping, search, details, credits }) => {
+  const toError = tmdbError(mapping.notFoundMessage)
+
+  return {
+    search: (titleSearch) => ResultAsync.fromPromise(
+      retrying(() => search(tmdbClient, titleSearch))
+        .then(({ data }) => toSearchResults(mapping, data)),
+      toError
+    ),
+
+    retrieve: (ref) => ResultAsync.fromPromise(
+      retrying(() => Promise.all([
+        details(tmdbClient, ref),
+        credits(tmdbClient, ref),
+      ]))
+        .then(([{ data }, { data: castAndCrew }]) =>
+          toWork(mapping, ref, data, castAndCrew)
+        ),
+      toError,
+    ),
+  }
+}
+
+module.exports = {
+  tmdbAdapter,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * `statusOf` rather than `err.errorCode`, because node-themoviedb only wraps
+ * the statuses it has a class for and throws `got`'s own error through for
+ * the rest — including the 5xx that `retrying` has just given up on.
+ *
+ * The 404 line is the only one the two media types worded differently, so it
+ * is the only thing this takes: telling someone who asked after a show that
+ * there is no such film would be worse than saying nothing.
+ * @type {(notFoundMessage: string) => (err: any) => Error}
+ */
+const tmdbError = (notFoundMessage) => (err) => match(statusOf(err))
+  .with(404, () => errors.notFound(undefined, notFoundMessage))
+  .with(401, () => errors.unauthorized(describeFailure(err), publicFailure('tmdb', err)))
+  .with(408, () => errors.internal(undefined, 'tmdb timed out'))
+  // Everything tmdb said goes to the log; the caller gets the class of the
+  // failure, which is the part that is theirs to act on. #105.
+  .otherwise(() => errors.internal(
+    `tmdb failed: ${describeFailure(err)}`,
+    publicFailure('tmdb', err),
+  ))

--- a/src/api/utils/external_api_adapters/tmdb_mapping.js
+++ b/src/api/utils/external_api_adapters/tmdb_mapping.js
@@ -1,0 +1,201 @@
+/**
+ * @file Turning a TMDB response into a stored work.
+ *
+ * Pure and dependency-free for the same reason ./games/release_dates.js is:
+ * ./tmdb_adapter.js constructs a node-themoviedb client at require time and
+ * throws without TMDB_API_KEY, so nothing behind it is reachable from the test
+ * suite. Everything that decides what gets written lives here instead — the
+ * two mappings included — and is unit tested against the response shapes TMDB
+ * really sends (./tmdb_mapping.test.js).
+ *
+ * films/tmdb.js and tv_shows/tmdb.js differ in the two mappings below and in
+ * the three client calls each hands ./tmdb_adapter.js. Everything else was
+ * duplicated between them until #112, which is how the film half went without
+ * the `release_date` guard the tv half had.
+ */
+
+/** The poster sizes: the small one for a search row, the large one for a work. */
+const SEARCH_IMAGE_URL_PREFIX = 'https://www.themoviedb.org/t/p/w116_and_h174_face'
+const POSTER_IMAGE_URL_PREFIX = 'https://www.themoviedb.org/t/p/w300_and_h450_bestv2'
+
+/** "The top ten notable actors": at most this many, none less popular than this. */
+const MAX_ACTORS = 10
+const MIN_ACTOR_POPULARITY = 6
+
+/** @type {(posterPath: any, prefix: string) => string | undefined} */
+const posterUrl = (posterPath, prefix) =>
+  typeof posterPath === 'string' && posterPath ? prefix + posterPath : undefined
+
+/**
+ * The four-digit year out of a TMDB date, as it goes into a search result.
+ *
+ * TMDB sends `""` for a film with no announced release date, `null` for some
+ * others, and omits the key outright for the rest, so this cannot be a bare
+ * `.substring(0, 4)`. See ./tmdb_mapping.test.js.
+ * @type {(date: any) => string | undefined}
+ */
+const releaseYearString = (date) =>
+  (typeof date === 'string' ? date.substring(0, 4) : '') || undefined
+
+/**
+ * The same year as a number, or undefined when TMDB has no usable date.
+ *
+ * Undefined rather than `NaN`: `releaseYear` is `z.number().nullable().or(
+ * z.undefined())`, so a `NaN` fails the parse instead of reading as "we don't
+ * know", which is what an unreleased film means. The film adapter read
+ * `data.release_date.substring(0, 4)` unguarded for as long as it was a copy
+ * of the tv one — a `""` was a zod failure and a `null` a 500.
+ * @type {(date: any) => number | undefined}
+ */
+const releaseYear = (date) => {
+  const year = parseInt(releaseYearString(date) ?? '')
+  return Number.isFinite(year) ? year : undefined
+}
+
+/** @type {(genres: any) => string[]} */
+const genreNames = (genres) =>
+  (Array.isArray(genres) ? genres : [])
+    .map((genre) => genre?.name)
+    .filter((name) => typeof name === 'string')
+
+/**
+ * The names of everyone in the crew doing one of `jobs`. TMDB files a show's
+ * own director under `Series Director` and an episode's under `Director`,
+ * where a film only ever has the latter.
+ * @type {(crew: any, jobs: string[]) => string[]}
+ */
+const directorNames = (crew, jobs) =>
+  (Array.isArray(crew) ? crew : [])
+    .filter((person) => jobs.includes(person?.job))
+    .map((person) => person.name)
+    .filter((name) => typeof name === 'string')
+
+/**
+ * The notable actors, most popular first.
+ *
+ * The filter runs before the slice. Sorting, slicing and then filtering — what
+ * this did — drops an eleventh-billed actor who clears the bar, and answers
+ * with three names for a cast where only three clear it. Neither is "the top
+ * ten notable actors", which is what the two constants read as together.
+ *
+ * The sort is in place on the array `filter` just built rather than on TMDB's
+ * own, which `[...credits.cast]` was there to protect.
+ * @type {(cast: any) => string[]}
+ */
+const notableActors = (cast) =>
+  (Array.isArray(cast) ? cast : [])
+    .filter((person) => Number(person?.popularity) > MIN_ACTOR_POPULARITY)
+    .sort((a, b) => b.popularity - a.popularity)
+    .slice(0, MAX_ACTORS)
+    .map((person) => person.name)
+    .filter((name) => typeof name === 'string')
+
+/**
+ * How many episodes a show has, not counting its specials.
+ *
+ * TMDB files specials as season 0, so summing every season's `episode_count`
+ * reports more episodes than the show has and the list's progress column
+ * (`${seen}/${totalEps}`) inherits it. Season 0 is excluded here; #112 has the
+ * reasoning, and it changes what gets stored for shows retrieved from now on.
+ *
+ * Undefined rather than 0 for a show TMDB lists no seasons for, for the reason
+ * a `duration` of 0 is not a duration: 0 renders as a real count in the
+ * progress column where undefined renders as `-`.
+ * @type {(seasons: any) => number | undefined}
+ */
+const episodeCount = (seasons) => {
+  const counts = (Array.isArray(seasons) ? seasons : [])
+    .filter((season) => Number(season?.season_number) > 0)
+    .map((season) => Number(season?.episode_count))
+    .filter((count) => Number.isFinite(count))
+
+  return counts.length ? counts.reduce((eps, count) => eps + count, 0) : undefined
+}
+
+/**
+ * @typedef {object} Mapping
+ * @property {string} entryType
+ * @property {string} urlSegment which themoviedb.org path a work sits under
+ * @property {string} title
+ * @property {string} originalTitle
+ * @property {string} releaseDate
+ * @property {string[]} directorJobs
+ * @property {string} notFoundMessage what a 404 tells the caller (#105)
+ * @property {(data: any) => number | undefined} duration
+ * @property {(data: any) => object} [extraFields] anything only one type has
+ */
+
+/** @type Mapping */
+const FILM_MAPPING = {
+  entryType: 'Film',
+  urlSegment: 'movie',
+  title: 'title',
+  originalTitle: 'original_title',
+  releaseDate: 'release_date',
+  directorJobs: ['Director'],
+  notFoundMessage: 'no such film',
+  duration: (data) => data?.runtime || undefined,
+}
+
+/** @type Mapping */
+const TV_SHOW_MAPPING = {
+  entryType: 'TVShow',
+  urlSegment: 'tv',
+  title: 'name',
+  originalTitle: 'original_name',
+  releaseDate: 'first_air_date',
+  directorJobs: ['Director', 'Series Director'],
+  notFoundMessage: 'no such tv show',
+  // A show's `duration` is one episode's; TMDB lists the runtimes it has seen.
+  duration: (data) => data?.episode_run_time?.[0] || undefined,
+  extraFields: (data) => ({ episodes: episodeCount(data?.seasons) }),
+}
+
+/** @type {(mapping: Mapping, data: any) => object[]} */
+const toSearchResults = (mapping, data) =>
+  (Array.isArray(data?.results) ? data.results : []).map((result) => ({
+    title: result[mapping.title],
+    year: releaseYearString(result[mapping.releaseDate]),
+    ref: String(result.id),
+    imageUrl: posterUrl(result.poster_path, SEARCH_IMAGE_URL_PREFIX),
+  }))
+
+/**
+ * A work document, from TMDB's details and credits responses for one id.
+ * @type {(mapping: Mapping, ref: string, data: any, credits: any) => object}
+ */
+const toWork = (mapping, ref, data, credits) => ({
+  entryType: mapping.entryType,
+  originalTitle: data?.[mapping.originalTitle],
+  englishTranslatedTitle: data?.[mapping.title],
+  releaseYear: releaseYear(data?.[mapping.releaseDate]),
+  duration: mapping.duration(data),
+  imageUrl: posterUrl(data?.poster_path, POSTER_IMAGE_URL_PREFIX),
+  genres: genreNames(data?.genres),
+  directors: directorNames(credits?.crew, mapping.directorJobs),
+  actors: notableActors(credits?.cast),
+  apiRefs: [`tmdb__${ref}`],
+  externalUrls: [{
+    name: 'tmdb',
+    url: `https://www.themoviedb.org/${mapping.urlSegment}/${ref}`,
+  }],
+  ...mapping.extraFields?.(data),
+})
+
+module.exports = {
+  SEARCH_IMAGE_URL_PREFIX,
+  POSTER_IMAGE_URL_PREFIX,
+  MAX_ACTORS,
+  MIN_ACTOR_POPULARITY,
+  FILM_MAPPING,
+  TV_SHOW_MAPPING,
+  posterUrl,
+  releaseYearString,
+  releaseYear,
+  genreNames,
+  directorNames,
+  notableActors,
+  episodeCount,
+  toSearchResults,
+  toWork,
+}

--- a/src/api/utils/external_api_adapters/tmdb_mapping.test.js
+++ b/src/api/utils/external_api_adapters/tmdb_mapping.test.js
@@ -1,0 +1,273 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  SEARCH_IMAGE_URL_PREFIX,
+  POSTER_IMAGE_URL_PREFIX,
+  MAX_ACTORS,
+  FILM_MAPPING,
+  TV_SHOW_MAPPING,
+  releaseYearString,
+  releaseYear,
+  genreNames,
+  directorNames,
+  notableActors,
+  episodeCount,
+  toSearchResults,
+  toWork,
+} = require('./tmdb_mapping')
+
+/** A `/movie/{id}` response, cut down to the fields that are read. */
+const aFilm = {
+  title: 'Spirited Away',
+  original_title: '千と千尋の神隠し',
+  release_date: '2001-07-20',
+  runtime: 125,
+  poster_path: '/poster.jpg',
+  genres: [{ id: 16, name: 'Animation' }, { id: 14, name: 'Fantasy' }],
+}
+
+/** A `/tv/{id}` response, likewise. */
+const aShow = {
+  name: 'Fargo',
+  original_name: 'Fargo',
+  first_air_date: '2014-04-15',
+  episode_run_time: [53, 60],
+  poster_path: '/poster.jpg',
+  genres: [{ id: 80, name: 'Crime' }],
+  seasons: [
+    { season_number: 0, episode_count: 4, name: 'Specials' },
+    { season_number: 1, episode_count: 10 },
+    { season_number: 2, episode_count: 10 },
+  ],
+}
+
+const credits = {
+  crew: [
+    { job: 'Director', name: 'Hayao Miyazaki' },
+    { job: 'Series Director', name: 'Adam Bernstein' },
+    { job: 'Producer', name: 'Toshio Suzuki' },
+  ],
+  cast: [
+    { name: 'Billed First', popularity: 4 },
+    { name: 'Billed Second', popularity: 30 },
+    { name: 'Billed Third', popularity: 12 },
+  ],
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The year, which is the bug this file exists for.
+
+test('a year comes out of a date', () => {
+  assert.equal(releaseYear('2001-07-20'), 2001)
+  assert.equal(releaseYearString('2001-07-20'), '2001')
+})
+
+test('a film with no release date has no year rather than a NaN', () => {
+  // TMDB sends `""` for an unreleased film. `parseInt("")` is `NaN`, which
+  // `releaseYear: z.number()...` rejects — the failure this refactor is for.
+  assert.equal(releaseYear(''), undefined)
+  assert.equal(releaseYear(null), undefined)
+  assert.equal(releaseYear(undefined), undefined)
+  assert.equal(releaseYear('not a date'), undefined)
+
+  assert.equal(releaseYearString(''), undefined)
+  assert.equal(releaseYearString(null), undefined)
+  assert.equal(releaseYearString(undefined), undefined)
+})
+
+test('an unreleased film maps without throwing and without a year', () => {
+  // The unguarded `data.release_date.substring(0, 4)` was a TypeError, and
+  // a 500 rather than a work with one field missing.
+  const work = toWork(FILM_MAPPING, '129', { ...aFilm, release_date: null }, credits)
+
+  assert.equal(work.releaseYear, undefined)
+  assert.equal(work.englishTranslatedTitle, 'Spirited Away')
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The two behaviours #112 decided on.
+
+test('specials do not count towards a show\'s episodes', () => {
+  // TMDB files specials as season 0. Counting them reported 24 episodes for a
+  // show with 20, and the progress column read `10/24`.
+  assert.equal(episodeCount(aShow.seasons), 20)
+})
+
+test('a show TMDB lists no seasons for has no episode count', () => {
+  // Not 0: `${seen}/0` reads as a real count where `${seen}/-` reads as
+  // unknown, the same reason a `duration` of 0 is not a duration.
+  assert.equal(episodeCount([]), undefined)
+  assert.equal(episodeCount([{ season_number: 0, episode_count: 3 }]), undefined)
+  assert.equal(episodeCount(undefined), undefined)
+  assert.equal(episodeCount({}), undefined)
+})
+
+test('a season without a usable count is skipped, not added as NaN', () => {
+  assert.equal(episodeCount([
+    { season_number: 1, episode_count: 10 },
+    { season_number: 2 },
+    { season_number: 3, episode_count: null },
+  ]), 10)
+})
+
+test('the notable actors are filtered before they are cut to ten', () => {
+  // Slicing first dropped an eleventh-billed actor who cleared the bar.
+  const cast = [
+    ...Array.from({ length: 10 }, (_, i) => ({ name: `Unpopular ${i}`, popularity: 1 })),
+    { name: 'Popular But Eleventh', popularity: 40 },
+  ]
+
+  assert.deepEqual(notableActors(cast), ['Popular But Eleventh'])
+})
+
+test('at most ten actors survive, most popular first', () => {
+  const cast = Array.from({ length: 15 }, (_, i) => ({
+    name: `Actor ${i}`,
+    popularity: 10 + i,
+  }))
+  const actors = notableActors(cast)
+
+  assert.equal(actors.length, MAX_ACTORS)
+  assert.equal(actors[0], 'Actor 14')
+  assert.equal(actors.at(-1), 'Actor 5')
+})
+
+test('a cast where only some clear the bar keeps only those', () => {
+  assert.deepEqual(notableActors(credits.cast), ['Billed Second', 'Billed Third'])
+})
+
+test('the popularity bar is exclusive and non-numbers do not clear it', () => {
+  assert.deepEqual(notableActors([{ name: 'Exactly Six', popularity: 6 }]), [])
+  assert.deepEqual(notableActors([{ name: 'No Number', popularity: 'lots' }]), [])
+  assert.deepEqual(notableActors([{ name: 'None At All' }]), [])
+  assert.deepEqual(notableActors(undefined), [])
+})
+
+test('the cast TMDB sent is left in the order it arrived in', () => {
+  // `sort` reorders in place; the sort here runs on the array `filter` built.
+  const cast = [
+    { name: 'First', popularity: 10 },
+    { name: 'Second', popularity: 30 },
+  ]
+  notableActors(cast)
+
+  assert.deepEqual(cast.map((person) => person.name), ['First', 'Second'])
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The rest of the shared mapping.
+
+test('a missing genres or crew is an empty list, not a throw', () => {
+  assert.deepEqual(genreNames(undefined), [])
+  assert.deepEqual(genreNames([{ id: 1 }]), [])
+  assert.deepEqual(directorNames(undefined, ['Director']), [])
+})
+
+test('a show counts its series directors and a film does not', () => {
+  assert.deepEqual(directorNames(credits.crew, FILM_MAPPING.directorJobs), [
+    'Hayao Miyazaki',
+  ])
+  assert.deepEqual(directorNames(credits.crew, TV_SHOW_MAPPING.directorJobs), [
+    'Hayao Miyazaki',
+    'Adam Bernstein',
+  ])
+})
+
+test('a film maps to a film work', () => {
+  const work = toWork(FILM_MAPPING, '129', aFilm, credits)
+
+  assert.deepEqual(work, {
+    entryType: 'Film',
+    originalTitle: '千と千尋の神隠し',
+    englishTranslatedTitle: 'Spirited Away',
+    releaseYear: 2001,
+    duration: 125,
+    imageUrl: POSTER_IMAGE_URL_PREFIX + '/poster.jpg',
+    genres: ['Animation', 'Fantasy'],
+    directors: ['Hayao Miyazaki'],
+    actors: ['Billed Second', 'Billed Third'],
+    apiRefs: ['tmdb__129'],
+    externalUrls: [{ name: 'tmdb', url: 'https://www.themoviedb.org/movie/129' }],
+  })
+})
+
+test('a show maps to a tv show work, episodes and all', () => {
+  const work = toWork(TV_SHOW_MAPPING, '60622', aShow, credits)
+
+  assert.deepEqual(work, {
+    entryType: 'TVShow',
+    originalTitle: 'Fargo',
+    englishTranslatedTitle: 'Fargo',
+    releaseYear: 2014,
+    // One episode's runtime, the first TMDB lists — not the whole show's.
+    duration: 53,
+    imageUrl: POSTER_IMAGE_URL_PREFIX + '/poster.jpg',
+    genres: ['Crime'],
+    directors: ['Hayao Miyazaki', 'Adam Bernstein'],
+    actors: ['Billed Second', 'Billed Third'],
+    apiRefs: ['tmdb__60622'],
+    externalUrls: [{ name: 'tmdb', url: 'https://www.themoviedb.org/tv/60622' }],
+    episodes: 20,
+  })
+})
+
+test('a film work carries no episodes key at all', () => {
+  assert.equal('episodes' in toWork(FILM_MAPPING, '129', aFilm, credits), false)
+})
+
+test('a zero runtime is no duration rather than a duration of zero', () => {
+  assert.equal(FILM_MAPPING.duration({ runtime: 0 }), undefined)
+  assert.equal(FILM_MAPPING.duration({}), undefined)
+  assert.equal(TV_SHOW_MAPPING.duration({ episode_run_time: [] }), undefined)
+  assert.equal(TV_SHOW_MAPPING.duration({}), undefined)
+})
+
+test('a work with no poster has no image url', () => {
+  const work = toWork(FILM_MAPPING, '129', { ...aFilm, poster_path: null }, credits)
+
+  assert.equal(work.imageUrl, undefined)
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// Search.
+
+test('a film search result reads its own field names', () => {
+  const results = toSearchResults(FILM_MAPPING, {
+    results: [{ id: 129, title: 'Spirited Away', release_date: '2001-07-20', poster_path: '/p.jpg' }],
+  })
+
+  assert.deepEqual(results, [{
+    title: 'Spirited Away',
+    year: '2001',
+    ref: '129',
+    imageUrl: SEARCH_IMAGE_URL_PREFIX + '/p.jpg',
+  }])
+})
+
+test('a tv search result reads its own field names', () => {
+  const results = toSearchResults(TV_SHOW_MAPPING, {
+    results: [{ id: 60622, name: 'Fargo', first_air_date: '2014-04-15', poster_path: null }],
+  })
+
+  assert.deepEqual(results, [{
+    title: 'Fargo',
+    year: '2014',
+    ref: '60622',
+    imageUrl: undefined,
+  }])
+})
+
+test('a search result with no date carries no year', () => {
+  const [result] = toSearchResults(FILM_MAPPING, {
+    results: [{ id: 1, title: 'Unannounced', release_date: '' }],
+  })
+
+  assert.equal(result.year, undefined)
+})
+
+test('a search that matched nothing is an empty list', () => {
+  assert.deepEqual(toSearchResults(FILM_MAPPING, { results: [] }), [])
+  assert.deepEqual(toSearchResults(FILM_MAPPING, {}), [])
+  assert.deepEqual(toSearchResults(FILM_MAPPING, undefined), [])
+})

--- a/src/api/utils/external_api_adapters/tv_shows/tmdb.js
+++ b/src/api/utils/external_api_adapters/tv_shows/tmdb.js
@@ -1,92 +1,17 @@
 /**
- * @file A lot of this code is duplicated
- * with the Film adapter...
+ * @file The tv half of the TMDB adapter: which endpoints a show lives on.
+ * The rest is ../tmdb_adapter.js, and what a show response maps to is
+ * ../tmdb_mapping.js's `TV_SHOW_MAPPING`.
  */
 /** @typedef {import('../types').Adapter} Adapter */
-/** @typedef {import('../types').SearchFunction} SearchFunction */
-/** @typedef {import('../types').SearchResult} SearchResult */
-/** @typedef {import('../types').TVShowRetrieveFunction} TVShowRetrieveFunction */
-/** @typedef {import('../../errors').Error} Error */
-/** @typedef {import('../../parsers/films').Film} Film */
-const tmdb = require('node-themoviedb')
-const { ResultAsync } = require('neverthrow')
-const errors = require('../../errors')
-const { match } = require('ts-pattern')
-const { throwIt } = require('../../general')
-const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
-
-const { TMDB_API_KEY } = process.env
-
-const tmdbClient = new tmdb(TMDB_API_KEY ?? throwIt('TMDB_API_KEY is not set.'))
-
-/** @type SearchFunction */
-const search = (titleSearch) => ResultAsync.fromPromise(
-  retrying(() => tmdbClient.search.TVShows({ query: { query: titleSearch } }))
-    .then(({ data }) =>
-      data.results.map((result) => ({
-        title: result.name,
-        year: result.first_air_date?.substring(0,4) || undefined,
-        ref: String(result.id),
-        imageUrl: result.poster_path
-          ? 'https://www.themoviedb.org/t/p/w116_and_h174_face' + result.poster_path
-          : undefined
-      }))
-    ),
-  toError
-)
-
-/** @type TVShowRetrieveFunction */
-const retrieve = (ref) => ResultAsync.fromPromise(
-  retrying(() => Promise.all([
-    tmdbClient.tv.getDetails({ pathParameters: { tv_id: ref } }),
-    tmdbClient.tv.getCredits({ pathParameters: { tv_id: ref } })
-  ]))
-    .then(([{ data }, { data: credits }]) => ({
-      entryType: 'TVShow',
-      originalTitle: data.original_name,
-      englishTranslatedTitle: data.name,
-      releaseYear: parseInt(data.first_air_date?.substring(0, 4)),
-      duration: data.episode_run_time?.[0] || undefined,
-      imageUrl: data.poster_path ? 'https://www.themoviedb.org/t/p/w300_and_h450_bestv2' + data.poster_path : undefined,
-      genres: data.genres.map(g => g.name),
-      directors: credits.crew
-        .filter((person) => ['Director', 'Series Director'].includes(person.job))
-        .map(p => p.name),
-      actors: [...credits.cast]
-        // @ts-ignore (library typing is wrong)
-        .sort((a, b) => b.popularity - a.popularity)
-        .slice(0, 10)
-        // @ts-ignore (library typing is wrong)
-        .filter((person) => person.popularity > 6)
-        .map((person) => person.name),
-      apiRefs: [`tmdb__${ref}`],
-      externalUrls: [{ name: 'tmdb', url: `https://www.themoviedb.org/tv/${ref}` }],
-      episodes: data.seasons.reduce((eps, s) => eps + s.episode_count, 0),
-    })),
-  toError,
-)
+/** @typedef {import('../../parsers/tvShows').TVShow} TVShow */
+const { tmdbAdapter } = require('../tmdb_adapter')
+const { TV_SHOW_MAPPING } = require('../tmdb_mapping')
 
 /** @type Adapter */
-module.exports = {
-  search,
-  retrieve
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-/**
- * `statusOf` rather than `err.errorCode`, because node-themoviedb only wraps
- * the statuses it has a class for and throws `got`'s own error through for
- * the rest — including the 5xx that `retrying` has just given up on.
- * @type {(err: any) => Error}
- */
-const toError = (err) => match(statusOf(err))
-  .with(404, () => errors.notFound(undefined, 'no such tv show'))
-  .with(401, () => errors.unauthorized(describeFailure(err), publicFailure('tmdb', err)))
-  .with(408, () => errors.internal(undefined, 'tmdb timed out'))
-  // Everything tmdb said goes to the log; the caller gets the class of the
-  // failure, which is the part that is theirs to act on. #105.
-  .otherwise(() => errors.internal(
-    `tmdb failed: ${describeFailure(err)}`,
-    publicFailure('tmdb', err),
-  ))
+module.exports = tmdbAdapter({
+  mapping: TV_SHOW_MAPPING,
+  search: (client, query) => client.search.TVShows({ query: { query } }),
+  details: (client, tv_id) => client.tv.getDetails({ pathParameters: { tv_id } }),
+  credits: (client, tv_id) => client.tv.getCredits({ pathParameters: { tv_id } }),
+})


### PR DESCRIPTION
Closes #112.

`films/tmdb.js` and `tv_shows/tmdb.js` were 83 and 90 lines that differed in about twelve, and the tv one opened by saying so. They are now the three client calls each media type answers on — 18 lines each — over a shared `tmdbAdapter` factory.

**The bug the duplication cost.** `films/tmdb.js` read `data.release_date.substring(0, 4)` where the tv copy had `data.first_air_date?.substring(0, 4)`. TMDB sends `""` for a film with no announced release date, which made `releaseYear: NaN` and failed `releaseYear: z.number().nullable().or(z.undefined())` instead of reading as "we don't know"; a `null` there was a `TypeError` and a 500. Both now go through one guarded `releaseYear`, and `genres`, `seasons`, `crew` and `cast` get the same treatment — an adapter should come back with one field missing, not with a 500. (The equivalent games bug was #118; this is the film one.)

## Layout

`tmdb_adapter.js` holds `tmdbAdapter({ mapping, search, details, credits })` and `toError`, which was byte-identical in both files before #125 and differs now only in its 404 message — so that message is the one thing the error mapper takes, since telling someone who asked after a show that there is no such film is worse than saying nothing.

`tmdb_mapping.js` holds everything that decides what gets written, including the two per-type mappings, and is pure and dependency-free. That is not tidiness: `tmdb_adapter.js` builds a `node-themoviedb` client at require time and throws without `TMDB_API_KEY`, so nothing behind it is reachable from `node --test`. The mapping is, and `tmdb_mapping.test.js` covers every bug listed here against real response shapes. It is the split `games/time_to_beat.js` and `games/release_dates.js` already use, which is also why the field names live next to the mapping rather than in the leaf files — a config the test cannot reach is a config the test cannot check.

`work_collections.js`'s `adapterModule` paths are untouched: both files keep their names and their `module.exports`, so #111 and this don't collide.

## Two behaviour changes, deliberate — please argue with either

**Specials no longer count towards a show's episodes.** `data.seasons.reduce((eps, s) => eps + s.episode_count, 0)` counted season 0, which is where TMDB files specials, so a show with a specials season reported more episodes than it has and the progress column (`${seen}/${totalEps}`) inherited it. Seasons are now filtered to `season_number > 0`. This changes stored metadata: shows retrieved from now on get the lower count, while shows already cached keep theirs — `hasGaps` won't spend an API call on a work whose `episodes` is already set, so correcting the existing ones means a deliberate `backfill_work_metadata.js` run rather than a `missingOnly` one. Nothing rewrites a user's `overrides.episodes` either way.

**The cast is filtered before it is sliced.** `.sort(by popularity).slice(0, 10).filter(popularity > 6)` dropped an eleventh-billed actor who cleared the threshold, and answered with three names for a cast where only three cleared it. Swapped, so `MAX_ACTORS`/`MIN_ACTOR_POPULARITY` read as "the top ten notable actors". Same caveat: it affects works retrieved from now on.

One smaller judgement call in the same spirit: a show TMDB lists no seasons for now gets no `episodes` rather than a `0`. `0` renders as a real count in the progress column where undefined renders as `-`, the same reason a stored `duration` of `0` is not a duration.

## Verification

`npm test` — 309 tests, 0 failures, 33 skipped (the ones that want dependencies); 22 of those are new. `git ls-files '*.js' | xargs -n1 node --check` is clean. The adapters themselves still can't be exercised without a key and a network, which is the point of the seam.
