### PR TITLE
docs: point the moved-file comments at where the files are now

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ We use:
   `AWS_LAMBDA_JS_RUNTIME` overrides the functions runtime, but only when set
   from the Netlify UI — it is ignored in `netlify.toml`.
 - [Eleventy](https://11ty.io) for static site generation
-- A tiny inline JS pipeline with a [component-based architecture](https://medium.com/@dan.shapiro1210/understanding-component-based-architecture-3ff48ec0c238)
+- A tiny JS pipeline with a [component-based architecture](https://medium.com/@dan.shapiro1210/understanding-component-based-architecture-3ff48ec0c238)
+  — no module system, just globals. `src/frontend/js/bundle.njk` lists every
+  frontend JS file, wraps each in its own IIFE, and concatenates and minifies
+  them into `/js/bundle.js`, which `layouts/base.njk` loads by url.
 - Serverless (FaaS) development pipeline with [Netlify Dev](https://www.netlify.com/products/dev) and [Netlify Functions](https://www.netlify.com/products/functions)
 
 **Credentials.**
@@ -61,7 +64,10 @@ You might need to run `npx netlify login` inside the project.
 **Netlify plugins.**
 
 - Identity. Managed at https://app.netlify.com/sites/td-memo/identity
-- FaunaDB. Managed at https://dashboard.fauna.com by logging in with netlify account integration.
+- FaunaDB. A leftover: we moved to MongoDB Atlas on 2022-10-10 and nothing
+  in this repo speaks FQL any more. The integration may still be attached to
+  the Netlify account, but the database the site reads is the one under **DB**
+  below.
 
 **DB**
 
@@ -76,11 +82,14 @@ once and runs the writes in order without a transaction, which is what the
 code did before it existed: the save still works, but a failure between the
 two writes can leave the note stale beside a freshly saved entry.
 
-**Backups.** `src/db_maintenance/backup_database.js` takes a timestamped
-snapshot of every collection and prunes old ones to a retention policy, so
-there is a history of backups rather than one overwritten dump;
-`restore_backup.js` puts a snapshot (or one collection of it) back. See
-[src/db_maintenance/README.md](src/db_maintenance/README.md).
+**Backups.** `src/db_maintenance/scripts/backup_database.js` takes a
+timestamped snapshot of every collection and prunes old ones to a retention
+policy, so there is a history of backups rather than one overwritten dump;
+`scripts/restore_backup.js` puts a snapshot (or one collection of it) back.
+Both live alongside the rest of the maintenance scripts, each of which is a
+dry run unless given `--apply`;
+[src/db_maintenance/README.md](src/db_maintenance/README.md) lists them and
+says what each one is for.
 
 **Reading a list without a browser.** The lists are drawn client-side, so
 fetching `https://nil.moe/films/nil` and reading the HTML gets you an empty

--- a/docs/API_choices.md
+++ b/docs/API_choices.md
@@ -60,7 +60,7 @@ the old field silently returns nothing rather than erroring.
 Playtime comes from IGDB's `/game_time_to_beats` endpoint. The games adapter
 ([../src/api/utils/external_api_adapters/games/igdb.js](../src/api/utils/external_api_adapters/games/igdb.js))
 asks for it whenever it retrieves a game, and
-[../src/db_maintenance/backfill_game_playtimes.js](../src/db_maintenance/backfill_game_playtimes.js)
+[../src/db_maintenance/scripts/backfill_game_playtimes.js](../src/db_maintenance/scripts/backfill_game_playtimes.js)
 fills in games that have none.
 
 Note the endpoint is **plural**; `game_time_to_beat` and `time_to_beat` both

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -6,6 +6,25 @@
 library: the pure modules that decide what a script should write, and their
 tests.
 
+The scripts, and the section below that explains each:
+
+| Script | What it does | Writes? |
+| --- | --- | --- |
+| `audit_database.js` | Reports every inconsistency it can find — unrefreshable works, missing metadata, duplicates, dangling `workRef`s. Needs no API keys. | never |
+| `backup_database.js` | Takes a timestamped snapshot of every collection and prunes old ones to a retention policy. | to disk only |
+| `restore_backup.js` | Puts a snapshot, or one collection of it, back — matching on `_id`. | `--apply` |
+| `ensure_indexes.js` | Creates the indexes the site's queries need. Re-running is a no-op. | `--apply` |
+| `backfill_work_metadata.js` | Re-runs the API adapters over cached works, filling gaps and refreshing stale metadata. | `--apply` |
+| `backfill_game_playtimes.js` | Fills in games with no playtime, from IGDB's `/game_time_to_beats`. | `--apply` |
+| `dedupe_works.js` | Merges works that duplicate each other, repoints the entries and deletes the leftovers. | `--apply` |
+
+Everything marked `--apply` is a **dry run without it**, and takes a backup of
+each collection it writes to first — except `ensure_indexes.js`, which writes
+no documents at all. The two backfills touch the **work** collections only, so
+the overrides a user set by hand, which live on the entry documents, are out
+of reach by construction; `dedupe_works.js` is the one that also writes to the
+entry collections, repointing `workRef` at the document it merged into.
+
 The commands below are written from this folder, as
 `node scripts/audit_database.js`, but nothing depends on that. The `.env` and
 the backups directory are both resolved from a fixed point in the tree rather

--- a/src/frontend/_includes/js/README.md
+++ b/src/frontend/_includes/js/README.md
@@ -1,5 +1,5 @@
-We don't have a JS bundling pipeline, so we're creating
-global variables. Every file in this directory must be added to
-`src/frontend/_includes/layouts/base.njk`. Mind include order
-as modules may only use objects from modules which have been
-included before them.
+We don't have a module system, so we're creating global variables.
+Every file in this directory must be added to `src/frontend/js/bundle.njk`,
+which concatenates the list into `/js/bundle.js` and wraps each file in its
+own IIFE. Mind include order as modules may only use objects from modules
+which have been included before them.

--- a/src/frontend/_includes/js/components/list/list.test.js
+++ b/src/frontend/_includes/js/components/list/list.test.js
@@ -22,9 +22,9 @@ const context = vm.createContext({
   Components: { UI: {}, List: {} },
 });
 
-// base.njk wraps each included file in its own IIFE, which is what keeps two
-// files' `const`s from colliding. Loading it the same way here keeps that
-// difference visible.
+// The `js()` macro in bundle.njk wraps each bundled file in its own IIFE,
+// which is what keeps two files' `const`s from colliding. Loading it the same
+// way here keeps that difference visible.
 const { byEnglishTitle } = vm.runInContext(
   `(() => {\n${source}\n;return ({ byEnglishTitle })\n})()`,
   context

--- a/src/frontend/_includes/js/components/profile/profile_stats.test.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.test.js
@@ -16,10 +16,10 @@ const source = fs.readFileSync(path.join(__dirname, "profile_stats.js"), "utf8")
 // Netlify. They exist because the file destructures all of these at load time,
 // and because its last line writes itself onto `Components.Profile`.
 //
-// base.njk wraps each included file in its own IIFE, which is what keeps two
-// files' `const`s from colliding and what makes an assignment with no keyword
-// the only thing that crosses between them. Loading it the same way here keeps
-// that difference visible.
+// The `js()` macro in bundle.njk wraps each bundled file in its own IIFE,
+// which is what keeps two files' `const`s from colliding and what makes an
+// assignment with no keyword the only thing that crosses between them. Loading
+// it the same way here keeps that difference visible.
 const context = vm.createContext({
   Netlify: { entryTypes: [], getStats: () => {} },
   Tables: { col: () => {} },

--- a/src/frontend/_includes/js/old_main.js
+++ b/src/frontend/_includes/js/old_main.js
@@ -1,11 +1,12 @@
 /**
  * @file nil's old main file, reduced to the one thing still wired up.
  *
- * base.njk gives every included file its own IIFE, so a bare `function` here
- * never reaches `window` — which is where bootstrap-table looks when an option
- * names its value as a string. `icons: 'icons'` in the list component resolves
- * to this object; the sorters and formatters that used to sit alongside it
- * resolved to nothing and were removed.
+ * The `js()` macro in `src/frontend/js/bundle.njk` gives every bundled file its
+ * own IIFE, so a bare `function` here never reaches `window` — which is where
+ * bootstrap-table looks when an option names its value as a string.
+ * `icons: 'icons'` in the list component resolves to this object; the sorters
+ * and formatters that used to sit alongside it resolved to nothing and were
+ * removed.
  */
 window.icons = {
   detailOpen: 'fa-caret-down',

--- a/src/frontend/_includes/js/utils/columns.test.js
+++ b/src/frontend/_includes/js/utils/columns.test.js
@@ -17,10 +17,10 @@ const generalSource = fs.readFileSync(path.join(__dirname, "general.js"), "utf8"
 // testing the stand-in. `URL` is a host global rather than a JS builtin, so a
 // fresh vm context has to be handed one.
 //
-// base.njk wraps each included file in its own IIFE, which is what keeps two
-// files' `const`s from colliding and what makes an assignment with no keyword
-// (`Utils = …`) the only thing that crosses between them. Loading them the
-// same way here keeps that difference visible.
+// The `js()` macro in bundle.njk wraps each bundled file in its own IIFE,
+// which is what keeps two files' `const`s from colliding and what makes an
+// assignment with no keyword (`Utils = …`) the only thing that crosses between
+// them. Loading them the same way here keeps that difference visible.
 const context = vm.createContext({
   URL,
   console,


### PR DESCRIPTION
Two rounds of refactoring moved files and left the comments behind. #135 moved the frontend script list out of `base.njk` into `src/frontend/js/bundle.njk`, and #92 moved the `db_maintenance` scripts down into `scripts/`. Nothing here changes behaviour — the `.js` diff is comments and nothing else, which `git diff -- '*.js'` filtered for non-comment lines confirms is empty.

`old_main.js` exists for exactly one reason: each bundled file gets its own IIFE, so a bare `function` there never reaches `window`, which is where bootstrap-table looks when an option names its value as a string. That wrapper is `bundle.njk`'s `js()` macro now. The same line appeared in the three tests that load a script into a vm context the way the bundle does — `list.test.js`, `profile_stats.test.js`, `columns.test.js` — and each got the same correction. `bundle.test.js` already described the split correctly and is untouched; it is the model the new wording follows, naming the macro as what wraps and `base.njk` as what loads the result by url.

`README.md` named `src/db_maintenance/backup_database.js` and `restore_backup.js` at the top level; `docs/API_choices.md` named `backfill_game_playtimes.js` the same way. All three are under `scripts/`. That third one is not in the issue — it turned up grepping for the pattern rather than the two paths.

The stack list still called the JS pipeline "inline", which is precisely what #135 stopped doing, so that bullet now says where the bundle is built and how it is loaded.

`src/db_maintenance/README.md` gains a table of the seven scripts, what each is for, and which of them write. `ensure_indexes.js` (#121) had never been named in the overview at all — it only appeared in its own section further down. The paragraph under the table is the part most worth checking: `dedupe_works.js` is the one script that also writes to the entry collections, repointing `workRef`, and `ensure_indexes.js` is the one `--apply` script that takes no backup because it writes no documents. An earlier draft of that paragraph claimed all of them were work-collections-only and all of them backed up first, which is wrong on both counts.

**One thing worth a second opinion.** The **FaunaDB** bullet under "Netlify plugins" read as live infrastructure, and the same README says we use MongoDB twenty lines further down. I rewrote it as a leftover rather than deleting it, because whether the integration is still attached to the Netlify account is a fact about a dashboard I cannot see — only the repo side (no FQL, no Fauna client, the 2022-10-10 migration) is verifiable from here. If it has since been detached, that bullet should just go.

**Deliberately not touched.** The Node version and deploy-context story that #131 rewrote is already accurate in `README.md` — `NODE_VERSION = 22` in one `[build.environment]`, `AWS_LAMBDA_JS_RUNTIME` ignored from the config file — so the issue's suspicion there does not hold. Nor does any doc in the repo describe a fork-and-upstream remote arrangement to correct. `bundle.test.js` is left alone as the issue asks.

No behaviour bugs turned up while reading, so there is nothing to file separately.

Verified with `npm test` (316 pass, 0 fail, 33 skipped — the ones that skip without dependencies or a database) and `git ls-files '*.js' | xargs -n1 node --check`.

Closes #146
