### PR TITLE
fix: answer 404 for a user who isn't there, instead of 502

### DIFF
--- a/src/api/controllers/bio.js
+++ b/src/api/controllers/bio.js
@@ -15,8 +15,11 @@ const setBio = (event) => toPromise(
     getUserId(event),
     getReqBody(event)
   ]))
+    // A valid token for a `sub` with no user document — which is every account
+    // between signing up and `setOwnName` running — is a 404 rather than the
+    // 502 that destructuring the db module's `{}` used to give. See #139.
     .asyncAndThen(([uid, { newBio }]) =>
-      db.findOneByField_('users', 'userId', uid)
+      db.findOneByFieldOrFail_('users', 'userId', uid)
         .map(({ ref }) => [ref, newBio])
     )
     .andThen(([ref, newBio]) =>

--- a/src/api/controllers/revisions.js
+++ b/src/api/controllers/revisions.js
@@ -238,7 +238,7 @@ const findDraft = async (entryRef, userId) => {
 
   // A miss is `{}` from the db module, and every caller here tests the draft
   // for truthiness before reaching into it.
-  return found?.ref?.id ? found : undefined
+  return db.isFound(found) ? found : undefined
 }
 
 /** @type {(collection: ValidCollection, entryRef: string) => Promise<any | undefined>} */

--- a/src/api/controllers/stats.js
+++ b/src/api/controllers/stats.js
@@ -16,10 +16,18 @@ const { toScoreTally, toStats } = require('../utils/score_tallies')
  * Both paths answer with `{ scores, updatedDate }` — `toStats` builds it, and
  * this one names the two fields rather than handing back the stored document
  * as it found it. See #145 and score_tallies.js.
+ *
+ * A name nobody has taken is a 404, unlike `/api/user/:username` and
+ * `/api/name/:username`, which answer 200 with an empty body. Those two are
+ * existence probes the frontend calls *expecting* a miss — the list page asks
+ * whether a name is free, and the profile page turns an empty answer into its
+ * own 404. This route is neither: the profile page only asks for stats once
+ * `/api/user` has told it the user exists, so a miss here is a URL naming
+ * something that isn't there. It used to be a 502. See #139.
  * @type {(event: Event) => Promise<Response>}
  */
 const getUserStats = (event) => toPromise(
-  db.findOneByField_('users', 'username', getSegment(0, event))
+  db.findOneByFieldOrFail_('users', 'username', getSegment(0, event))
     .andThen(result => {
       // The stored tallies stand for 48 hours; past that they are recomputed.
       const stats = result?.data?.stats

--- a/src/api/controllers/stats.test.js
+++ b/src/api/controllers/stats.test.js
@@ -9,9 +9,17 @@
  * each other rather than each against a literal — a shape that changes has to
  * change on both paths or fail here.
  *
+ * The two at the end are #139: a name nobody has taken used to reach
+ * `refreshStats` with the `{}` the db module reports a miss as, read
+ * `.data.userId` off it and throw — inside an `andThen` callback, where
+ * neverthrow does not catch, so the handler returned a rejected promise and
+ * Netlify answered 502 with an empty body. The route is public, so that was
+ * one unauthenticated GET away.
+ *
  * That needs the actual dependencies, so the file **skips itself** when they
  * aren't installed (which is how CI runs the suite). The same shape is pinned
- * without them on `toStats` in ../utils/score_tallies.test.js.
+ * without them on `toStats` in ../utils/score_tallies.test.js, and the
+ * absent-document rule on `isFound` in ../utils/db/found.test.js.
  */
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
@@ -236,4 +244,28 @@ test('a field stored beside the two is not published with them', options, async 
 
   assert.deepEqual(Object.keys(body).sort(), ['scores', 'updatedDate'])
   assert.equal('internalNote' in body, false)
+})
+
+/**
+ * #139. `findOneByField_` reports a miss as `{}`, which `refreshStats` used to
+ * read `.data.userId` off. The throw happened inside an `andThen` callback,
+ * where neverthrow does not catch it, so the handler returned a rejected
+ * promise and the caller got a 502 with no body.
+ */
+test('a username nobody has taken is a 404 and not a crash', options, async () => {
+  seed({ statsAge: MS_IN_DAY })
+
+  const { statusCode, body } = await getStats('nosuchuser')
+
+  assert.equal(statusCode, 404)
+  assert.equal(body.error, 'NotFound')
+})
+
+test('a username nobody has taken counts nothing and stores nothing', options, async () => {
+  seed({})
+  const before = JSON.stringify(store.users)
+
+  await getStats('nosuchuser')
+
+  assert.equal(JSON.stringify(store.users), before)
 })

--- a/src/api/utils/db/found.js
+++ b/src/api/utils/db/found.js
@@ -1,0 +1,25 @@
+/**
+ * @file Whether a single-document read found anything.
+ *
+ * `findFirst` in ./unsafe_functions.js reports "no such document" as `{}`
+ * rather than as `null`, because most callers here treat absence as a normal
+ * answer: `user.js` and `name.js` test `?.data` and answer 200 with an empty
+ * body, which is what the profile page turns into its own 404. That
+ * convention is only a trap for the callers that treat absence as a *failure*
+ * and reach straight into what came back — `{}.data.userId` throws, and inside
+ * a neverthrow callback that throw leaves as a rejected promise. See #139.
+ *
+ * So the test lives here, once, instead of being spelled out by hand at each
+ * site that needs it. `ref.id` and not `data`: a document always has a `ref`,
+ * and the `users` document a brand-new account gets from `create_` has no
+ * fields on it worth speaking of yet.
+ *
+ * Dependency-free on purpose — the suite runs with no install (see CLAUDE.md).
+ */
+
+/** @type {(document: any) => boolean} */
+const isFound = (document) => Boolean(document?.ref?.id)
+
+module.exports = {
+  isFound,
+}

--- a/src/api/utils/db/found.test.js
+++ b/src/api/utils/db/found.test.js
@@ -1,0 +1,42 @@
+/**
+ * @file The one test that says what "the db module found nothing" looks like.
+ *
+ * Dependency-free, like the module it covers, so it runs in the suite CI
+ * actually runs — no install, no database. The endpoints that used to 502 on
+ * a miss are covered through their handlers in ../../controllers/stats.test.js,
+ * which needs the dependencies and skips itself without them.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { isFound } = require('./found')
+const { toSameFormatAsFaunaDb } = require('./shapes')
+
+test('the empty object a miss comes back as is not a document', () => {
+  assert.equal(isFound({}), false)
+})
+
+test('a document the db module shaped is found', () => {
+  assert.equal(isFound(toSameFormatAsFaunaDb({ _id: 'a1', username: 'someone' })), true)
+})
+
+/**
+ * The reason this asks about `ref` and not `data`: a `users` document created
+ * by `create_` for a brand-new account carries a `userId` and nothing else,
+ * and it is still a document. A test on `data.stats`, or on any other field a
+ * caller happens to want, would call that a miss and take the absent branch.
+ */
+test('a document is found on its ref, whatever it does or does not carry', () => {
+  assert.equal(isFound({ data: {}, ref: { id: 'a1' } }), true)
+})
+
+test('nothing at all is not a document', () => {
+  assert.equal(isFound(undefined), false)
+  assert.equal(isFound(null), false)
+})
+
+/** `unwrapOr({})` and `okAsync({})` are how two callers seed the miss. */
+test('a half-shaped document does not pass for one', () => {
+  assert.equal(isFound({ ref: {} }), false)
+  assert.equal(isFound({ ref: { id: undefined } }), false)
+  assert.equal(isFound({ data: { username: 'someone' } }), false)
+})

--- a/src/api/utils/db/index.js
+++ b/src/api/utils/db/index.js
@@ -21,11 +21,13 @@
 /** @typedef {import('../responses').Response} Response */
 /** @typedef {import('../parsers').ValidCollection} ValidCollection */
 /** @typedef {import('../errors').Error} Error */
-const { ResultAsync } = require('neverthrow')
+const { ResultAsync, okAsync, errAsync } = require('neverthrow')
 const { _findOne, _findMany, _countScoresByValue, _findOneByField, _findOneByRef, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
 const { compose } = require('ramda')
 const { withTransaction } = require('./db')
 const { toResponse, toResult } = require('./into_safe_values')
+const { isFound } = require('./found')
+const errors = require('../errors')
 
 /** @typedef {import('./queries').QueryOptions} QueryOptions */
 /** @typedef {import('mongodb').ClientSession} ClientSession */
@@ -41,6 +43,26 @@ const findOneByField = compose(toResponse, _findOneByField)
 
 /** @type {(collection: ValidCollection, field: string, value: any) => ResultAsync<any, Error>} */
 const findOneByField_ = compose(toResult, _findOneByField)
+
+/**
+ * The same read, for a caller that cannot carry on without the document.
+ *
+ * `findOneByField_` reports "no such document" as `{}`, which is the right
+ * answer for the callers that test it — see ./found.js — and a trap for the
+ * ones that destructure it. Absence becomes an err here instead, so the rest
+ * of the chain simply does not run and the `mapErr` every controller already
+ * ends with turns it into a 404. Two endpoints answered 502 for want of this;
+ * see #139.
+ *
+ * The err carries no `detail`. A name nobody has taken is a normal answer to a
+ * public, unauthenticated route rather than a fault, and `responses.fromError`
+ * logs every `detail` it is given — which would let anyone write to the
+ * function log by asking for profiles at random.
+ * @type {(collection: ValidCollection, field: string, value: any) => ResultAsync<any, Error>}
+ */
+const findOneByFieldOrFail_ = (collection, field, value) =>
+  findOneByField_(collection, field, value)
+    .andThen((found) => isFound(found) ? okAsync(found) : errAsync(errors.notFound()))
 
 /**
  * The general form of the two above: a filter of as many fields as the caller
@@ -93,6 +115,7 @@ const create_ = compose(toResult, _create)
 
 module.exports = {
   withTransaction,
+  isFound,
   findOneByRef,
   findOneByRef_,
   findAll,
@@ -102,6 +125,7 @@ module.exports = {
   findAllByFieldIn_,
   findOneByField,
   findOneByField_,
+  findOneByFieldOrFail_,
   findAllUserEntriesWithMetadata_,
   updateByRef,
   updateByRef_,


### PR DESCRIPTION
Closes #139.

`findFirst` reports "no such document" as `{}` rather than `null`, deliberately, because most callers here treat absence as a normal answer — `user.js` and `name.js` test `?.data` and answer 200 with an empty body, which is what the profile page turns into its own 404. Two callers reached straight into it instead. `getUserStats` passed the `{}` to `refreshStats`, which reads `.data.userId` off it; `setBio` destructured `{ ref }` and then read `ref.id`. Both throws happen inside a neverthrow callback, which does not catch, so the handler returned a rejected promise and Netlify answered 502 with an empty body. `GET /api/stats/:username` is public, so `curl https://nil.moe/api/stats/nosuchuser` was the whole reproduction.

Rebased onto #154, which landed on the same handler while this was open. That change is untouched here: both paths still answer through `toStats`, and the two tests this adds sit alongside its six rather than replacing them.

## Why not flip the convention

The issue suggests making the helpers return `undefined` instead. I checked every caller of `findOneByField_`, `findOneByRef_`, `findOne_` and `findOneByField` first, and it comes out worse on both counts.

It would not have fixed either bug. Both sites destructure or dereference before they test anything, so `undefined` just moves the same `TypeError` one frame earlier — `.map` and `.andThen` don't catch it either way, and the answer is still a 502. A guard at each site would still have been needed.

And it would break six other callers that are relying on `{}` today:

| Caller | What it does with the miss | Survives `undefined`? |
| --- | --- | --- |
| `user.js` `getUserFromName` | `.map(({ data }) => data ? … : {})` | no — destructures |
| `name.js` `findOwnName` | `.map(({ data }) => …)` | no — destructures |
| `name.js` `getUserIdFromName` | `.map(({ data }) => …)` | no — destructures |
| `name.js` `assignNameIfNotTaken` | `.andThen(({ data }) => …)` | no — destructures |
| `name.js` `assignName` | `.andThen(({ ref }) => ref ? update : create)` | no — destructures |
| `entries.js` `deleteEntry` | `entry.data?.userId === uid` | no — `entry.data` on `undefined` |
| `entries.js` `withOwnedEntry` | `entry?.data?.userId` | yes |
| `entries.js` `updateEntry_` | `.unwrapOr({})`, then `?.data?.text` | yes |
| `works.js` `findCachedWork` | `result?.data`, seeded `okAsync({})` | yes |
| `utils.js` `findIdOfName` | `result?.data?.userId` | yes |
| `revisions.js` `findDraft` | `.unwrapOr({})`, then `found?.ref?.id` | yes |
| `revisions.js` `findReview` | `.unwrapOr({})`, then `?.data` | yes |
| `reviews.js` `getReview` | through `toResponse` | yes |

The five in `user.js` and `name.js` are the deliberate empty-body answer the frontend depends on, and `deleteEntry` is how a delete for an entry that doesn't exist becomes a 401 rather than a crash. So the convention is right for the majority and wrong only for the minority who treat absence as a failure — which argues for giving that minority a different way to ask, not for changing what everyone gets.

## What this does instead

`findOneByFieldOrFail_` is the same read for a caller that cannot carry on without the document: absence becomes `err(errors.notFound())`, so the rest of the chain never runs and the `mapErr` each controller already ends with turns it into a 404. At the two fixed sites the bug is now impossible rather than merely absent — the callback that used to throw is not reached. Every other caller is untouched.

The err carries no `detail`. `responses.fromError` logs every `detail` it is given, and a name nobody has taken is a normal answer on a public unauthenticated route, not a fault — with one attached, anyone could write to the function log by asking for profiles at random.

The predicate is `isFound` in `db/found.js`, on its own so it can be pure and dependency-free. `findDraft` in `revisions.js` had been spelling out `found?.ref?.id` by hand with a comment explaining why, and now shares it. It tests `ref.id` and not `data` because the `users` document a brand-new account gets from `create_` carries a `userId` and little else, and is still a document.

## 404, not an empty 200

`/api/user/:username` and `/api/name/:username` answer 200 with an empty body for an unknown name, and I kept that. They are existence probes the frontend calls *expecting* a miss — the list page asks whether a name is free, and `ProfilePage` turns the empty answer into `Error404()`. Stats is not one of those: `ProfilePage` only mounts `ProfileStats` in the branch where `/api/user` has already said the user exists, so the app never asks for the stats of a user who isn't there. A miss is therefore a URL naming something that isn't there, which is what `responses.js` already calls a 404. Nothing in the frontend reaches the new status code.

`POST /api/bio` for a token whose `sub` has no user document is a 404 on the same reasoning. Creating the document there would be a behaviour change — `setOwnName` is what creates it — so this reports rather than repairs.

## Tests

`found.test.js` is pure and dependency-free, so it runs in the suite CI actually runs, with no install and no database. It pins what a miss looks like, including the `ref`-not-`data` distinction above.

The two added to `stats.test.js` reuse the `seed` and `getStats` that #154 built, and pin the unknown username at a 404 that writes nothing. That file skips itself without the dependencies, as it already did.

I checked they fail against the unfixed code rather than trusting that they would: reverting `stats.js` alone turns both red with `TypeError: Cannot read properties of undefined (reading 'userId')` while #154's six stay green. `setBio` has no handler test in the suite; I drove it the same way in a throwaway script and confirmed 404 with the fix, an uncaught `TypeError: Cannot read properties of undefined (reading 'id')` without it, and that the ordinary path still writes the biography and answers 200.

`npm test` is 369 passing, 0 failing, 0 skipped with the dependencies installed. Without them the new `found.test.js` still runs in full and `stats.test.js` skips, which is the CI configuration. `git ls-files '*.js' | xargs -n1 node --check` is clean across all 144 files.

## Left for later

`findOneByRefOrFail_` and `findOneOrFail_` are the obvious companions and I did not add them, because nothing needs them yet and an unused helper is one more way to ask. `entries.js` `deleteEntry` reads `entry.data?.userId` where `withOwnedEntry` twelve lines away reads `entry?.data?.userId`; both are correct against `{}` today, but the first is the one that would break if anyone did flip the convention later, and it is worth a note rather than an unrelated edit here.
