### PR TITLE
fix: make the backfill actually load its adapters

### DIFF
--- a/src/db_maintenance/scripts/backfill_work_metadata.js
+++ b/src/db_maintenance/scripts/backfill_work_metadata.js
@@ -188,15 +188,25 @@ const backfillCollection = async (db, collection) => {
  * Lazily required: each adapter reads (and the games one throws on) its own
  * env vars at load time, so requiring all four would make a films-only run
  * depend on Twitch credentials.
+ *
+ * Which is why the catch has to be narrow. Skipping a collection is the right
+ * answer to "this run has no Twitch credentials" and the wrong answer to "the
+ * path in the descriptor is wrong" — the second silently turns every run into
+ * a no-op that reports nothing amiss, which is what it did until
+ * work_collections.js started resolving these paths itself. That resolution
+ * means the adapter's own module can no longer be the thing that isn't found,
+ * so if it is, something is wrong with the wiring: say so and stop.
  */
 const loadAdapter = (collection) => {
   try {
     return require(collection.adapterModule);
   } catch (e) {
+    if (e?.code === "MODULE_NOT_FOUND" && e.requireStack?.[0] === __filename) {
+      throw e;
+    }
     console.log(
-      `  skipping ${collection.works}: could not load adapter (${
-        e?.message ?? e
-      })`
+      `  skipping ${collection.works}: ${collection.adapterModule} failed to ` +
+        `load (${e?.message ?? e})`
     );
     return undefined;
   }

--- a/src/db_maintenance/work_collections.js
+++ b/src/db_maintenance/work_collections.js
@@ -18,24 +18,43 @@ const { WORK_TYPES } = require("../api/utils/work_types");
  * — always one of the shared row's `identityPrefixes`.
  * `stringArrayFields` / `numberFields` are the metadata fields we expect the
  * adapter to fill, and that the audit checks for corruption.
+ *
+ * `adapterModule` is resolved here, with `require.resolve`, rather than stored
+ * as a relative specifier: the descriptors are read from `scripts/` as well as
+ * from this directory, and a relative specifier resolves against whichever
+ * module calls `require`, not against this file. `scripts/` is one level down,
+ * so every path missed by exactly one `..` and the backfill silently skipped
+ * every collection. Resolving means the path is fixed at the only place it can
+ * be read correctly, and a typo throws here, at load, instead of arriving in
+ * the consumer's catch looking like a missing API key.
+ *
+ * `require.resolve` finds the file without executing it, so the adapters stay
+ * unloaded — see `loadAdapter` in scripts/backfill_work_metadata.js for why
+ * that matters.
  */
 const SCRIPT_FIELDS = {
   films: {
-    adapterModule: "../api/utils/external_api_adapters/films/tmdb",
+    adapterModule: require.resolve(
+      "../api/utils/external_api_adapters/films/tmdb"
+    ),
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration"],
     defaultDelayMs: 300,
   },
   tv: {
-    adapterModule: "../api/utils/external_api_adapters/tv_shows/tmdb",
+    adapterModule: require.resolve(
+      "../api/utils/external_api_adapters/tv_shows/tmdb"
+    ),
     retrievePrefix: "tmdb",
     stringArrayFields: ["genres", "directors", "actors"],
     numberFields: ["releaseYear", "duration", "episodes"],
     defaultDelayMs: 300,
   },
   games: {
-    adapterModule: "../api/utils/external_api_adapters/games/igdb",
+    adapterModule: require.resolve(
+      "../api/utils/external_api_adapters/games/igdb"
+    ),
     retrievePrefix: "igdb",
     stringArrayFields: ["genres", "platforms", "studios", "publishers"],
     numberFields: ["releaseYear", "duration"],
@@ -43,7 +62,9 @@ const SCRIPT_FIELDS = {
     defaultDelayMs: 1000,
   },
   books: {
-    adapterModule: "../api/utils/external_api_adapters/books/google",
+    adapterModule: require.resolve(
+      "../api/utils/external_api_adapters/books/google"
+    ),
     retrievePrefix: "ISBN",
     stringArrayFields: ["genres", "authors", "publishers"],
     numberFields: ["releaseYear", "duration"],

--- a/src/db_maintenance/work_collections.test.js
+++ b/src/db_maintenance/work_collections.test.js
@@ -1,0 +1,68 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { COLLECTIONS } = require("./work_collections");
+
+/**
+ * The consumer is scripts/backfill_work_metadata.js, a directory below this
+ * one, and it passes `adapterModule` straight to `require`. A relative
+ * specifier resolves against the caller, so one stored relative to this file
+ * pointed at src/db_maintenance/api/... from there — every collection skipped,
+ * every run reporting success.
+ */
+test("every adapterModule is an absolute path to a file that exists", () => {
+  for (const collection of COLLECTIONS) {
+    assert.ok(
+      path.isAbsolute(collection.adapterModule),
+      `${collection.type}: ${collection.adapterModule} is not absolute, so it ` +
+        `means different things to different callers`
+    );
+    assert.ok(
+      fs.existsSync(collection.adapterModule),
+      `${collection.type}: no adapter at ${collection.adapterModule}`
+    );
+  }
+});
+
+test("each collection names an adapter under its own type's folder", () => {
+  const folders = {
+    films: "films",
+    tv: "tv_shows",
+    games: "games",
+    books: "books",
+  };
+
+  for (const collection of COLLECTIONS) {
+    assert.equal(
+      path.basename(path.dirname(collection.adapterModule)),
+      folders[collection.type],
+      `${collection.type} points at ${collection.adapterModule}`
+    );
+  }
+});
+
+/**
+ * The script-only half is written here, the prefixes come from
+ * ../api/utils/work_types.js, and only a retrieve by an identity prefix names
+ * the work it claims to — an `hltb` id names a page, not a game.
+ */
+test("a retrievePrefix is always one of its type's identityPrefixes", () => {
+  for (const collection of COLLECTIONS) {
+    assert.ok(
+      collection.identityPrefixes.includes(collection.retrievePrefix),
+      `${collection.type} retrieves by ${collection.retrievePrefix}, which is ` +
+        `not in ${collection.identityPrefixes.join(", ")}`
+    );
+  }
+});
+
+test("every shared work type gets its script-only fields", () => {
+  for (const collection of COLLECTIONS) {
+    assert.ok(
+      collection.adapterModule && collection.retrievePrefix,
+      `${collection.type} has no SCRIPT_FIELDS entry`
+    );
+  }
+});


### PR DESCRIPTION
Every collection descriptor in `src/db_maintenance/work_collections.js` names its adapter with a path relative to that file (`../api/utils/external_api_adapters/films/tmdb`). The only thing that reads it is `loadAdapter` in `scripts/backfill_work_metadata.js`, one directory down, and `require` resolves a relative specifier against the module that calls it — so it looked for `src/db_maintenance/api/utils/...`, which does not exist. Every path was short by exactly one `..`, and no adapter had ever loaded.

It failed quietly. `loadAdapter` requires lazily inside a try/catch on purpose — each adapter reads its own env vars at load time and the igdb one throws outright without Twitch credentials, so a films-only run should not need them — and a skip is the right answer to that. It was also, until now, the answer to a wrong path: a full backfill retrieved nothing, skipped all four collections, and reported nothing amiss.

The paths are now resolved with `require.resolve` in `work_collections.js`, the file they are written in and the only place they read correctly. That hands every caller an absolute path, and it finds the file without executing it, so the adapters stay unloaded until `loadAdapter` asks for one. A typo now throws at import instead of arriving in the consumer's catch dressed as a missing API key.

`loadAdapter` keeps the lazy require and the catch, but no longer swallows everything. With the path resolved on the way in, the adapter's own module can only be missing if the wiring is broken, so a `MODULE_NOT_FOUND` naming it (`requireStack[0] === __filename`) rethrows; a module the adapter itself requires, or an unset key, still skips that one collection. The skip message names the resolved module.

Only the four `adapterModule` values change — `SCRIPT_FIELDS` and the merge over the shared `WORK_TYPES` rows from #133 are untouched.

`src/db_maintenance/work_collections.test.js` is new: it asserts each `adapterModule` is an absolute path to a file that exists, under its type's folder — what the old strings would have failed — plus two invariants on the assembled descriptors, that every shared row picks up its script-only half and that a `retrievePrefix` is always one of its type's `identityPrefixes`. No install, database or keys needed.

## Verifying

Run from a local-disk copy per `CLAUDE.md`, with credentials read from the Drive `.env` through `MEMO_ENV_FILE`, driving a copy of `loadAdapter` over all four descriptors:

- No credentials: films and tv skip with `TMDB_API_KEY is not set.`, games with the Twitch message, books loads. That is resolution reaching the adapter and the adapter's own initialisation failing — the case the catch exists for.
- With the real `.env`: all four load, each with a `retrieve` function.
- `npm test`: 337 pass, 0 fail.

No backfill was run — that reads production and hits the external APIs.
