### PR TITLE
fix: find a novel called "Recursion" by searching for "Recursion"

### DIFF
--- a/src/api/utils/external_api_adapters/books/google.js
+++ b/src/api/utils/external_api_adapters/books/google.js
@@ -7,7 +7,9 @@
 const { ResultAsync } = require('neverthrow')
 const errors = require('../../errors')
 const axios = require('axios').default
+const { throwIt } = require('../../general')
 const { retrying, describeFailure, publicFailure, statusOf } = require('../retry')
+const { BASE_URL, searchUrls, toSearchResults } = require('./google_search')
 
 const { GOOGLE_API_KEY } = process.env
 
@@ -17,23 +19,14 @@ const urlKey =
     ? `&key=${GOOGLE_API_KEY}`
     : ''
 
-/** @type SearchFunction */
+/**
+ * A search is several requests now — see ./google_search.js for which, and
+ * why one of them wasn't enough.
+ * @type SearchFunction
+ */
 const search = (titleSearch) => ResultAsync.fromPromise(
-  retrying(() => axios({
-    method: 'get',
-    url: `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(titleSearch)}&maxResults=40${urlKey}`
-  }))
-    .then(({ data }) => volumesOf(data)
-      .filter(({ volumeInfo }) =>
-        volumeInfo?.industryIdentifiers?.some((i) => i.type?.includes('ISBN'))
-      )
-      .map(({ volumeInfo }) => ({
-        title: `${volumeInfo?.title} [${volumeInfo?.authors?.join(', ')}]`,
-        year: volumeInfo?.publishedDate?.substring(0, 4),
-        ref: volumeInfo?.industryIdentifiers?.find((i) => i.type?.includes('ISBN'))?.identifier,
-        imageUrl: volumeInfo?.imageLinks?.thumbnail,
-      }))
-    ),
+  searchPages(searchUrls(titleSearch, urlKey))
+    .then((pages) => toSearchResults(titleSearch, pages)),
   toError('searching for books')
 )
 
@@ -41,7 +34,7 @@ const search = (titleSearch) => ResultAsync.fromPromise(
 const retrieve = (ref) => ResultAsync.fromPromise(
   retrying(() => axios({
     method: 'get',
-    url: `https://www.googleapis.com/books/v1/volumes?q=isbn:${ref}${urlKey}`
+    url: `${BASE_URL}?q=isbn:${ref}${urlKey}`
   }))
     .then(({ data }) => volumesOf(data).map(({ volumeInfo }) => ({
       entryType: 'Book',
@@ -74,6 +67,31 @@ module.exports = {
  * @type {(data: any) => any[]}
  */
 const volumesOf = (data) => data?.items ?? []
+
+/**
+ * The volumes on each of `urls`, requested together.
+ *
+ * A page Google wouldn't answer comes back empty rather than failing the
+ * search: it answers something like one search in eight with a 503 (see
+ * ../retry.js), and four requests where there used to be one is four chances
+ * of that. Fewer results is a better answer than none, and `retrying` has
+ * already given the page its three attempts by the time we get here.
+ *
+ * If *every* page failed there is nothing to show, so the first failure goes
+ * on to `toError` the way a single failed request always did.
+ * @type {(urls: string[]) => Promise<any[][]>}
+ */
+const searchPages = (urls) => Promise.all(
+  urls.map((url) =>
+    retrying(() => axios({ method: 'get', url }))
+      .then(({ data }) => ({ volumes: volumesOf(data) }))
+      .catch((err) => ({ err }))
+  )
+).then((pages) =>
+  pages.some((page) => page.volumes)
+    ? pages.map((page) => page.volumes ?? [])
+    : throwIt(pages[0].err)
+)
 
 /** @type {(ref: string) => never} */
 const throwNoSuchVolume = (ref) => {

--- a/src/api/utils/external_api_adapters/books/google_search.js
+++ b/src/api/utils/external_api_adapters/books/google_search.js
@@ -1,0 +1,186 @@
+/**
+ * @file What a book search asks Google Books for, and what it makes of the
+ * answers.
+ *
+ * Pure and dependency-free for the reason ../tmdb_mapping.js is: ./google.js
+ * is axios and a network call, and everything that decides which books a
+ * search comes back with — and in what order — lives here where the suite can
+ * reach it.
+ *
+ * Searching "recursion" used to answer with eleven books on recursion theory
+ * and nothing else, which read as "the novel isn't in the database"; the same
+ * search typed as "recursion blake crouch" found it at the top. #138. Google
+ * ranks a bare keyword against the whole of a book's text, so a 2019 novel
+ * loses to every monograph with the word in its index. Three things come of
+ * that: `queriesFor`, `searchUrls` and the sort in `toSearchResults`.
+ */
+
+/**
+ * Google caps a response at 20 volumes however large `maxResults` is — the
+ * old search asked for 40 and was answered with 20 every time — so more than
+ * a page's worth means asking for more than one page.
+ */
+const PAGE_SIZE = 20
+
+/** Pages of each query. 80 candidates in, somewhere near 50 out. */
+const PAGES = 2
+
+const BASE_URL = 'https://www.googleapis.com/books/v1/volumes'
+
+/**
+ * The ISBN a book is stored and retrieved under. Google reports ISBN_10 and
+ * ISBN_13 for most volumes and one or the other for the rest; whichever comes
+ * first is what has always been used, and changing that would file new books
+ * under a different `apiRef` from the ones already in the database.
+ * @type {(volumeInfo: any) => string | undefined}
+ */
+const isbnOf = (volumeInfo) =>
+  volumeInfo?.industryIdentifiers
+    ?.find((identifier) => identifier?.type?.includes('ISBN'))
+    ?.identifier
+
+/**
+ * A book's title as it is shown and matched on. The subtitle is in it because
+ * a search now answers with enough books that "Sapiens" eight times over is
+ * not a list anyone can pick from, and Google files "A Brief History of
+ * Humankind" separately.
+ * @type {(volumeInfo: any) => string}
+ */
+const titleOf = (volumeInfo) =>
+  [volumeInfo?.title, volumeInfo?.subtitle].filter((part) => part).join(': ')
+
+/** @type {(volumeInfo: any) => object} */
+const toSearchResult = (volumeInfo) => ({
+  title: `${titleOf(volumeInfo)} [${volumeInfo?.authors?.join(', ')}]`,
+  year: volumeInfo?.publishedDate?.substring(0, 4),
+  ref: isbnOf(volumeInfo),
+  imageUrl: volumeInfo?.imageLinks?.thumbnail,
+})
+
+/**
+ * Punctuation, case and spacing are not what anyone is searching by:
+ * "Recursion: A Novel" and "recursion - a novel" are one title typed twice.
+ * @type {(title: any) => string}
+ */
+const normalizeTitle = (title) =>
+  String(title ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+
+/**
+ * 0 for a title that is the query, 1 for one that begins with it, 2 for the
+ * rest.
+ *
+ * Measured against the volume's own title rather than the row's, which carries
+ * the authors too — and against it both with and without its subtitle, so that
+ * "sapiens" is an exact match for "Sapiens: A Brief History of Humankind" and
+ * so is the whole thing typed out.
+ * @type {(titleSearch: string, volumeInfo: any) => number}
+ */
+const matchRank = (titleSearch, volumeInfo) => {
+  const query = normalizeTitle(titleSearch)
+  if (!query) return 2
+
+  return Math.min(...[volumeInfo?.title, titleOf(volumeInfo)].map((title) => {
+    const normalized = normalizeTitle(title)
+    if (normalized === query) return 0
+    return normalized.startsWith(`${query} `) ? 1 : 2
+  }))
+}
+
+/**
+ * Sorted by `matchRank` and stable within a rank, so Google's own ordering is
+ * what breaks ties. The rank is computed once per volume rather than once per
+ * comparison.
+ * @type {(titleSearch: string, volumeInfos: any[]) => any[]}
+ */
+const byTitleMatch = (titleSearch, volumeInfos) =>
+  volumeInfos
+    .map((volumeInfo) => ({ volumeInfo, rank: matchRank(titleSearch, volumeInfo) }))
+    .sort((a, b) => a.rank - b.rank)
+    .map(({ volumeInfo }) => volumeInfo)
+
+/**
+ * The first of `xs` under each key, keys of `undefined` dropped — which is how
+ * a volume Google holds no ISBN for leaves the results.
+ * @type {<T>(xs: T[], key: (x: T) => any) => T[]}
+ */
+const dedupedBy = (xs, key) => {
+  const seen = new Set()
+
+  return xs.filter((x) => {
+    const k = key(x)
+    if (k === undefined || seen.has(k)) return false
+    seen.add(k)
+    return true
+  })
+}
+
+/**
+ * The search runs twice: once restricted to titles and once as typed. The
+ * title-restricted one is what has the novel in it at all, and the plain one
+ * still carries the searches that aren't titles — an author's name, a phrase
+ * off the cover.
+ *
+ * The whole query goes inside the quotes because `intitle:` binds to the token
+ * after it and nothing else: `intitle:the hobbit` asks for "the" in a title
+ * and "hobbit" anywhere, where `intitle:"the hobbit"` asks what the user
+ * meant. Quotes the user typed come out first — they would close ours early.
+ * @type {(titleSearch: string) => string[]}
+ */
+const queriesFor = (titleSearch) => [
+  `intitle:"${titleSearch.replace(/"/g, ' ')}"`,
+  titleSearch,
+]
+
+/**
+ * Both queries, `PAGES` pages of each, in the order their results should be
+ * offered: the title-restricted ones first.
+ *
+ * `printType=books` keeps journals and magazines out. They carry no ISBN and
+ * are dropped below anyway, but they were dropped *after* Google had spent a
+ * page's worth of results on them — "Bulletin of the American Mathematical
+ * Society" cost as much of a search for "recursion" as a book did.
+ * @type {(titleSearch: string, urlSuffix?: string) => string[]}
+ */
+const searchUrls = (titleSearch, urlSuffix = '') =>
+  queriesFor(titleSearch).flatMap((query) =>
+    Array.from({ length: PAGES }, (_, page) =>
+      `${BASE_URL}?q=${encodeURIComponent(query)}` +
+      `&printType=books&maxResults=${PAGE_SIZE}` +
+      `&startIndex=${page * PAGE_SIZE}${urlSuffix}`
+    )
+  )
+
+/**
+ * The search results for `pages` of Google volumes, in the order they should
+ * be shown: the books whose title is what was typed, then the ones whose title
+ * starts with it, then the rest, each group in the order Google gave it.
+ *
+ * That sort is what puts Blake Crouch's "Recursion" on screen. It is 23rd of
+ * the title-restricted results, behind twenty books called "Recursion Theory"
+ * and the like, and an exact title match outranks every one of them.
+ *
+ * A volume with no ISBN is dropped rather than shown, because `retrieve` looks
+ * a book up by its ISBN and there would be nothing to fetch. Volumes are
+ * deduplicated by it too — the same edition comes back from both queries.
+ * @type {(titleSearch: string, pages: any[][]) => object[]}
+ */
+const toSearchResults = (titleSearch, pages) =>
+  byTitleMatch(
+    titleSearch,
+    dedupedBy(pages.flat().map((volume) => volume?.volumeInfo), isbnOf)
+  )
+    .map(toSearchResult)
+
+module.exports = {
+  BASE_URL,
+  PAGES,
+  PAGE_SIZE,
+  isbnOf,
+  matchRank,
+  normalizeTitle,
+  queriesFor,
+  searchUrls,
+  titleOf,
+  toSearchResult,
+  toSearchResults,
+}

--- a/src/api/utils/external_api_adapters/books/google_search.test.js
+++ b/src/api/utils/external_api_adapters/books/google_search.test.js
@@ -1,0 +1,191 @@
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  PAGES,
+  PAGE_SIZE,
+  isbnOf,
+  matchRank,
+  normalizeTitle,
+  queriesFor,
+  searchUrls,
+  titleOf,
+  toSearchResult,
+  toSearchResults,
+} = require('./google_search')
+
+/** A `/volumes` item, cut down to the fields that are read. */
+const aVolume = (volumeInfo) => ({ volumeInfo })
+
+/** Both of a volume's ISBNs, in the order Google lists them. */
+const isbns = (isbn13, isbn10) => [
+  { type: 'ISBN_13', identifier: isbn13 },
+  { type: 'ISBN_10', identifier: isbn10 },
+]
+
+const theNovel = aVolume({
+  title: 'Recursion',
+  subtitle: 'A Novel',
+  authors: ['Blake Crouch'],
+  publishedDate: '2019-06-11',
+  industryIdentifiers: isbns('9781524759797', '1524759791'),
+  imageLinks: { thumbnail: 'https://books.google.com/recursion.jpg' },
+})
+
+const theTextbook = aVolume({
+  title: 'Recursion Theory',
+  authors: ['Joseph R. Shoenfield'],
+  publishedDate: '2017-03-02',
+  industryIdentifiers: isbns('9781315077871', '1315077876'),
+})
+
+const aJournal = aVolume({
+  title: 'Bulletin of the American Mathematical Society',
+  publishedDate: '1930',
+  industryIdentifiers: [{ type: 'OTHER', identifier: 'UOM:39015026287299' }],
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// What gets asked for, which is half of the bug this file exists for: one
+// request for `recursion` had the novel nowhere in it at all.
+
+test('the search is title-restricted first, then as typed', () => {
+  assert.deepEqual(
+    queriesFor('recursion'),
+    ['intitle:"recursion"', 'recursion'],
+  )
+})
+
+test('a multi-word query is one title phrase, not a first word and a rest', () => {
+  // `intitle:the hobbit` asks for "the" in the title and "hobbit" anywhere.
+  assert.equal(queriesFor('the hobbit')[0], 'intitle:"the hobbit"')
+})
+
+test("a quote in the query can't close the one around it", () => {
+  assert.equal(queriesFor('say "hello"')[0], 'intitle:"say  hello "')
+})
+
+test('every query is asked for by the page, because a response holds 20', () => {
+  const urls = searchUrls('recursion')
+
+  assert.equal(urls.length, 2 * PAGES)
+  assert.deepEqual(
+    urls.map((url) => new URL(url).searchParams.get('startIndex')),
+    ['0', '20', '0', '20'],
+  )
+  assert.ok(urls.every((url) =>
+    new URL(url).searchParams.get('maxResults') === String(PAGE_SIZE)
+  ))
+})
+
+test('the title-restricted pages are asked for first', () => {
+  assert.deepEqual(
+    searchUrls('recursion').map((url) => new URL(url).searchParams.get('q')),
+    ['intitle:"recursion"', 'intitle:"recursion"', 'recursion', 'recursion'],
+  )
+})
+
+test('journals and magazines are left out of the search itself', () => {
+  assert.ok(searchUrls('recursion').every((url) =>
+    new URL(url).searchParams.get('printType') === 'books'
+  ))
+})
+
+test('the key, when there is one, survives being appended', () => {
+  const urls = searchUrls('recursion', '&key=abc123')
+
+  assert.ok(urls.every((url) => new URL(url).searchParams.get('key') === 'abc123'))
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// What comes back.
+
+test('a book is offered under the ISBN it will be retrieved by', () => {
+  // Whichever Google lists first, which is what books already in the database
+  // are filed under.
+  assert.equal(isbnOf(theNovel.volumeInfo), '9781524759797')
+  assert.equal(isbnOf(aJournal.volumeInfo), undefined)
+  assert.equal(isbnOf({}), undefined)
+})
+
+test('a row carries the subtitle, so that eight "Sapiens" are eight books', () => {
+  assert.equal(titleOf(theNovel.volumeInfo), 'Recursion: A Novel')
+  assert.equal(titleOf(theTextbook.volumeInfo), 'Recursion Theory')
+})
+
+test('a row is title, authors, year and cover', () => {
+  assert.deepEqual(toSearchResult(theNovel.volumeInfo), {
+    title: 'Recursion: A Novel [Blake Crouch]',
+    year: '2019',
+    ref: '9781524759797',
+    imageUrl: 'https://books.google.com/recursion.jpg',
+  })
+})
+
+test('a volume Google has no ISBN for is not offered', () => {
+  // `retrieve` looks a book up by its ISBN, so there would be nothing to fetch.
+  assert.deepEqual(toSearchResults('recursion', [[aJournal]]), [])
+})
+
+test('an edition that came back from both queries is offered once', () => {
+  const results = toSearchResults('recursion', [[theNovel], [theNovel, theTextbook]])
+
+  assert.deepEqual(results.map((r) => r.ref), ['9781524759797', '9781315077871'])
+})
+
+test('a page Google sent nothing for is no trouble', () => {
+  assert.deepEqual(toSearchResults('recursion', [[], [], [], []]), [])
+  assert.deepEqual(toSearchResults('recursion', [[{}]]), [])
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The order, which is the other half of #138: the novel is 23rd of the
+// title-restricted results, behind twenty books on recursion theory.
+
+test('the book called what was searched for comes first', () => {
+  const results = toSearchResults('recursion', [[theTextbook, theNovel]])
+
+  assert.deepEqual(
+    results.map((r) => r.title),
+    [
+      'Recursion: A Novel [Blake Crouch]',
+      'Recursion Theory [Joseph R. Shoenfield]',
+    ],
+  )
+})
+
+test('an exact title outranks a title that merely starts with the query', () => {
+  assert.equal(matchRank('recursion', theNovel.volumeInfo), 0)
+  assert.equal(matchRank('recursion', theTextbook.volumeInfo), 1)
+  assert.equal(matchRank('recursion', aJournal.volumeInfo), 2)
+})
+
+test('the subtitle counts as part of the title, typed or not', () => {
+  assert.equal(matchRank('Recursion: A Novel', theNovel.volumeInfo), 0)
+  assert.equal(matchRank('recursion a novel', theNovel.volumeInfo), 0)
+})
+
+test('case, punctuation and spacing are not what anyone searches by', () => {
+  assert.equal(normalizeTitle('  Recursion:  A Novel! '), 'recursion a novel')
+  assert.equal(normalizeTitle(undefined), '')
+  assert.equal(matchRank('RECURSION', theNovel.volumeInfo), 0)
+})
+
+test('a query that begins a title is not the same as one that appears in it', () => {
+  // "The History of the Hobbit" starts with neither.
+  const hobbit = aVolume({ title: 'The Hobbit, Or, There and Back Again' })
+  const history = aVolume({ title: 'The History of the Hobbit' })
+
+  assert.equal(matchRank('the hobbit', hobbit.volumeInfo), 1)
+  assert.equal(matchRank('the hobbit', history.volumeInfo), 2)
+})
+
+test('Google\'s own order is what breaks a tie', () => {
+  const first = aVolume({
+    ...theNovel.volumeInfo,
+    industryIdentifiers: isbns('9780525483601', '0525483608'),
+  })
+  const results = toSearchResults('recursion', [[first, theNovel]])
+
+  assert.deepEqual(results.map((r) => r.ref), ['9780525483601', '9781524759797'])
+})


### PR DESCRIPTION
Fixes #138.

Searching books for `recursion` answered with eleven volumes of recursion theory and nothing else, which reads as "the novel is not in the database", while `recursion blake crouch` found it at the top. Google Books ranks a bare keyword against the whole of a book's text, so a 2019 novel loses to every monograph with the word in its index — Blake Crouch's *Recursion* is not in the first hundred results for `q=recursion`, so this was never a matter of showing more of them.

Everything that decides which books a search comes back with, and in what order, now lives in a new `books/google_search.js`. It is pure and dependency-free for the reason `tmdb_mapping.js` is — `books/google.js` is axios and a network call, and the suite cannot reach behind it — so the whole of this is unit tested without a network or a key. `google.js` keeps the requests and the error mapping.

**The search runs twice**, restricted to titles and as typed, and the title-restricted results are offered first. The title-restricted one is what has the novel in it at all; the plain one still carries the searches that aren't titles, an author's name or a phrase off the cover. The whole query goes inside the quotes — `intitle:"the hobbit"` rather than `intitle:the hobbit` — because `intitle:` binds to the token after it and nothing else, so the unquoted form asks for "the" in a title and "hobbit" anywhere.

**Both queries are asked for by the page.** Google caps a response at 20 volumes however large `maxResults` is; the old search asked for 40 and was answered with 20 every time, and the ISBN filter then dropped the journals and magazines Google had already spent slots on. Two pages of each query, with `printType=books` keeping the journals out of the response in the first place, comes back with around 50 books to scroll rather than 11. That is four requests where there used to be one, so a page Google will not answer is left out of the results instead of failing the search — it 503s often enough that `retry.js` exists — and only an all-pages failure surfaces as an error, the way a single failed request always did.

**Results are then sorted by how well the title matches what was typed**: the books whose title *is* the query, then the ones whose title starts with it, then the rest, each group in the order Google gave it. This is the part that fixes the reported case. Crouch's *Recursion* is 23rd of the title-restricted results, behind twenty books called "Recursion Theory" and the like, and an exact title match outranks every one of them. The comparison ignores case, punctuation and spacing, and is made against the volume's title both with and without its subtitle, so `sapiens` is an exact match for *Sapiens: A Brief History of Humankind* and so is the whole thing typed out.

Rows carry the subtitle now too. Google files it separately from the title, and a list of fifty books all reading "Sapiens" is not one anybody can pick from.

No frontend change was needed: the modal's content wrapper already scrolls, so the cap on what a search offered was entirely in what the API returned.

### What this does not touch

Films and TV (TMDB) still fetch one page of 20, and games (IGDB) 50. Both APIs search titles by design and rank well on the queries in the issue's shape, and there is no failing example to verify an improvement against, so changing them here would be a guess.

### Verified

Against the live API, with the tests as they stand:

| query | results | first row |
| --- | --- | --- |
| `recursion` | 39 | Recursion: A Novel [Blake Crouch] (2019) |
| `the hobbit` | 49 | The Hobbit [J.R.R. Tolkien] |
| `sapiens` | 57 | Sapiens: A Brief History of Humankind [Yuval Noah Harari] |
| `dune` | 51 | Dune [Frank Herbert] |
| `pride and prejudice` | 67 | Pride and Prejudice [Jane Austen] |
| `blake crouch` | 39 | Blake Crouch Collection 6 Books Set |

`retrieve` on the first row's ISBN returns *Recursion*, Blake Crouch, 2019, under `ISBN__9781524759780`. A query with no hits still comes back with zero results rather than an error. `npm test`: 368 tests, 0 failures, 19 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
