### PR TITLE
fix: answer the stats endpoint with one shape, not two

### DIFF
--- a/src/api/controllers/stats.js
+++ b/src/api/controllers/stats.js
@@ -8,9 +8,16 @@ const { combine, okAsync, ResultAsync } = require('neverthrow')
 const { getSegment } = require('./utils')
 const { toPromise } = require('../utils/general')
 const db = require('../utils/db/')
-const { toScoreTally } = require('../utils/score_tallies')
+const { toScoreTally, toStats } = require('../utils/score_tallies')
 
-/** @type {(event: Event) => Promise<Response>} */
+/**
+ * GET /api/stats/:username
+ *
+ * Both paths answer with `{ scores, updatedDate }` — `toStats` builds it, and
+ * this one names the two fields rather than handing back the stored document
+ * as it found it. See #145 and score_tallies.js.
+ * @type {(event: Event) => Promise<Response>}
+ */
 const getUserStats = (event) => toPromise(
   db.findOneByField_('users', 'username', getSegment(0, event))
     .andThen(result => {
@@ -20,7 +27,7 @@ const getUserStats = (event) => toPromise(
       if (!lastUpdated || isMoreThan48HoursAgo(lastUpdated)) {
         return refreshStats(result)
       } else {
-        return okAsync(responses.ok(stats))
+        return okAsync(responses.ok(toStats(stats.scores, lastUpdated)))
       }
     }
   )
@@ -61,12 +68,14 @@ const refreshStats = (userDocument) =>
     )
   )
     .map(([games, tv, films, books]) => ({ games, tv, films, books }))
-    .andThen((scores) =>
-      db.updateByRef_('users', userDocument.ref.id, { stats: {
-        scores,
-        updatedDate: Date.now(),
-      }})
-        .map(() => responses.ok({ scores }))
+    .map((scores) => toStats(scores, Date.now()))
+    // The stats that are answered with are the stats that were stored, down to
+    // the one object: the response used to omit `updatedDate` entirely, and
+    // computing it a second time for the caller would have dated the numbers
+    // to a moment other than the one recorded beside them.
+    .andThen((stats) =>
+      db.updateByRef_('users', userDocument.ref.id, { stats })
+        .map(() => responses.ok(stats))
     )
 
 const MS_IN_DAY = 86400000

--- a/src/api/controllers/stats.test.js
+++ b/src/api/controllers/stats.test.js
@@ -1,0 +1,239 @@
+/**
+ * @file `GET /api/stats/:username` on both sides of the 48-hour cache, driven
+ * through the real Netlify handler against an in-memory Mongo.
+ *
+ * The point of these is #145: the endpoint answered with `{ scores,
+ * updatedDate }` when the stored tallies were fresh and `{ scores }` when it
+ * had just recomputed them, so which shape a caller got depended on when
+ * somebody last loaded that profile. So they assert the two answers against
+ * each other rather than each against a literal — a shape that changes has to
+ * change on both paths or fail here.
+ *
+ * That needs the actual dependencies, so the file **skips itself** when they
+ * aren't installed (which is how CI runs the suite). The same shape is pinned
+ * without them on `toStats` in ../utils/score_tallies.test.js.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const Module = require('module')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('neverthrow')
+    require('zod')
+    require('ts-pattern')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+
+///////////////////////////////////////////////////////////////////////////////
+// A Mongo small enough to keep in a variable — the same one name.test.js
+// keeps, plus the `$group` this route is built on.
+
+const store = {}
+
+const matchesValue = (value, wanted) =>
+  wanted && typeof wanted === 'object' && !Array.isArray(wanted)
+    ? '$ne' in wanted
+      ? value !== wanted.$ne
+      : wanted.$in.includes(value)
+    : value === wanted
+
+const matches = (doc, filter = {}) =>
+  Object.entries(filter).every(([field, wanted]) =>
+    matchesValue(doc[field], wanted)
+  )
+
+const collectionOf = (name) => (store[name] = store[name] ?? [])
+
+/**
+ * `[{ $match }, { $group }]`, which is the whole of `toScoreTallyPipeline`.
+ * A missing field and an explicit `null` group together under one `_id: null`
+ * here as they do in Mongo, because that is the `unrated` bucket.
+ */
+const runPipeline = (name, [{ $match: filter }, grouping]) => {
+  const matched = collectionOf(name).filter((doc) => matches(doc, filter))
+  if (!grouping) return matched
+
+  const field = grouping.$group._id.replace('$', '')
+  const counts = matched.reduce(
+    (tally, doc) =>
+      tally.set(doc[field] ?? null, (tally.get(doc[field] ?? null) ?? 0) + 1),
+    new Map()
+  )
+  return [...counts].map(([_id, count]) => ({ _id, count }))
+}
+
+const collection = (name) => ({
+  aggregate: (pipeline) => ({
+    toArray: async () => runPipeline(name, pipeline),
+  }),
+  find: (filter) => ({
+    toArray: async () => collectionOf(name).filter((doc) => matches(doc, filter)),
+  }),
+  findOne: async (filter) =>
+    collectionOf(name).find((doc) => matches(doc, filter)) ?? null,
+  insertOne: async (doc) => (collectionOf(name).push(doc), { insertedId: doc._id }),
+  updateOne: async (filter, { $set }) => {
+    const doc = collectionOf(name).find((d) => matches(d, filter))
+    if (doc) Object.assign(doc, $set)
+    return { modifiedCount: doc ? 1 : 0 }
+  },
+  deleteOne: async (filter) => {
+    store[name] = collectionOf(name).filter((doc) => !matches(doc, filter))
+    return { deletedCount: 1 }
+  },
+})
+
+class MongoClient {
+  async connect() {}
+  db() {
+    return { databaseName: 'memo', collection }
+  }
+}
+
+const loadModule = Module._load
+Module._load = function (request, ...args) {
+  if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
+  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  return loadModule.call(this, request, ...args)
+}
+
+const stats = dependenciesInstalled ? require('../routes/stats') : undefined
+
+///////////////////////////////////////////////////////////////////////////////
+
+const getStats = async (username) => {
+  const response = await stats.handler(
+    {
+      httpMethod: 'GET',
+      path: `/.netlify/functions/stats/${username}`,
+      headers: {},
+      body: null,
+    },
+    {}
+  )
+  return {
+    statusCode: response.statusCode,
+    body: response.body ? JSON.parse(response.body) : undefined,
+  }
+}
+
+const MS_IN_DAY = 86400000
+
+const emptyTally = () => ({
+  1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0, unrated: 0,
+})
+
+/** A user whose stored tallies are as old as the caller says. */
+const seed = ({ statsAge, extraStoredFields = {} } = {}) => {
+  store.users = [
+    {
+      _id: 'a1',
+      userId: 'u1',
+      username: 'reader',
+      ...(statsAge === undefined
+        ? {}
+        : {
+            stats: {
+              scores: {
+                games: { ...emptyTally(), 9: 1 },
+                tv: emptyTally(),
+                films: emptyTally(),
+                books: emptyTally(),
+              },
+              updatedDate: Date.now() - statsAge,
+              ...extraStoredFields,
+            },
+          }),
+    },
+  ]
+
+  store.gameEntries = [
+    { _id: 'g1', userId: 'u1', status: 'Completed', score: 8 },
+    { _id: 'g2', userId: 'u1', status: 'Completed', score: 8 },
+    { _id: 'g3', userId: 'u1', status: 'Planned', score: null },
+  ]
+  store.tvShowEntries = [{ _id: 't1', userId: 'u1', status: 'Watching' }]
+  store.filmEntries = []
+  store.bookEntries = [{ _id: 'b1', userId: 'u1', status: 'Read', score: 3 }]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+test('a fresh cache and a recompute answer with the same keys', options, async () => {
+  // The bug, stated as directly as it can be: two requests for the same
+  // profile, one on each side of the 48-hour line, used to come back with a
+  // different set of fields.
+  seed({ statsAge: MS_IN_DAY })
+  const { body: cached } = await getStats('reader')
+
+  seed({ statsAge: 3 * MS_IN_DAY })
+  const { body: recomputed } = await getStats('reader')
+
+  assert.deepEqual(Object.keys(cached).sort(), Object.keys(recomputed).sort())
+  assert.deepEqual(Object.keys(cached).sort(), ['scores', 'updatedDate'])
+})
+
+test('a profile with no stats yet answers with that same shape', options, async () => {
+  seed({})
+  const { statusCode, body } = await getStats('reader')
+
+  assert.equal(statusCode, 200)
+  assert.deepEqual(Object.keys(body).sort(), ['scores', 'updatedDate'])
+  assert.equal(typeof body.updatedDate, 'number')
+})
+
+test('the fresh tallies are answered with, not recomputed ones', options, async () => {
+  seed({ statsAge: MS_IN_DAY })
+  const stored = store.users[0].stats
+
+  const { body } = await getStats('reader')
+
+  assert.equal(body.updatedDate, stored.updatedDate)
+  // The stored 9 rather than the 8s the entries would count to.
+  assert.equal(body.scores.games['9'], 1)
+  assert.equal(body.scores.games['8'], 0)
+})
+
+test('the recomputed answer carries the timestamp that was stored', options, async () => {
+  // Not a second `Date.now()`: the numbers a caller is given and the moment
+  // they are dated to have to be the same moment.
+  seed({ statsAge: 3 * MS_IN_DAY })
+
+  const { body } = await getStats('reader')
+
+  assert.equal(body.updatedDate, store.users[0].stats.updatedDate)
+  assert.deepEqual(body.scores, store.users[0].stats.scores)
+})
+
+test('the recompute counts the entries and skips the Planned one', options, async () => {
+  seed({ statsAge: 3 * MS_IN_DAY })
+
+  const { body } = await getStats('reader')
+
+  assert.equal(body.scores.games['8'], 2)
+  assert.equal(body.scores.games.unrated, 0)
+  assert.equal(body.scores.tv.unrated, 1)
+  assert.equal(body.scores.books['3'], 1)
+  assert.deepEqual(body.scores.films, emptyTally())
+})
+
+test('a field stored beside the two is not published with them', options, async () => {
+  // The cache-hit path handed back the stored object as it found it, so
+  // anything ever added under `users.stats` went out with it. See #105.
+  seed({ statsAge: MS_IN_DAY, extraStoredFields: { internalNote: 'not yours' } })
+
+  const { body } = await getStats('reader')
+
+  assert.deepEqual(Object.keys(body).sort(), ['scores', 'updatedDate'])
+  assert.equal('internalNote' in body, false)
+})

--- a/src/api/utils/score_tallies.js
+++ b/src/api/utils/score_tallies.js
@@ -1,6 +1,7 @@
 /**
- * @file What a score histogram is, and how the database's count of one becomes
- * the shape that gets stored and drawn.
+ * @file What a score histogram is, how the database's count of one becomes the
+ * shape that gets stored and drawn, and what the four of them together are
+ * stored and published as.
  *
  * The counting is the database's job — `{ $group: { _id: '$score' } }` over the
  * user's entries, which is at most eleven rows instead of several hundred
@@ -63,10 +64,32 @@ const toScoreTally = (groups) =>
 const emptyScoreTally = () =>
   Object.fromEntries(SCORE_TALLY_KEYS.map((key) => [key, 0]))
 
+/**
+ * The four tallies and when they were counted — both what `users.stats` holds
+ * and what `GET /api/stats/:username` answers with.
+ *
+ * One function for both, because they were two. The endpoint handed back the
+ * stored document whole when the cache was fresh and `{ scores }` alone when
+ * it had just recomputed, so whether a caller got `updatedDate` depended on
+ * when somebody last loaded that profile — the sort of thing nobody
+ * reproduces on purpose. See #145.
+ *
+ * Naming the two fields is the other half of it. The cache-hit path used to
+ * publish the stored object as it found it, so anything ever added under
+ * `users.stats` would go out with it; here it stays unpublished until someone
+ * adds it below on purpose. Same shape #105 took out of user.js and name.js.
+ *
+ * @typedef {Record<string, number>} ScoreTally
+ * @typedef {{ scores: Record<string, ScoreTally>, updatedDate: number }} Stats
+ * @type {(scores: Record<string, ScoreTally>, updatedDate: number) => Stats}
+ */
+const toStats = (scores, updatedDate) => ({ scores, updatedDate })
+
 module.exports = {
   SCORE_TALLY_KEYS,
   toScoreTally,
   emptyScoreTally,
+  toStats,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/api/utils/score_tallies.test.js
+++ b/src/api/utils/score_tallies.test.js
@@ -5,6 +5,7 @@ const {
   SCORE_TALLY_KEYS,
   toScoreTally,
   emptyScoreTally,
+  toStats,
 } = require('./score_tallies')
 
 /** What `scoreTallyParser` in parsers/users.js accepts, checked here without zod. */
@@ -107,4 +108,59 @@ test('a fresh tally each time, so one user cannot carry into the next', () => {
 
   assert.equal(toScoreTally([{ _id: 6, count: 5 }])[6], 5)
   assert.equal(emptyScoreTally()[6], 0)
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The stats document: what `users.stats` holds, and what the endpoint answers
+// with on either side of the 48-hour cache. See #145 — and controllers/
+// stats.test.js, which asserts the same thing through the real handler.
+
+const fourTallies = () => ({
+  games: emptyScoreTally(),
+  tv: emptyScoreTally(),
+  films: emptyScoreTally(),
+  books: emptyScoreTally(),
+})
+
+test('the cached answer and the recomputed one have the same keys', () => {
+  // The bug: a cache hit returned the stored blob, which carries
+  // `updatedDate`, and a recompute returned `{ scores }`, which does not. A
+  // caller therefore saw a field appear and disappear depending on when
+  // someone last loaded that profile.
+  const stored = { scores: fourTallies(), updatedDate: 1700000000000 }
+
+  const cacheHit = toStats(stored.scores, stored.updatedDate)
+  const recomputed = toStats(fourTallies(), 1700000086400)
+
+  assert.deepEqual(Object.keys(cacheHit).sort(), Object.keys(recomputed).sort())
+  assert.deepEqual(Object.keys(cacheHit).sort(), ['scores', 'updatedDate'])
+})
+
+test('the four tallies and the timestamp come back as they went in', () => {
+  const scores = fourTallies()
+  const stats = toStats(scores, 1700000000000)
+
+  assert.deepEqual(stats.scores, scores)
+  assert.equal(stats.updatedDate, 1700000000000)
+  assert.deepEqual(Object.keys(stats.scores).sort(), [
+    'books', 'films', 'games', 'tv',
+  ])
+})
+
+test('anything else stored under users.stats is not published with it', () => {
+  // The cache-hit path used to hand back the stored document as it found it,
+  // so a field added to `users.stats` later would have gone out with it
+  // without anyone deciding to publish it — what #105 took out of user.js and
+  // name.js. Naming the two fields is what keeps that true.
+  const stored = {
+    scores: fourTallies(),
+    updatedDate: 1700000000000,
+    // Not real, and that is the point: it must not survive the trip.
+    computedFromEntryIds: ['e1', 'e2'],
+  }
+
+  assert.deepEqual(
+    Object.keys(toStats(stored.scores, stored.updatedDate)),
+    ['scores', 'updatedDate']
+  )
 })

--- a/src/frontend/_includes/js/components/profile/profile_stats.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.js
@@ -1,7 +1,7 @@
 const { entryTypes, getStats } = Netlify
 const { col } = Tables
 const { typeToTitle } = Conversions
-const { html, css } = Utils
+const { html, css, timeAgo, dateTime } = Utils
 const { initComponent, WithRemoteData } = Components
 const { Tabbed } = Components.UI
 
@@ -18,6 +18,7 @@ const ProfileStats = (username) => initComponent({
                 { title: "Global stats", component: GlobalStats(stats) },
               ]
               ))}
+            ${include(StatsFreshness(stats.updatedDate))}
           `
         })
       }))}
@@ -80,6 +81,34 @@ const ProfileStatsOfType = (username, type, stats) => initComponent({
     )
       .render()
   }
+})
+
+/**
+ * When the numbers above were counted.
+ *
+ * They are a cache that stands for 48 hours — see api/controllers/stats.js —
+ * so a profile can be a day and a half behind the entries it is drawn from,
+ * and a reader comparing two of them is entitled to know which. The exact
+ * moment goes in the `title`, as it does everywhere else `timeAgo` is used.
+ *
+ * `updatedDate` reaches this on both of the endpoint's paths as of #145; the
+ * recomputing one used to leave it out. `timeAgo` answers "at an unknown
+ * time" for a response that predates that, which is the honest thing to say
+ * about it.
+ */
+const StatsFreshness = (updatedDate) => initComponent({
+  content: () => html`
+    <div class="stats-freshness" title="${dateTime(updatedDate)}">
+      Counted ${timeAgo(updatedDate)}
+    </div>
+  `,
+  style: () => css`
+    .stats-freshness {
+      text-align: right;
+      font-size: 11px;
+      color: #aaa;
+    }
+  `
 })
 
 const AdditionalStats = (relevantScores) => initComponent({

--- a/src/frontend/_includes/js/components/profile/profile_stats.test.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.test.js
@@ -24,7 +24,12 @@ const context = vm.createContext({
   Netlify: { entryTypes: [], getStats: () => {} },
   Tables: { col: () => {} },
   Conversions: { typeToTitle: {} },
-  Utils: { html: () => "", css: () => "" },
+  Utils: {
+    html: () => "",
+    css: () => "",
+    timeAgo: () => "",
+    dateTime: () => "",
+  },
   Components: {
     initComponent: () => {},
     WithRemoteData: () => {},
@@ -126,5 +131,22 @@ test("the global tally keeps all eleven buckets whatever it was given", () => {
   assert.deepEqual(
     Object.keys(totals(scoresOf({}, {}, {}, {}))).sort(),
     [...BUCKETS].sort()
+  );
+});
+
+test("the timestamp beside the scores is not counted as a fifth type", () => {
+  // `GET /api/stats/:username` answers with `{ scores, updatedDate }` on both
+  // of its paths as of #145, where a recompute used to answer with `{ scores }`
+  // alone. The global chart sums `Object.values(stats.scores)`; were it ever
+  // to sum `Object.values(stats)`, the timestamp would be read as a tally and
+  // every bucket would come back `undefined`.
+  const stats = {
+    ...scoresOf(oneOfEach(), oneOfEach(), oneOfEach(), oneOfEach()),
+    updatedDate: 1700000000000,
+  };
+
+  assert.deepEqual(
+    totals(stats),
+    Object.fromEntries(BUCKETS.map((b) => [b, 4]))
   );
 });


### PR DESCRIPTION
`GET /api/stats/:username` answered with `{ scores, updatedDate }` when the stored tallies were still inside their 48 hours, and with `{ scores }` alone when it had just recomputed them — the cache-hit path handed back the stored document whole, the refresh path built a fresh object and left the timestamp out of it. Which shape a caller got therefore depended on when somebody last loaded that profile. Nothing is broken today, because `profile_stats.js` only ever reaches for `stats.scores[type]`; it is latent in the expensive way, where the field is there until it isn't and the condition is not one anyone reproduces on purpose.

Both paths now build their answer with `toStats(scores, updatedDate)`, which lives in `score_tallies.js` beside the tally shaping it belongs to — pure and dependency-free, so the tests reach it without an install. The refresh path answers with the very object it stored rather than assembling a second one, which also settles the smaller oddity that the stored timestamp and the one implied by the response were two different `Date.now()` calls.

Naming the two fields is the other half of it. The cache-hit path published the stored object as it found it, so anything ever added under `users.stats` would have gone out with it — today that is exactly `scores` and `updatedDate`, so nothing leaked, but it is the shape #105 removed from `user.js` and `name.js` and it costs nothing to keep it that way.

Now that the field is reliably there, the profile page shows it: a muted "Counted 3 hours ago" under the tabs, with the exact moment in the `title`, using the same `timeAgo`/`dateTime` pair the entry history already uses. `timeAgo` says "at an unknown time" for a response without one, so a page served an older shape still reads as a sentence.

The keys are pinned in two places, which is the whole point of the change:

- `score_tallies.test.js` asserts the two paths' bodies against each other on `toStats`, and that a field stored beside the two does not survive the trip. Runs with no install, no database and no API keys.
- `controllers/stats.test.js` is new and does it end to end — the real Netlify handler, an in-memory Mongo modelled on `name.test.js`, one request either side of the 48-hour line, and `Object.keys` of the two answers compared to each other rather than to a literal. It skips itself without dependencies, as `name.test.js` does; against the pre-fix controller four of its six tests fail.

One frontend test comes with the page change, and it is about the chart rather than the line: the global histogram sums `Object.values(stats.scores)`, and a timestamp now sitting beside `scores` would poison every bucket if that were ever loosened to `Object.values(stats)`.

Verified with `npm test` both ways — 359 pass with dependencies installed, 320 pass and 39 skip without, matching how CI runs it — and `git ls-files '*.js' | xargs -n1 node --check`.

The crash on an unknown username is untouched here: `findOneByField_` answers `{}`, and `refreshStats` reads `userDocument.data.userId` off it. That is #139's, and this branch deliberately stays out of its way.

Closes #145
