### PR TITLE
ci: build the site in CI, and check the bundle that ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,55 @@ jobs:
       # the Netlify functions and the frontend globals.
       - name: Syntax check every JS file
         run: git ls-files '*.js' | xargs -n1 node --check
+
+  # The job above checks the inputs; this one checks what ships. `node --check`
+  # reads each tracked file on its own, and `bundle.test.js` reconstructs the
+  # concatenation from the templates as text — both good proxies, neither the
+  # artefact. The bundle is forty files joined through Nunjucks and put through
+  # UglifyJS, and every page on the site is drawn by that one file, so a syntax
+  # change UglifyJS cannot parse blanks every url. Until this job existed that
+  # only surfaced on Netlify, after merge.
+  #
+  # It needs an install, which is why it is separate rather than more steps on
+  # the job above: keeping that one dependency-free is deliberate. The install
+  # is also the only thing in CI that would notice a dependency removal that
+  # breaks the build, or a `package-lock.json` out of step with `package.json`.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Matches `netlify.toml`'s `[build.environment]`. The point of building
+      # here is to build the way Netlify does, so the two versions stay equal.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      # `_redirects` ends in a forced catch-all (`/* /index.html 200!`), so an
+      # asset the build didn't write is not a 404 — it is served the homepage's
+      # HTML. That is how `/js/bundle.js` once came back as `<!doctype html>`.
+      # Nothing upstream fails when a passthrough copy silently stops copying,
+      # so absence and emptiness both have to be asserted here.
+      - name: The shipped assets must exist and be non-empty
+        run: |
+          for asset in dist/js/bundle.js dist/css/main.css; do
+            if [ ! -s "$asset" ]; then
+              echo "$asset is missing or empty — every url that asks for it" \
+                   "will be served the homepage's HTML instead"
+              exit 1
+            fi
+          done
+
+      # Today `npm run build` is what actually goes red on a bundle that will
+      # not parse, because #135 made the `jsmin` filter throw. This asserts the
+      # same thing about the artefact rather than about the build, so it still
+      # holds if that one line in `.eleventy.js` is ever softened back to
+      # returning its input — which is what it did before #135, and what let
+      # `3c3fab0` ship. It is the cheap half of the pair, not the redundant one.
+      - name: The bundle must parse
+        run: node --check dist/js/bundle.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -22568,6 +22568,21 @@
         }
       }
     },
+    "node_modules/terser-webpack-plugin/node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
@@ -39793,6 +39808,14 @@
         "terser": "^5.7.2"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+          "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
         "terser": {
           "version": "5.10.0",
           "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",


### PR DESCRIPTION
Closes #140.

CI ran the unit suite and a per-file `node --check`, both deliberately install-free, and that is a property worth keeping — the unit-tested modules are dependency-free on purpose. It also meant nothing in CI had ever run `npm ci` or `npm run build`, so `.eleventy.js`, Nunjucks, UglifyJS and the passthrough copies were exercised only by Netlify, after the merge.

Since #135 that gap has teeth. The build joins forty files through Nunjucks and pushes the result through `jsmin` to produce `/js/bundle.js`, the single file every page on the site loads. #135 correctly made that filter throw rather than hand back unminified source, so a bundle that will not parse fails the build — but the build was downstream of the merge, so a syntax change UglifyJS cannot take passed CI green and blanked every url. That is what `3c3fab0` was.

Neither existing step reaches it. `node --check` reads each tracked file on its own, and the failure lives in the concatenation and the minification. `bundle.test.js` reconstructs the concatenation from the templates as text, which is a good proxy and not the artefact.

So this adds a third job rather than more steps on the existing one, which is untouched. It installs, builds, asserts the shipped assets exist and are non-empty, and runs `node --check` over the built, minified bundle.

## It found something on its first run

The second commit is not scope creep — it is the new job going red immediately, on `main` as it stands:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: acorn@8.18.0 from lock file
```

The lockfile carries one top-level `acorn` at 7.4.1 while several packages want `^8`, and `terser-webpack-plugin`'s nested copy was never written into the `packages` section. The entry is `dev`, `optional` and `peer` at once — an optional peer dependency of webpack's minimizer — which is the kind npm's resolver treats differently between versions. **npm 11 installs from the lockfile as it stands; npm 10, which is what Node 22 ships and therefore what both CI and Netlify run, errors.** Nothing in CI ever installed, so neither version was ever exercised. This is exactly the second gap the issue predicted, and it was already there.

Regenerated with `npm install --package-lock-only` under npm 10, per CLAUDE.md: 23 added lines, no removed ones, no production dependency changes and no version bumps. `npm ci` then passes under npm 10 and npm 11 both, and the bundle comes out byte-for-byte the size it was before. It is a separate commit so it can be reviewed apart from the workflow.

Worth knowing before #143 and #144 land, since both are dependency PRs.

## On the last step, honestly

Today `npm run build` is what actually goes red first. I broke a bundled file two ways on a scratch copy — a stray brace, and the `{{` JSDoc typedef that caused `3c3fab0` — and both fail at `npm run build`, because of #135's throw. I could not construct a case that builds green and produces a bundle Node rejects; UglifyJS either parses the input or errors.

The step earns its place anyway, at the cost of one process spawn: it asserts on the artefact rather than on an exit code, so it does not depend on that one line in `.eleventy.js` continuing to throw. Returning the input on failure is exactly what it did before #135, and exactly what let `3c3fab0` ship.

| break | `node --check` per file | `npm run build` | asset guard | `node --check dist` |
|---|---|---|---|---|
| none | pass | pass | pass | pass |
| stray brace | **fails** | **fails** | — | — |
| `{{` in a JSDoc typedef | pass | **fails** | — | — |
| bundle empty / not written | pass | pass | **fails** | — |

## The asset check

`_redirects` ends in a forced catch-all (`/* /index.html 200!`), so an asset the build did not write is not a 404 — it is served the homepage's HTML. That is how `/js/bundle.js` once came back as `<!doctype html>`, per the comment at the top of that file. Nothing upstream fails when a passthrough copy quietly stops copying, so absence and emptiness are both asserted here. Verified in both directions: empty file caught, missing file caught.

`node-version` is `22` in both jobs, matching what `netlify.toml`'s `[build.environment]` has set since #131.

## Verification

Locally, on a local-disk copy from a clean `git archive` per the CLAUDE.md procedure: the lockfile failure reproduces under npm 10 and not under npm 11; after the fix, `npm ci`, `npm run build` and `node --check dist/js/bundle.js` all pass under both npm versions, with `dist/js/bundle.js` at 73672 bytes and `dist/css/main.css` at 2990. The deliberate breaks were reverted and the restore verified byte-for-byte before committing.

On CI, both jobs are green and all six `build` steps ran in order on Node 22 / npm 10 — `npm ci` installing 1938 packages, the `jsmin` filter firing, 6 files copied and 3 written, then both guard steps. The existing `test` job is unchanged and still passes (349 tests, 0 failing, 33 skipped).
