### PR TITLE
perf: serve the frontend from urls instead of inlining it into every page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,25 +5,44 @@ module.exports = (config) => {
   const env = process.env.ELEVENTY_ENV
 
   // minify the html output
-  config.addTransform('htmlmin', (content) =>
-    HtmlMinifier.minify(content, {
+  config.addTransform('htmlmin', (content, outputPath) => {
+    // A transform runs over every output file, and `/js/bundle.js` is one of
+    // them now. `collapseWhitespace` over JavaScript eats the newline that
+    // ends a `//` comment, and the rest of the file goes with it.
+    if (!outputPath || !outputPath.endsWith('.html')) return content
+
+    return HtmlMinifier.minify(content, {
       useShortDoctype: true,
       removeComments: true,
       collapseWhitespace: true,
-    }),
-  )
+    })
+  })
 
   // compress and combine js files
   config.addFilter('jsmin', (code) => {
-    const minified = UglifyJS.minify(code)
+    // `{% set %}` hands a filter a Nunjucks SafeString, and UglifyJS reads
+    // anything that is not a string as a map of filenames to sources.
+    const minified = UglifyJS.minify(String(code))
+
+    // Handing back the unminified input on failure is how a bundle that does
+    // not parse gets shipped anyway. Every page on this site is drawn by that
+    // one file, so a syntax error in it is a blank page on every url, with
+    // nothing in the build log above it. Fail the build instead.
     if (minified.error) {
-      console.log('UglifyJS error: ', minified.error)
+      throw new Error(`jsmin: UglifyJS could not parse the bundle: ${minified.error}`)
     }
-    return minified.error ? code : minified.code
+
+    return minified.code
   })
 
   // pass some assets right through
   config.addPassthroughCopy('./src/frontend/img')
+  // The stylesheet is served from `/css/main.css` rather than inlined into
+  // every page, for the same reason the scripts are. It lives under
+  // `_includes` because it used to be `{% include %}`d.
+  config.addPassthroughCopy({
+    './src/frontend/_includes/css/main.css': 'css/main.css',
+  })
   config.addPassthroughCopy('./_redirects')
 
   return {

--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,11 @@
+# The catch-all at the bottom is forced (`200!`), so it rewrites even urls
+# that do exist as files. Every static asset therefore needs a forced rule of
+# its own, mapping it to itself, or it is served the HTML of the homepage:
+# `/js/bundle.js` came back as `<!doctype html>` and the whole site was a
+# blank page with `Unexpected token '<'` in the console.
 /img/*	/img/:splat	200!
+/js/*	/js/:splat	200!
+/css/*	/css/:splat	200!
 
 # The functions answer at `/.netlify/functions/*`, which is not a url anyone
 # would type or hand to a language model. `/api/*` is the one the README and

--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -1,26 +1,36 @@
 /**
- * @file The frontend bundle is built by Nunjucks `{% include %}`-ing every
- * file listed in base.njk into one inline <script>, each wrapped in its own
- * IIFE. So Nunjucks reads these .js files as templates, and anything that
- * looks like a Nunjucks delimiter is not JavaScript to it.
+ * @file The frontend bundle is built by Nunjucks `{% include %}`-ing every file
+ * listed in `src/frontend/js/bundle.njk` into one file, each wrapped in its own
+ * IIFE, emitted to `/js/bundle.js` and loaded by base.njk from that url. So
+ * Nunjucks reads these .js files as templates, and anything that looks like a
+ * Nunjucks delimiter is not JavaScript to it.
  *
  * When that happens nothing fails loudly: the include renders to nothing, the
- * IIFE around it loses its closing brace, and the whole 130KB bundle becomes
- * one syntax error. The build is green, the deploy is green, and every page
- * on the site is blank. A JSDoc `@typedef {{ a: string }}` cost us exactly
- * that, so the delimiters are worth a test.
+ * IIFE around it loses its closing brace, and the whole 140KB bundle becomes
+ * one syntax error. The build is green, the deploy is green, and every page on
+ * the site is blank. A JSDoc `@typedef` with a brace pair cost us exactly that,
+ * so the delimiters are worth a test — as is the bundle parsing at all, which
+ * is the check that catches the next cause rather than that one.
  */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const LAYOUT = path.join(__dirname, "..", "layouts", "base.njk");
+const INCLUDES = path.join(__dirname, "..");
+const BUNDLE = path.join(INCLUDES, "..", "js", "bundle.njk");
+const LAYOUT = path.join(INCLUDES, "layouts", "base.njk");
+const ROOT = path.join(INCLUDES, "..", "..", "..");
+const ELEVENTY = path.join(ROOT, ".eleventy.js");
+const REDIRECTS = path.join(ROOT, "_redirects");
 
-/** The files base.njk inlines, in the order it inlines them. */
+const read = (file) => fs.readFileSync(file, "utf8");
+
+/** The files bundle.njk inlines, in the order it inlines them. */
 const includedFiles = () =>
-  [...fs.readFileSync(LAYOUT, "utf8").matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)]
-    .map(([, includePath]) => includePath);
+  [...read(BUNDLE).matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)].map(
+    ([, includePath]) => includePath
+  );
 
 /** `{{ … }}` interpolates, `{% … %}` is a tag, `{# … #}` is a comment. */
 const DELIMITERS = [
@@ -29,14 +39,123 @@ const DELIMITERS = [
   ["{#", /\{#/],
 ];
 
-test("base.njk still inlines the frontend scripts", () => {
-  assert.ok(includedFiles().length > 0, "found no js() includes in base.njk");
+test("bundle.njk still inlines the frontend scripts", () => {
+  assert.ok(includedFiles().length > 0, "found no js() includes in bundle.njk");
+});
+
+test("bundle.njk emits the bundle to a url, minified", () => {
+  const source = read(BUNDLE);
+
+  assert.match(
+    source,
+    /^---\r?\n(?:.*\r?\n)*?permalink:\s*\/js\/bundle\.js\s*\r?$/m,
+    "bundle.njk must emit to /js/bundle.js, which is the url base.njk loads"
+  );
+  assert.match(
+    source,
+    /\{\{\s*scripts\s*\|\s*jsmin\s*\|\s*safe\s*\}\}/,
+    "the bundle must go through the jsmin filter"
+  );
+});
+
+test("bundle.njk still wraps each file in its own IIFE", () => {
+  // `const` at the top level of a file would otherwise collide with the same
+  // name in any other file — they share one global scope. The concatenation
+  // this file's parse test builds mirrors this macro, so it has to hold.
+  assert.match(
+    read(BUNDLE),
+    /\{%\s*macro js\(path\)\s*%\}\s*\(\(\)\s*=>\s*\{\s*\{%\s*include path\s*%\}\s*\}\)\(\);\s*\{%\s*endmacro\s*%\}/,
+    "the js() macro no longer wraps its include in an IIFE"
+  );
+});
+
+test("base.njk loads the bundle by url and inlines no frontend script", () => {
+  const layout = read(LAYOUT);
+
+  assert.match(
+    layout,
+    /<script src="\/js\/bundle\.js"><\/script>/,
+    "base.njk must load /js/bundle.js"
+  );
+  assert.equal(
+    [...layout.matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)].length,
+    0,
+    "base.njk inlines frontend files again; the list belongs in bundle.njk"
+  );
+});
+
+test("the stylesheet is served from a url, not inlined", () => {
+  const layout = read(LAYOUT);
+
+  assert.match(layout, /<link rel="stylesheet" href="\/css\/main\.css">/);
+  assert.doesNotMatch(
+    layout,
+    /\{%\s*include\s+"css\/main\.css"\s*%\}/,
+    "base.njk inlines the stylesheet again"
+  );
+  assert.match(
+    read(ELEVENTY),
+    /addPassthroughCopy\(\{[^}]*'\.\/src\/frontend\/_includes\/css\/main\.css':\s*'css\/main\.css'/,
+    ".eleventy.js must copy main.css to /css/, or that <link> is a 404"
+  );
+});
+
+test("the assets base.njk loads are exempt from the SPA catch-all", () => {
+  // `/*  /index.html  200!` is forced, so it rewrites urls that exist as files
+  // too. An asset is only served as itself if it has a forced rule of its own,
+  // the way `/img/*` does. Without one, `/js/bundle.js` answers with the
+  // homepage's HTML and the site is blank with `Unexpected token '<'`.
+  const exempt = [
+    ...read(REDIRECTS).matchAll(/^(\/\S*?)\/\*\s+\S+\s+200!/gm),
+  ].map(([, prefix]) => prefix + "/");
+
+  const assets = [
+    ...read(LAYOUT).matchAll(/<(?:link|script)\b[^>]*?\b(?:href|src)="(\/[^"]*)"/g),
+  ].map(([, url]) => url);
+
+  assert.ok(assets.length > 0, "found no local assets in base.njk");
+
+  assets.forEach((url) =>
+    assert.ok(
+      exempt.some((prefix) => url.startsWith(prefix)),
+      `base.njk loads ${url}, which no forced rule in _redirects exempts, so ` +
+        `the catch-all answers it with index.html`
+    )
+  );
+});
+
+test("every file the bundle lists exists", () => {
+  includedFiles().forEach((includePath) =>
+    assert.ok(
+      fs.existsSync(path.join(INCLUDES, includePath)),
+      `bundle.njk lists ${includePath}, which does not exist`
+    )
+  );
+});
+
+test("components/index.js comes before the files that populate it", () => {
+  // It is the file that creates the `Components` global and the `Components.UI`
+  // / `.Home` / `.Profile` / `.List` objects every other component assigns
+  // into. Order is load-bearing across the whole list; this is the edge of it
+  // that turns into a TypeError on a blank page rather than something subtle.
+  const files = includedFiles();
+  const root = files.indexOf("js/components/index.js");
+
+  assert.notEqual(root, -1, "js/components/index.js is no longer bundled");
+
+  files.forEach((includePath, i) => {
+    if (!includePath.startsWith("js/components/") || i === root) return;
+    assert.ok(
+      i > root,
+      `${includePath} is bundled before js/components/index.js, which is what ` +
+        `creates the Components object it assigns into`
+    );
+  });
 });
 
 includedFiles().forEach((includePath) => {
   test(`${includePath} holds no Nunjucks delimiter`, () => {
-    const file = path.join(__dirname, "..", includePath);
-    const lines = fs.readFileSync(file, "utf8").split("\n");
+    const lines = read(path.join(INCLUDES, includePath)).split("\n");
 
     lines.forEach((line, i) => {
       DELIMITERS.forEach(([delimiter, pattern]) =>
@@ -48,4 +167,21 @@ includedFiles().forEach((includePath) => {
       );
     });
   });
+});
+
+test("the concatenated bundle parses as JavaScript", () => {
+  // Mirrors the js() macro in bundle.njk, which the test above pins. `new
+  // Function` compiles the body without running it, so this is a syntax check
+  // and nothing more — but a syntax error here is the whole site, blank.
+  const bundle = includedFiles()
+    .map((includePath) => {
+      const source = read(path.join(INCLUDES, includePath));
+      return `(() => {\n${source}\n})();\n`;
+    })
+    .join("");
+
+  assert.doesNotThrow(
+    () => new Function(bundle),
+    "the bundle does not parse, so every page on the site would be blank"
+  );
 });

--- a/src/frontend/_includes/js/components/index.js
+++ b/src/frontend/_includes/js/components/index.js
@@ -19,11 +19,16 @@ const initComponent = ({ content, initializer, style }) => {
   // This is passed to `content`, `initializer` and `style`
   const id = uniqueId()
 
-  // Create <style> tag if none exists
-  const styleTag = $('head style')
-  if (styleTag.length === 0) {
-    $('head').prepend('<style></style>')
+  // The <style> the component styles below are collected into, created on
+  // first use. It is this component system's own tag, named rather than found
+  // with `$('head style')`: litepicker injects a <style> of its own at the top
+  // of <head>, and whichever of the two got there first used to decide where
+  // every component style landed. Appended, so it sits after the stylesheet
+  // <link>s and a component's style wins over main.css and bootstrap.
+  if ($('#component-styles').length === 0) {
+    $('head').append('<style id="component-styles"></style>')
   }
+  const styleTag = $('#component-styles')
 
   // Add the component style to the site if it has not already
   const componentStyle = style?.({ id })

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -25,9 +25,12 @@
     {# 1.12.1, matching the bootstrap-table script below. #}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.css" integrity="sha384-HyusOcKCYSnjwC8jY4YvjZAwLgeqDPWFDu2/AFf5OrZd7ykufk0gwxexoqmg5W8N" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
-    <style>
-        {% include "css/main.css" %}
-    </style>
+    {# `_includes/css/main.css`, copied to this url by the `addPassthroughCopy`
+       in `.eleventy.js`. #126 dropped a <link> at this url because nothing
+       emitted the file and every page load spent a request on a 404; the
+       passthrough is the other half of that, so the <link> comes back and the
+       stylesheet stops being re-sent inline with every HTML response. #}
+    <link rel="stylesheet" href="/css/main.css">
 
     {# The page cannot draw until every script below has been fetched and run,
        so anything not needed to draw it carries `defer` and gets out of the
@@ -49,63 +52,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.js" integrity="sha384-ClQpQScPqQSyD6GCOejtBWJ/GwscJaHjNtqDcG3/JmeQ1VBuzQCeZy0zNBQtuhiH" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js" integrity="sha384-pF+2qz7eFoUyrCTPr8gVboYJ7fNpmJKJzl0vPX6w3XDML+Of8bMSyd6fZIRJdwo7" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    {# macro to include JS with its own const variable scope
-       to not have `const` assignments pollute projectwide scope #}
-    {% macro js(path) %}
-      (() => {
-        {% include path %}
-      })();
-    {% endmacro %}
-
-    {# Include *all* your JS files here.
-      The order matters, files above can't use
-      global variables set in files under.
-    #}
-    {% set scripts %}
-      {{ js("js/old_main.js") }}
-      {{ js("js/packages/neverthrow.js") }}
-      {{ js("js/utils/general.js") }}
-      {{ js("js/utils/nullable.js") }}
-      {{ js("js/utils/conversions.js") }}
-      {{ js("js/utils/http.js") }}
-      {{ js("js/utils/netlify.js") }}
-      {{ js("js/utils/diff.js") }}
-      {{ js("js/utils/entry_form_io.js") }}
-      {{ js("js/utils/review_template.js") }}
-      {{ js("js/utils/columns.js") }}
-      {{ js("js/utils/tables.js") }}
-      {{ js("js/components/index.js") }}
-      {{ js("js/components/common.js") }}
-      {{ js("js/components/with_remote_data.js") }}
-      {{ js("js/components/ui/button.js") }}
-      {{ js("js/components/ui/menu.js") }}
-      {{ js("js/components/ui/input_with_action.js") }}
-      {{ js("js/components/ui/notification.js") }}
-      {{ js("js/components/ui/base.js") }}
-      {{ js("js/components/ui/modal.js") }}
-      {{ js("js/components/ui/tabbed.js") }}
-      {{ js("js/components/home/username_setter.js") }}
-      {{ js("js/components/profile/profile_lists.js") }}
-      {{ js("js/components/profile/profile_stats.js") }}
-      {{ js("js/components/profile/biography.js") }}
-      {{ js("js/components/profile/index.js") }}
-      {{ js("js/components/home/index.js") }}
-      {{ js("js/components/list/add_edit_entry/buttons.js") }}
-      {{ js("js/components/list/add_edit_entry/external_fields.js") }}
-      {{ js("js/components/list/add_edit_entry/personal_fields.js") }}
-      {{ js("js/components/list/add_edit_entry/cover_column.js") }}
-      {{ js("js/components/list/add_edit_entry/draft.js") }}
-      {{ js("js/components/list/add_edit_entry/history.js") }}
-      {{ js("js/components/list/add_edit_entry/entry_form.js") }}
-      {{ js("js/components/list/add_edit_entry/search_results.js") }}
-      {{ js("js/components/list/add_edit_entry/add_entry_link.js") }}
-      {{ js("js/components/list/list.js") }}
-      {{ js("js/components/list/index.js") }}
-      {{ js("js/components/router.js") }}
-    {% endset %}
-    <script>
-      {{ scripts | safe }}
-    </script>
+    {# The frontend's own forty files, concatenated and minified into one file
+       by `js/bundle.njk` — which is where the list and, more to the point, the
+       order live. Inlining them here meant re-sending 140 KB with every HTML
+       response; as a url the browser fetches it once and revalidates it after
+       that. No `defer`: the block at the end of <body> reaches for
+       `Components`, and the CDN scripts above are what the bundle itself
+       reaches for while it runs. #}
+    <script src="/js/bundle.js"></script>
   </head>
   <body>
     {#

--- a/src/frontend/js/bundle.njk
+++ b/src/frontend/js/bundle.njk
@@ -1,0 +1,69 @@
+---
+permalink: /js/bundle.js
+eleventyExcludeFromCollections: true
+---
+{# The frontend, concatenated and minified into one file the browser can keep.
+
+   This block used to sit inline in `layouts/base.njk`, so every HTML response
+   carried all 140 KB of it and no browser could ever reuse a copy. The site is
+   a client-side router, so `/`, `/profile/nil`, `/films/nil` and `/games/nil`
+   are one page answered four times — four copies of the same bytes for one
+   visitor. As a url it is fetched once and revalidated by ETag after that.
+
+   `base.njk` loads the result with `<script src="/js/bundle.js">`. #}
+
+{# macro to include JS with its own const variable scope
+   to not have `const` assignments pollute projectwide scope #}
+{% macro js(path) %}
+  (() => {
+    {% include path %}
+  })();
+{% endmacro %}
+
+{# Include *all* your JS files here.
+  The order matters, files above can't use
+  global variables set in files under.
+#}
+{% set scripts %}
+  {{ js("js/old_main.js") }}
+  {{ js("js/packages/neverthrow.js") }}
+  {{ js("js/utils/general.js") }}
+  {{ js("js/utils/nullable.js") }}
+  {{ js("js/utils/conversions.js") }}
+  {{ js("js/utils/http.js") }}
+  {{ js("js/utils/netlify.js") }}
+  {{ js("js/utils/diff.js") }}
+  {{ js("js/utils/entry_form_io.js") }}
+  {{ js("js/utils/review_template.js") }}
+  {{ js("js/utils/columns.js") }}
+  {{ js("js/utils/tables.js") }}
+  {{ js("js/components/index.js") }}
+  {{ js("js/components/common.js") }}
+  {{ js("js/components/with_remote_data.js") }}
+  {{ js("js/components/ui/button.js") }}
+  {{ js("js/components/ui/menu.js") }}
+  {{ js("js/components/ui/input_with_action.js") }}
+  {{ js("js/components/ui/notification.js") }}
+  {{ js("js/components/ui/base.js") }}
+  {{ js("js/components/ui/modal.js") }}
+  {{ js("js/components/ui/tabbed.js") }}
+  {{ js("js/components/home/username_setter.js") }}
+  {{ js("js/components/profile/profile_lists.js") }}
+  {{ js("js/components/profile/profile_stats.js") }}
+  {{ js("js/components/profile/biography.js") }}
+  {{ js("js/components/profile/index.js") }}
+  {{ js("js/components/home/index.js") }}
+  {{ js("js/components/list/add_edit_entry/buttons.js") }}
+  {{ js("js/components/list/add_edit_entry/external_fields.js") }}
+  {{ js("js/components/list/add_edit_entry/personal_fields.js") }}
+  {{ js("js/components/list/add_edit_entry/cover_column.js") }}
+  {{ js("js/components/list/add_edit_entry/draft.js") }}
+  {{ js("js/components/list/add_edit_entry/history.js") }}
+  {{ js("js/components/list/add_edit_entry/entry_form.js") }}
+  {{ js("js/components/list/add_edit_entry/search_results.js") }}
+  {{ js("js/components/list/add_edit_entry/add_entry_link.js") }}
+  {{ js("js/components/list/list.js") }}
+  {{ js("js/components/list/index.js") }}
+  {{ js("js/components/router.js") }}
+{% endset %}
+{{ scripts | jsmin | safe }}


### PR DESCRIPTION
`base.njk` built a `scripts` variable out of forty `{% include %}`s and emitted it into one inline `<script>`, and inlined `main.css` the same way. That is ~140 KB of JavaScript and 2.6 KB of CSS in every HTML response, uncacheable by construction. The site is a client-side router, so `/`, `/profile/nil`, `/films/nil` and `/games/nil` are one page answered four times — four copies of the same bytes for one visitor.

The same forty files, in the same order, now go to `/js/bundle.js`, built by the new `src/frontend/js/bundle.njk`; `main.css` is passed through to `/css/main.css`. The list and the ordering comment moved wholesale into `bundle.njk`, which is the only place they live now — `base.njk` loads the result with one `<script src>`, kept undeferred where the inline block was, since the snippet at the end of `<body>` reaches for `Components`.

| | before | after |
| --- | --- | --- |
| `index.html` | 151,821 B | 4,215 B |
| `/js/bundle.js` | — | 74,021 B (cached) |
| `/css/main.css` | — | 2,990 B (cached) |
| first visit | 151,821 B | 81,226 B |
| each navigation after | 151,821 B | 4,215 B |

The `jsmin` filter that has sat unused in `.eleventy.js` since the repo was bootstrapped is what takes the bundle from 142 KB to 74 KB. Its worry was whether UglifyJS — an ES5-era minifier — could cope with the optional chaining, nullish coalescing, template literals and private class fields this code uses; 3.14.5 parses and mangles all of them, and the deploy preview draws a real list off the minified bundle rather than this resting on a zero exit code.

## Things that had to not break

**The catch-all in `_redirects` is forced.** `/*  /index.html  200!` rewrites urls that exist as files too — which is what the otherwise-puzzling `/img/*  /img/:splat  200!` line above it is for. Without the same rule for `/js/*` and `/css/*`, `/js/bundle.js` answers with the homepage's HTML and every page is blank with `Unexpected token '<'`. Worth knowing that a static server pointed at `dist/` does *not* reproduce this, because it checks the filesystem before falling back; the first deploy preview on this branch was blank, and that is what caught it.

**`jsmin` swallowed its own failures.** It logged and returned the input unminified, so a bundle that did not parse shipped anyway with one line in the build log. Every page here is drawn by that one file, so that is a blank site — the failure mode of `3c3fab0`, where a JSDoc brace pair blanked everything. It throws now, which is also what makes the build itself a real check on the bundle.

**The `htmlmin` transform runs over every output file**, and `/js/bundle.js` is one of them now. `collapseWhitespace` over JavaScript eats the newline that ends a `//` comment and takes the rest of the file with it, so the transform is limited to `.html` output.

**`initComponent` had a latent crash that dropping the inline `<style>` woke up.** It captured `$('head style')` *before* the branch that creates the tag, so when no `<style>` existed the selection stayed empty and `styleTag.html().includes(...)` threw on `undefined`. Nothing had ever reached it, because the layout always inlined `main.css` into a `<style>` for it to find. Removing that made it the only path, and the first local build of this branch was a blank page. It now owns a `#component-styles` tag of its own, matched by id rather than by `$('head style')`: litepicker injects a `<style>` at the top of `<head>`, and whichever of the two got there first used to decide where every component style landed. It is appended rather than prepended so component styles still outrank `main.css` and bootstrap instead of losing to them from the top of `<head>`.

## Relationship to #103

#126 took the first of the two options #103 offered — delete the dead `<link>`, keep the inline `<style>` — and noted the second was the better end state and belonged with this issue. This is that second option, so the `<link rel="stylesheet" href="/css/main.css">` comes back, now pointing at a file the build actually emits.

## Tests

`bundle.test.js` follows the list to `bundle.njk` and keeps its Nunjucks-delimiter checks — the files are still `{% include %}`d, so that hazard is unchanged. Added around them: that every asset `base.njk` loads is exempt from the forced catch-all in `_redirects` (this one fails on `main` + the passthrough alone, which is the bug above), that `base.njk` loads the bundle by url and inlines neither the scripts nor the stylesheet, that `bundle.njk` still emits to `/js/bundle.js` through `jsmin`, that the `js()` macro still wraps each file in its own IIFE, that every listed file exists, that `js/components/index.js` still precedes every file that assigns into the `Components` object it creates, and that the whole concatenation parses as JavaScript — the general form of the brace bug, rather than only its one known cause.

`npm test` is 295 passing, and `git ls-files '*.js' | xargs -n1 node --check` is clean.

## Verifying

Locally: built `dist/` and served it with the SPA fallback, against a build of `main` on another port. The rendered `#site` markup is byte-identical to `main`'s at 744 characters once the random component ids are normalised, and computed colour, font, size, alignment and margin match on `body`, `a`, `h1`, `#menu-logo` and `#menu-logo img`. That comparison is what rules out a mangling or cascade regression, but as above it cannot see the redirect problem.

On the deploy preview, which can: `/films/nil` draws 1,519 rows of real data with an empty console, `/js/bundle.js` and `/css/main.css` each arrive as their own 200 rather than as HTML, and `#component-styles` lands last in `<head>`, after the `/css/main.css` link.

Closes #110.
