### PR TITLE
fix: stop building src/frontend/README.md into the site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,7 +2,9 @@ const UglifyJS = require('uglify-js')
 const HtmlMinifier = require('html-minifier')
 
 module.exports = (config) => {
-  const env = process.env.ELEVENTY_ENV
+  // Set by both npm scripts. Anything else — a bare `eleventy`, a CI job, a
+  // Netlify build — is treated as production, so the fallback is the safe one.
+  const isDev = process.env.ELEVENTY_ENV === 'dev'
 
   // minify the html output
   config.addTransform('htmlmin', (content, outputPath) => {
@@ -22,7 +24,17 @@ module.exports = (config) => {
   config.addFilter('jsmin', (code) => {
     // `{% set %}` hands a filter a Nunjucks SafeString, and UglifyJS reads
     // anything that is not a string as a map of filenames to sources.
-    const minified = UglifyJS.minify(String(code))
+    //
+    // Compressing and mangling 140KB is the slowest thing in the build — 300ms
+    // of a 900ms run — and it buys a watch loop nothing. Parsing is the part
+    // worth keeping in dev: it costs 40ms and it is what the check below reads.
+    const minified = isDev
+      ? UglifyJS.minify(String(code), {
+          compress: false,
+          mangle: false,
+          output: { beautify: true },
+        })
+      : UglifyJS.minify(String(code))
 
     // Handing back the unminified input on failure is how a bundle that does
     // not parse gets shipped anyway. Every page on this site is drawn by that

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -50,9 +50,13 @@ module.exports = (config) => {
       input: 'src/frontend',
       output: 'dist',
     },
-    templateFormats: ['njk', 'md', '11ty.js'],
+    // No `md`. The input directory is source, not content: the only `.md`
+    // files under it are README notes to whoever is reading the code, and as a
+    // template format each one is a page — `src/frontend/README.md` was being
+    // published at `/README/` as a layout-less fragment. Every real page here
+    // is Nunjucks, so the format earns nothing back.
+    templateFormats: ['njk', '11ty.js'],
     htmlTemplateEngine: false,
-    markdownTemplateEngine: 'njk',
     passthroughFileCopy: true,
   }
 }


### PR DESCRIPTION
`https://nil.moe/README/` served a developer note about the frontend's file-to-route convention, as a layout-less fragment with no `<html>` and no `<head>`, starting mid-sentence. `dir.input` is `src/frontend` and `md` was in `templateFormats`, so every `.md` file under the input directory was a page, and `src/frontend/README.md` carried no front matter excluding it.

**Dropped `md` from `templateFormats`** rather than adding front matter to that one file or an `.eleventyignore` for `**/README.md`. The input directory is source, not content — the next README added under it would have been published too.

What I checked before removing the format, since `markdownTemplateEngine: 'njk'` and the `@11ty/eleventy-plugin-syntaxhighlight` dependency both suggest markdown pages were once intended:

- The only `.md` files under `src/frontend` are four READMEs. Three are under `_includes`, which 11ty never renders as pages; the fourth is the one being published.
- The only pages are `index.njk` and `js/bundle.njk`, both Nunjucks. The build log before this change wrote exactly three files: `dist/README/index.html`, `dist/js/bundle.js`, `dist/index.html`.
- `@11ty/eleventy-plugin-syntaxhighlight` is never registered — there is no `addPlugin` call anywhere in the repo, so the plugin has been inert dependency weight rather than a reason to keep the format. Left in `package.json`; removing a dependency is its own change.

`markdownTemplateEngine: 'njk'` goes with the format, having nothing left to configure.

## The dead `ELEVENTY_ENV` line

`const env = process.env.ELEVENTY_ENV` had no readers, so the variable both npm scripts go through `cross-env` to set decided nothing. Wired it up instead of deleting it: compressing and mangling the 140KB bundle is the slowest step in the build, and the watch loop pays it on every save for nothing.

Dev still runs the bundle through UglifyJS, with `compress` and `mangle` off. Parsing is 40ms of the 300ms and it is the part the existing error check reads, so an unparseable bundle still fails the build in dev — which is where it matters, since the alternative is a blank page and a green log. As a side effect the dev bundle is readable in a debugger.

Anything that is not `ELEVENTY_ENV=dev` minifies, including a bare `eleventy` with no variable set, so `npm run build`, Netlify and a CI job that builds in prod mode (#140) are unaffected.

| build | jsmin | total | `dist/js/bundle.js` |
| --- | --- | --- | --- |
| `ELEVENTY_ENV=prod` | 282ms | 0.36s | 73,672 b |
| bare `eleventy` | 212ms | 0.27s | 73,672 b |
| `ELEVENTY_ENV=dev` | 42ms | 0.11s | 137,420 b |

## Verification

Built on a local-disk copy per CLAUDE.md. `dist/` now holds one HTML file, `dist/index.html` — no `dist/README/` — alongside `dist/js/bundle.js`, `dist/css/main.css`, `dist/_redirects` and the four images, all still emitted. `npm test` passes, 349 of 349, including `bundle.test.js`, which reads `.eleventy.js` and asserts the `main.css` passthrough copy is still there.

Closes #141
