### PR TITLE
perf(db_maintenance): index the entry list's sort, not just its match

### DIFF
--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -68,8 +68,8 @@ types the other scripts take), `--json=path`.
 
 Which indexes, and why each one, is declared in `index_plan.js` — every entry
 names the queries that want it, because an index nobody can name a query for
-is an index to delete. They are all single ascending fields: every query the
-site makes goes through `findOneByField` / `findAllByField`, which is an
+is an index to delete. Most are single ascending fields: almost every query
+the site makes goes through `findOneByField` / `findAllByField`, which is an
 equality match on one field, and `_id` is indexed by MongoDB already.
 
 - **`users.username` is unique**, which closes the check-then-write race in
@@ -81,6 +81,14 @@ equality match on one field, and `_id` is indexed by MongoDB already.
   if it wouldn't, that one index is skipped and the rest are still created.
   Two users with no username at all count as duplicates — MongoDB indexes a
   missing field as null.
+- **The entry lists have a compound index**, `{ userId: 1, updatedDate: -1,
+  _id: 1 }`, because `toUserEntriesPipeline` sorts as well as matches. An
+  index serves a sort only when the sort is a prefix of what is left of the
+  index after the equality match, so all three fields have to be there, in
+  that order and those directions; with any less, the `$sort` becomes a
+  blocking one in front of the `$limit`. The plain `{ userId: 1 }` index is
+  kept beside it even though a compound index serves its own prefix — see the
+  comment in `index_plan.js`.
 - **`apiRefs` is an array**, so its index is a *multikey* index. That is
   correct, not something to fix: `findCachedWork` asks
   `{ apiRefs: "igdb__1234" }`, an equality match against one element, which

--- a/src/db_maintenance/index_plan.js
+++ b/src/db_maintenance/index_plan.js
@@ -5,11 +5,15 @@
  *
  * The I/O lives in scripts/ensure_indexes.js.
  *
- * Every query the site makes goes through `_findOneByField` /
+ * Almost every query the site makes goes through `_findOneByField` /
  * `_findAllByField` in ../api/utils/db/unsafe_functions.js, which is an
- * equality `$match` on one field. Each entry below names a field one of those
- * calls is given. Nothing here is a sort or a range, so every index is a
- * single ascending field, and `_id` is already indexed by MongoDB itself.
+ * equality `$match` on one field, so almost every index below is a single
+ * ascending field named after the field one of those calls is given. `_id` is
+ * already indexed by MongoDB itself.
+ *
+ * The exception is the entry list, which sorts as well as matches, and wants a
+ * compound index so that the sort can be *served* rather than performed. See
+ * the `updatedDate` entry below.
  *
  * The collection names come from ../api/utils/work_types.js, which is pure
  * too, so this file stays testable without an install.
@@ -49,10 +53,41 @@ const DESIRED_INDEXES = [
     key: { userId: 1 },
     why: "findOwnName, setBio, assignName",
   },
+  // Kept, though the compound index below begins with `userId` and a compound
+  // index serves its own prefix — so anything this one can answer, that one can
+  // answer too. It stays for two reasons. Dropping an index is a human's call
+  // (CLAUDE.md), and nothing here drops one anyway: taking an entry out of this
+  // list does not remove it from the database, it only leaves it live and no
+  // longer declared, which is the one state worse than either. And it is the
+  // narrower index — `toScoreTallyPipeline`'s four `$group`s match on `userId`
+  // and read no dates, so they walk fewer bytes through it.
   ...ENTRY_COLLECTIONS.map((collection) => ({
     collection,
     key: { userId: 1 },
-    why: "every list load, every profile load, /api/export, refreshStats",
+    why: "the $match in toScoreTallyPipeline, /api/export, refreshStats",
+  })),
+  // The list query, `toUserEntriesPipeline` in ../api/utils/db/queries.js, is
+  // `$match: { userId }` then `$sort: { updatedDate: -1, _id: 1 }` then
+  // `$limit`. Matching on the `userId` index alone leaves the sort a *blocking*
+  // one: every one of the user's entries has to be read and ordered before the
+  // limit can take five, and a blocking sort gives up at 100 MB rather than
+  // spilling. Walking a compound index in order instead means the limit stops
+  // the scan after five documents.
+  //
+  // `_id` is in the key because the sort names it. An index serves a sort only
+  // when the sort is a prefix of what the index has left after the equality
+  // match, so `{ userId: 1, updatedDate: -1 }` on its own serves
+  // `{ updatedDate: -1 }` but not `{ updatedDate: -1, _id: 1 }` — the planner
+  // would add the blocking sort back to break the ties. Which would matter:
+  // the ties are the reason `_id` is in the sort at all, a bulk import stamping
+  // a whole list with one millisecond.
+  //
+  // Directions have to line up too, and here they do: the index is read
+  // forwards for `{ updatedDate: -1, _id: 1 }`.
+  ...ENTRY_COLLECTIONS.map((collection) => ({
+    collection,
+    key: { userId: 1, updatedDate: -1, _id: 1 },
+    why: "the sort and limit in toUserEntriesPipeline — every list load and every profile load",
   })),
   ...ENTRY_COLLECTIONS.map((collection) => ({
     collection,

--- a/src/db_maintenance/index_plan.test.js
+++ b/src/db_maintenance/index_plan.test.js
@@ -2,12 +2,14 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  ENTRY_COLLECTIONS,
   DESIRED_INDEXES,
   indexName,
   planIndexes,
   duplicateValues,
   uniqueIndexes,
 } = require("./index_plan");
+const { toUserEntriesPipeline } = require("../api/utils/db/queries");
 
 /** What `db.collection(name).indexes()` hands back, trimmed to what we read. */
 const existing = (name, key, unique) => ({
@@ -27,6 +29,11 @@ const desired = (collection, key, options) => ({
 test("an index is named the way MongoDB would name it", () => {
   assert.equal(indexName({ entryRef: 1 }), "entryRef_1");
   assert.equal(indexName({ userId: 1, updatedDate: -1 }), "userId_1_updatedDate_-1");
+  // Underscores double up around `_id`, because the field is already one.
+  assert.equal(
+    indexName({ userId: 1, updatedDate: -1, _id: 1 }),
+    "userId_1_updatedDate_-1__id_1"
+  );
 });
 
 test("every desired index names a collection, a key and a reason", () => {
@@ -50,6 +57,10 @@ test("the list covers every field the issue names, and no field twice", () => {
     "tvShowEntries.userId_1",
     "gameEntries.userId_1",
     "bookEntries.userId_1",
+    "filmEntries.userId_1_updatedDate_-1__id_1",
+    "tvShowEntries.userId_1_updatedDate_-1__id_1",
+    "gameEntries.userId_1_updatedDate_-1__id_1",
+    "bookEntries.userId_1_updatedDate_-1__id_1",
     "filmEntries.workRef_1",
     "tvShowEntries.workRef_1",
     "gameEntries.workRef_1",
@@ -201,4 +212,73 @@ test("values of different types are not conflated", () => {
   const documents = [{ _id: "a", ref: 1 }, { _id: "b", ref: "1" }];
 
   assert.deepEqual(duplicateValues(documents, "ref"), []);
+});
+
+test("the entry list's sort is served by a compound index, not performed", () => {
+  // The index has to answer the whole of `toUserEntriesPipeline`: `userId`
+  // first, for the equality match, then the sort's fields in the sort's own
+  // order and directions. Anything less and the planner puts a blocking sort
+  // back in front of the `$limit` — which is what the single-field `userId`
+  // index on its own leaves it doing. Reading the pipeline rather than
+  // restating it is what keeps the two from drifting apart.
+  const [{ $match }, { $sort }] = toUserEntriesPipeline({
+    userId: "u1",
+    workCollection: "films",
+  });
+  const wanted = {
+    ...Object.fromEntries(Object.keys($match).map((field) => [field, 1])),
+    ...$sort,
+  };
+
+  assert.deepEqual(wanted, { userId: 1, updatedDate: -1, _id: 1 });
+
+  for (const collection of ENTRY_COLLECTIONS) {
+    const keys = DESIRED_INDEXES.filter(
+      (index) => index.collection === collection
+    ).map((index) => JSON.stringify(index.key));
+
+    assert.ok(
+      keys.includes(JSON.stringify(wanted)),
+      `${collection} has no index matching ${JSON.stringify(wanted)}`
+    );
+  }
+});
+
+test("the plain userId index is still declared alongside the compound one", () => {
+  // A compound index serves its own prefix, so this one answers nothing the
+  // compound one cannot. It stays anyway: nothing in this folder drops an
+  // index, so undeclaring it would leave it live and no longer explained. See
+  // the comment on it in index_plan.js.
+  for (const collection of ENTRY_COLLECTIONS) {
+    const names = DESIRED_INDEXES.filter(
+      (index) => index.collection === collection
+    ).map((index) => indexName(index.key));
+
+    assert.ok(names.includes("userId_1"), `${collection} lost its userId index`);
+  }
+});
+
+test("the compound index is created beside the plain one, not in place of it", () => {
+  // Same leading field, but a different key and a different name, so a database
+  // that already has the single-field index — which is what the dry run of
+  // #147 found — needs the compound one built and keeps both.
+  const plan = planIndexes(
+    [
+      desired("filmEntries", { userId: 1 }),
+      desired("filmEntries", { userId: 1, updatedDate: -1, _id: 1 }),
+    ],
+    {
+      filmEntries: [
+        existing("_id_", { _id: 1 }),
+        existing("userId_1", { userId: 1 }),
+      ],
+    }
+  );
+
+  assert.deepEqual(plan.conflicting, []);
+  assert.equal(plan.satisfied.length, 1);
+  assert.deepEqual(
+    plan.create.map((index) => indexName(index.key)),
+    ["userId_1_updatedDate_-1__id_1"]
+  );
 });


### PR DESCRIPTION
`toUserEntriesPipeline` matches on `userId`, sorts on `{ updatedDate: -1, _id: 1 }`, and only then limits. `DESIRED_INDEXES` declared nothing past `{ userId: 1 }` for the four `*Entries` collections, which answers the `$match` and leaves the `$sort` blocking: every one of the user's entries has to be read and ordered before the `$limit` can take five, and a blocking sort gives up at 100 MB rather than spilling to disk. A compound index the sort can be walked along instead lets the limit stop the scan after five documents. So #121's half of the perf work covered the match and not the sort, and #123 has been landing on the wrong side of that ever since.

**`_id` is in the key, and that is the decision worth arguing with.** An index serves a sort only when the sort is a prefix of what the index has left after the equality match. `{ userId: 1, updatedDate: -1 }` serves `{ updatedDate: -1 }` but not `{ updatedDate: -1, _id: 1 }` — the planner would add the blocking sort back to break the ties, which is the thing this is trying to remove, so the two-field version would look right and do nothing. The ties are not hypothetical either: `_id` is in the sort precisely because a bulk import stamps a whole list with one millisecond, as the comment in `queries.js` says. Directions line up, so the index is read forwards. The issue suggests `{ userId: 1, updatedDate: -1 }`; this is that plus the one field that makes it actually serve the sort.

**The plain `{ userId: 1 }` stays**, and I want to be explicit that this is deliberate rather than an oversight. A compound index serves its own prefix, so it is redundant *as an index* — anything it can answer, the compound one can. Two reasons to leave it declared. Removing the entry from `DESIRED_INDEXES` would not drop the index: nothing in this folder drops anything, so the only effect would be a live index that is no longer declared and no longer carries a `why`, which is worse than either keeping or dropping it. And dropping an index is a human's call under `CLAUDE.md` in any case. It is also the narrower of the two for `toScoreTallyPipeline`'s four `$group`s, which match on `userId` and read no dates; its `why` now names those instead of the list loads the compound index took over.

The new test derives the wanted key from `toUserEntriesPipeline` itself rather than restating it, so the index and the sort cannot drift apart — if someone changes the sort, the plan test is what fails. `queries.js` is pure and requires nothing, so this costs the suite no install.

## What the dry run says

Posted in full on #147. Before this branch, all 19 declared indexes already existed and 0 would be created — so #121 *was* applied at some point, `users.username_1` included, unique and with no duplicate blockers. With this branch:

```
19 index(es) already exist, 4 would be created, 0 conflict.

Would create:
  filmEntries.userId_1_updatedDate_-1__id_1
  tvShowEntries.userId_1_updatedDate_-1__id_1
  gameEntries.userId_1_updatedDate_-1__id_1
  bookEntries.userId_1_updatedDate_-1__id_1
```

`npm test` passes, 352 tests. The three new ones fail against the plan as it stands on `main`, which is the point of them.

**Merging this does not create the indexes.** It only changes what the dry run asks for. Someone still has to run `node src/db_maintenance/scripts/ensure_indexes.js --apply`, which is why this says `Refs #147` and not `Closes #147` — the issue also still wants the durable record of the apply written into the README, and that is a note about something that has happened, so it belongs to whoever runs it.

Refs #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
