### PR TITLE
feat(search): field terms and regexes in the list search box

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,38 @@ is in its source, and it points at these urls, so a reader that fetches
 `/api/*` onto `/.netlify/functions/*`, which is what makes every url in this
 README real rather than aspirational.
 
+**Searching a list.** The box above each sublist takes a comma-separated list
+of terms, all of which have to match. A bare term is a case-insensitive
+substring, tried against the columns the table is currently showing; a
+`field:value` term is a case-insensitive **regular expression**, tried against
+that field alone:
+
+```
+nolan                          films whose visible columns say "nolan"
+director:nolan                 films Nolan directed
+title:"^the ",director:nolan   ...whose title starts with "The"
+completed:^2019                finished in 2019
+actor:"lee, christopher"       quotes keep spaces and commas out of the parse
+year:                          an empty value keeps the rows that have a year
+```
+
+The names are `title`, `score`, `year`, `duration` (`playtime`, `pages`),
+`director`, `actor`, `studio`, `publisher`, `author`, `platform`, `genre`,
+`progress`, `started`, `completed` and `status`. A prefix that is not one of
+them is part of the text, so `9:00` searches for `9:00`, and a value that is
+not a valid regex is matched as text rather than matching nothing — every
+query with a bracket in it is typed through that state.
+
+The query goes in `?q=`, so a search can be linked to and survives a reload:
+[`/films/nil?q=director:nolan`](https://nil.moe/films/nil?q=director:nolan).
+The sublists are one list cut up by status and share the query, since the url
+describes the page rather than one table on it.
+
+Only the columns on show are searched, which is the fix for `nolan` returning
+Goldfinger: Margaret Nolan is in its cast, and the cast column is hidden. Turn
+the column on from the dropdown and it counts again. See
+`src/frontend/_includes/js/utils/entry_search.js`.
+
 **Entry history and drafts.** Saving an entry stores the version it replaced
 in the `entryRevisions` collection, and the edit form autosaves what is in it
 to the same collection while it is open. The edit modal grows a *History*

--- a/src/frontend/_includes/js/asset_plan.js
+++ b/src/frontend/_includes/js/asset_plan.js
@@ -29,6 +29,7 @@ const BUNDLED_FILES = [
   "js/utils/diff.js",
   "js/utils/entry_form_io.js",
   "js/utils/review_template.js",
+  "js/utils/entry_search.js",
   "js/utils/columns.js",
   "js/utils/tables.js",
   "js/components/index.js",

--- a/src/frontend/_includes/js/components/list/list.js
+++ b/src/frontend/_includes/js/components/list/list.js
@@ -1,5 +1,5 @@
 const { html, css } = Utils
-const { col, initTable, detailFormatter, allColumns, statuses, entryTypeToFullColumns, editColumn, filmStatuses } = Tables
+const { col, initTable, detailFormatter, allColumns, statuses, entryTypeToFullColumns, editColumn, filmStatuses, searchSettings } = Tables
 const { typeToTitle, statusToTitle } = Conversions
 const { initComponent, WithRemoteData, appendContent, Nothing } = Components
 const { Modal_ } = Components.UI
@@ -232,12 +232,18 @@ const initFullTable = (selector, data, entryType, isOwner, status) => {
   // one registry serves every table on it.
   data.forEach((row) => { Rows.byRef[row.dbRef] = row })
 
+  searchedTables.push(selector)
+
   initTable(selector, data, {
     detailView: true,
     detailFormatter,
     icons: 'icons',
     iconsPrefix: 'fa',
-    search: true,
+    ...searchSettings(),
+    // Every sublist opens on whatever the url asked for, which is what makes
+    // a searched list a thing you can link someone.
+    searchText: Http.getSearchFromUrl(),
+    onSearch: (text) => onSearched(selector, text),
     showColumns: true,
     sortName: 'score',
     sortOrder: 'desc',
@@ -253,6 +259,26 @@ const initFullTable = (selector, data, entryType, isOwner, status) => {
       showCloseConfirmationDialog: () => window.hasUnsavedChange === true
     }))
   }
+}
+
+/** Every table on the page, in the order they were built. */
+const searchedTables = []
+
+/**
+ * The sublists are one list cut up by status, and each of them draws a search
+ * box of its own. Searching one and not the others leaves the page in a state
+ * no single url can describe — and the url is where the query now lives — so
+ * a search in any box is a search in all of them.
+ * @type {(selector: string, text: string) => void}
+ */
+const onSearched = (selector, text) => {
+  Http.setSearchInUrl(text)
+  searchedTables
+    .filter((other) => other !== selector)
+    // `resetSearch` comes back through here, but bootstrap-table drops a
+    // search that does not change the text before it fires the event, so the
+    // second lap is where this stops.
+    .forEach((other) => $(other).bootstrapTable('resetSearch', text))
 }
 
 const toStats = (entries, entryType) => {

--- a/src/frontend/_includes/js/utils/columns.js
+++ b/src/frontend/_includes/js/utils/columns.js
@@ -8,10 +8,14 @@ const title = () =>
     sortable: true,
   })
 
+// `searchable: false` here and on `edit` below: neither column holds any of
+// the entry, so a row that matched on one would have matched on its row number
+// or on the hex of its id.
 const index = () =>
   col('#', '#', {
     formatter: indexFormatter,
     visible: false,
+    searchable: false,
     cellStyle: () => ({ css: { 'width': '15px' } })
   })
 
@@ -81,6 +85,7 @@ const genre = () =>
 
 const edit = () =>
   col('<i class="fas fa-edit"></i>', 'editCol', {
+    searchable: false,
     formatter: (_, row, i) => {
       // We use `onclick` and a global (window.xx) function instead of binding
       // an event, because bootstrap-table destroys the node and rebuilds it

--- a/src/frontend/_includes/js/utils/entry_search.js
+++ b/src/frontend/_includes/js/utils/entry_search.js
@@ -1,0 +1,237 @@
+/**
+ * @file What the search box above a list means, and which rows survive it.
+ *
+ * bootstrap-table's own search is a case-insensitive substring test against
+ * every searchable column — hidden ones included — run over the rendered HTML
+ * of the cell rather than the value behind it. Searching a film list for
+ * `nolan` therefore returns Goldfinger, whose hidden cast column holds
+ * Margaret Nolan, and searching for `go` returns the whole list, because
+ * every linked name renders with `&go=Go` in its href.
+ *
+ * So this replaces it, wired up as `customSearch` in `utils/tables.js`. A
+ * query is a comma-separated list of terms, all of which have to match:
+ *
+ *   nolan          a bare term: a case-insensitive substring, tried against
+ *                  the columns the table is actually showing
+ *   director:nolan a field term: a case-insensitive *regex*, tried against
+ *                  that one field
+ *   title:"^the ",director:nolan
+ *                  both of them, and quotes keep the spaces and commas inside
+ *                  them out of the parse
+ *   director:      an empty field term keeps the rows that have a director at
+ *                  all
+ *
+ * A prefix that is not a field name is not a field term — `9:00` searches for
+ * `9:00`. A field value that is not a valid regex falls back to a substring
+ * test rather than matching nothing, which is what every half-typed `title:^(`
+ * on the way to a real query is.
+ *
+ * Pure: no DOM, no jQuery, no bootstrap-table. The glue is in
+ * `utils/tables.js`, and `components/list/list.js` puts the query in the url.
+ */
+
+/**
+ * The fields a term can name, keyed by the bootstrap-table column field they
+ * belong to so that a table can ask which of its columns are searchable and
+ * what each one holds.
+ */
+const searchFields = {
+  'commonMetadata.englishTranslatedTitle': {
+    names: ['title', 'name'],
+    // The Title column shows the original title beside the translated one
+    // when they differ, so `title:` matches either of them.
+    paths: [
+      'commonMetadata.englishTranslatedTitle',
+      'commonMetadata.originalTitle',
+    ],
+  },
+  'score': { names: ['score', 'preference'], paths: ['score'] },
+  'commonMetadata.releaseYear': {
+    names: ['year'],
+    paths: ['commonMetadata.releaseYear'],
+  },
+  // Minutes for a film, an episode or a game, pages for a book: the number
+  // that is stored, not the `2h30m` the cell draws from it.
+  'commonMetadata.duration': {
+    names: ['duration', 'playtime', 'pages', 'runtime'],
+    paths: ['commonMetadata.duration'],
+  },
+  'commonMetadata.directors': {
+    names: ['director', 'directors'],
+    paths: ['commonMetadata.directors'],
+  },
+  'commonMetadata.actors': {
+    names: ['actor', 'actors', 'cast'],
+    paths: ['commonMetadata.actors'],
+  },
+  'commonMetadata.studios': {
+    names: ['studio', 'studios'],
+    paths: ['commonMetadata.studios'],
+  },
+  'commonMetadata.publishers': {
+    names: ['publisher', 'publishers'],
+    paths: ['commonMetadata.publishers'],
+  },
+  'commonMetadata.authors': {
+    names: ['author', 'authors'],
+    paths: ['commonMetadata.authors'],
+  },
+  'commonMetadata.platforms': {
+    names: ['platform', 'platforms'],
+    paths: ['commonMetadata.platforms'],
+  },
+  'commonMetadata.genres': {
+    names: ['genre', 'genres'],
+    paths: ['commonMetadata.genres'],
+  },
+  'progress': { names: ['progress'], paths: ['progress'] },
+  'startedDate': {
+    names: ['started', 'starteddate'],
+    paths: ['startedDate'],
+    asDate: true,
+  },
+  'completedDate': {
+    names: ['completed', 'completeddate'],
+    paths: ['completedDate'],
+    asDate: true,
+  },
+  // No column of its own — each sublist is one status already — but a url
+  // that describes the whole page is worth the name being spellable.
+  'status': { names: ['status'], paths: ['status'] },
+}
+
+/** The field a column holds, or `undefined` for `#` and the edit button. */
+const fieldFor = (columnField) => searchFields[columnField]
+
+/**
+ * Splits a query into terms and reads each one, so that the parse happens once
+ * per search rather than once per row.
+ * @type {(text: string) => object[]}
+ */
+const parseQuery = (text) => splitTerms(text).map(toTerm)
+
+/**
+ * @type {(row: object, terms: object[], freeTextFields: object[]) => boolean}
+ */
+const matchesQuery = (row, terms, freeTextFields) =>
+  terms.every((term) =>
+    (term.field ? [term.field] : freeTextFields)
+      .some((field) =>
+        toSearchStrings(row, field).some((value) => term.matches(value))
+      )
+  )
+
+/**
+ * `freeTextFields` is what a bare term is tried against — the fields of the
+ * columns the table is showing. An empty query keeps the rows as they are,
+ * array and all, the way bootstrap-table's own search does.
+ * @type {(rows: object[], text: string, freeTextFields: object[]) => object[]}
+ */
+const filterEntries = (rows, text, freeTextFields) => {
+  const terms = parseQuery(text)
+  return terms.length === 0
+    ? rows
+    : rows.filter((row) => matchesQuery(row, terms, freeTextFields))
+}
+
+EntrySearch = {
+  fieldFor,
+  parseQuery,
+  matchesQuery,
+  filterEntries,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/** Every name in `searchFields`, pointing at the field that offers it. */
+const fieldsByName = Object.fromEntries(
+  Object.values(searchFields).flatMap((field) =>
+    field.names.map((name) => [name, field])
+  )
+)
+
+const FIELD_TERM = /^([a-z][a-z0-9_]*)\s*:\s*([\s\S]*)$/i
+
+/**
+ * Commas separate terms, except inside a quoted value: an actor is
+ * `actor:"lee, christopher"` and a title can hold a comma of its own. The
+ * quotes are left in for `unquote` to take off, so that a value only loses
+ * them when it is the value that was quoted.
+ * @type {(text: string) => string[]}
+ */
+const splitTerms = (text) => {
+  const terms = ['']
+  let quoted = false
+  for (const character of String(text ?? '')) {
+    if (character === '"') quoted = !quoted
+    if (character === ',' && !quoted) terms.push('')
+    else terms[terms.length - 1] += character
+  }
+  return terms.map((term) => term.trim()).filter((term) => term !== '')
+}
+
+/**
+ * A term names a field or it does not. An unknown prefix is not an error and
+ * not an empty result — `9:00` and `re:zero` are things to search for, so the
+ * whole term becomes the text to look for.
+ */
+const toTerm = (raw) => {
+  const [, name, value] = FIELD_TERM.exec(raw) ?? []
+  const field = name === undefined ? undefined : fieldsByName[name.toLowerCase()]
+  return field
+    ? { field, matches: toRegexTest(unquote(value)) }
+    : { field: null, matches: toSubstringTest(unquote(raw)) }
+}
+
+const unquote = (value) =>
+  value.length > 1 && value.startsWith('"') && value.endsWith('"')
+    ? value.slice(1, -1)
+    : value
+
+/**
+ * Anything that does not compile is treated as the text it is. Every prefix of
+ * a query is typed on the way to typing the query, so `title:^the (` happens
+ * to everyone who searches for a bracket, and a thrown SyntaxError there would
+ * empty the page mid-keystroke.
+ */
+const toRegexTest = (value) => {
+  try {
+    const pattern = new RegExp(value, 'i')
+    return (text) => pattern.test(text)
+  } catch {
+    return toSubstringTest(value)
+  }
+}
+
+const toSubstringTest = (value) => {
+  const needle = value.toLowerCase()
+  return (text) => text.toLowerCase().includes(needle)
+}
+
+/** Every string of a row worth matching a term against, for one field. */
+const toSearchStrings = (row, field) =>
+  field.paths.flatMap((path) => toStrings(valueAt(row, path), field))
+
+const valueAt = (row, path) =>
+  path.split('.').reduce((value, key) => value?.[key], row)
+
+const toStrings = (value, field) =>
+  value === null || value === undefined
+    ? []
+    : Array.isArray(value)
+    ? value.flatMap((each) => toStrings(each, field))
+    : field.asDate
+    ? [toIsoDate(value)]
+    : [String(value)]
+
+/**
+ * Dates are stored as epoch milliseconds, which nobody searches for. As
+ * `YYYY-MM-DD` — the same string the column draws — `completed:^2019` is a
+ * year and `completed:2019-06` is a month.
+ */
+const toIsoDate = (value) => {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? String(value)
+    : date.toISOString().slice(0, 10)
+}

--- a/src/frontend/_includes/js/utils/entry_search.test.js
+++ b/src/frontend/_includes/js/utils/entry_search.test.js
@@ -1,0 +1,231 @@
+/**
+ * @file The frontend scripts are plain globals concatenated into a bundle
+ * rather than modules, so this loads entry_search.js into a vm context and
+ * pulls the search out of the script's scope.
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "entry_search.js"), "utf8");
+
+// base.njk wraps each included file in its own IIFE, which is what keeps two
+// files' `const`s from colliding and what makes an assignment with no keyword
+// (`EntrySearch = …`) the only thing that crosses between them. Loading it the
+// same way here keeps that difference visible.
+const { EntrySearch, searchFields } = vm.runInContext(
+  `(() => {\n${source}\n;return ({ EntrySearch, searchFields })\n})()`,
+  vm.createContext({})
+);
+
+const { filterEntries, fieldFor } = EntrySearch;
+
+/** The fields of the columns a film list shows before anything is toggled. */
+const visibleFilmFields = [
+  "commonMetadata.englishTranslatedTitle",
+  "score",
+  "commonMetadata.releaseYear",
+  "commonMetadata.directors",
+].map(fieldFor);
+
+/**
+ * A row as the table sees it: the entry's own fields at the top, the work's
+ * metadata under `commonMetadata` with the overrides already folded in.
+ */
+const entry = ({ score, completedDate, title, ...metadata }) => ({
+  status: "Completed",
+  score,
+  completedDate,
+  commonMetadata: { englishTranslatedTitle: title, ...metadata },
+});
+
+const inception = entry({
+  title: "Inception",
+  releaseYear: 2010,
+  directors: ["Christopher Nolan"],
+  actors: ["Leonardo DiCaprio", "Elliot Page"],
+  score: 7,
+  completedDate: Date.UTC(2019, 5, 14),
+});
+
+const goldfinger = entry({
+  title: "Goldfinger",
+  releaseYear: 1964,
+  directors: ["Guy Hamilton"],
+  // The cast is the reason this film came back from a search for `nolan`.
+  actors: ["Sean Connery", "Margaret Nolan"],
+  score: 6,
+  completedDate: Date.UTC(2021, 0, 2),
+});
+
+const thePrestige = entry({
+  title: "The Prestige",
+  releaseYear: 2006,
+  directors: ["Christopher Nolan"],
+  actors: ["Hugh Jackman", "Christian Bale"],
+  score: 7,
+});
+
+const theWitcher = entry({
+  title: "The Witcher: Nightmare of the Wolf",
+  directors: ["Han Kwang-il"],
+  actors: ["Theo James", "Nolan North"],
+});
+
+const films = [inception, goldfinger, thePrestige, theWitcher];
+
+const titlesOf = (rows) =>
+  rows.map((row) => row.commonMetadata.englishTranslatedTitle);
+
+const search = (query, fields = visibleFilmFields) =>
+  titlesOf(filterEntries(films, query, fields));
+
+test("a bare term does not match a column the table is not showing", () => {
+  // The complaint in #137: `nolan` returned Goldfinger, Friends with Benefits
+  // and The Witcher, because each has a Nolan in the hidden cast column.
+  assert.deepEqual(search("nolan"), ["Inception", "The Prestige"]);
+});
+
+test("a bare term does match a hidden column once it is shown", () => {
+  assert.deepEqual(
+    search("nolan", [...visibleFilmFields, fieldFor("commonMetadata.actors")]),
+    ["Inception", "Goldfinger", "The Prestige", "The Witcher: Nightmare of the Wolf"]
+  );
+});
+
+test("a field term matches that field and nothing else", () => {
+  assert.deepEqual(search("director:nolan"), ["Inception", "The Prestige"]);
+  assert.deepEqual(search("actor:nolan"), [
+    "Goldfinger",
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+  // The field is named, so the columns on show have nothing to do with it.
+  assert.deepEqual(search("actor:nolan", []), [
+    "Goldfinger",
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+});
+
+test("a field term is case-insensitive on both sides", () => {
+  assert.deepEqual(search("DIRECTOR:NoLaN"), ["Inception", "The Prestige"]);
+});
+
+test("a field term is a regex", () => {
+  assert.deepEqual(search('title:"^the "'), [
+    "The Prestige",
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+  assert.deepEqual(search("year:^19"), ["Goldfinger"]);
+  assert.deepEqual(search("score:^7$"), ["Inception", "The Prestige"]);
+});
+
+test("terms are separated by commas and all of them have to match", () => {
+  assert.deepEqual(search('title:"^the ",director:nolan'), ["The Prestige"]);
+  assert.deepEqual(search("director:nolan, 2010"), ["Inception"]);
+  assert.deepEqual(search("director:nolan,director:hamilton"), []);
+});
+
+test("quotes keep a comma inside a value out of the split", () => {
+  assert.deepEqual(search('actor:"connery, sean"'), []);
+  assert.deepEqual(search('actor:"connery|nolan north"'), [
+    "Goldfinger",
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+});
+
+test("a bare term is text, not a regex", () => {
+  // Which is the point of only the field terms being regexes: a title typed
+  // into the box with brackets or a dot in it is still a title.
+  assert.deepEqual(search("the witcher: nightmare of the wolf"), [
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+  assert.deepEqual(search("t.e prestige"), []);
+});
+
+test("a prefix that is not a field name is part of the text", () => {
+  // `re:zero` and `9:00` are things to search for, not fields to search in.
+  assert.deepEqual(search("witcher: nightmare"), [
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+  assert.deepEqual(search("nosuchfield:nolan"), []);
+});
+
+test("a value that is not a valid regex is matched as text", () => {
+  // Every query with a bracket in it is typed through this state, and an
+  // uncaught SyntaxError here would empty the page mid-keystroke.
+  assert.deepEqual(search("title:^the ("), []);
+  assert.deepEqual(search("title:witcher("), []);
+  assert.deepEqual(search('title:"the witcher: nightmare of the wolf"'), [
+    "The Witcher: Nightmare of the Wolf",
+  ]);
+});
+
+test("an empty field term keeps the rows that have the field at all", () => {
+  assert.deepEqual(search("year:"), ["Inception", "Goldfinger", "The Prestige"]);
+  assert.deepEqual(search("completed:"), ["Inception", "Goldfinger"]);
+});
+
+test("dates are matched as YYYY-MM-DD, not as the epoch milliseconds", () => {
+  assert.deepEqual(search("completed:^2019"), ["Inception"]);
+  assert.deepEqual(search("completed:2021-01-02"), ["Goldfinger"]);
+  assert.deepEqual(search(`completed:${Date.UTC(2019, 5, 14)}`), []);
+});
+
+test("the title term matches the original title as well as the English one", () => {
+  const akira = {
+    commonMetadata: {
+      englishTranslatedTitle: "Akira",
+      originalTitle: "アキラ",
+    },
+  };
+  assert.deepEqual(
+    filterEntries([akira], "title:アキラ", visibleFilmFields),
+    [akira]
+  );
+});
+
+test("an empty query is every row, and the array it arrived in", () => {
+  assert.equal(filterEntries(films, "", visibleFilmFields), films);
+  assert.equal(filterEntries(films, "   ", visibleFilmFields), films);
+  assert.equal(filterEntries(films, " , , ", visibleFilmFields), films);
+});
+
+test("a row missing the field it is searched on is dropped, not thrown over", () => {
+  const bare = {};
+  assert.deepEqual(filterEntries([bare], "director:nolan", visibleFilmFields), []);
+  assert.deepEqual(filterEntries([bare], "nolan", visibleFilmFields), []);
+});
+
+test("every field name a column offers is spellable, and spelled one way", () => {
+  // `fieldFor` is how a table turns its columns into the fields a bare term
+  // is tried against, so a column whose field is not in the table searches
+  // nothing at all — silently.
+  const columnFields = [
+    "commonMetadata.englishTranslatedTitle",
+    "score",
+    "commonMetadata.releaseYear",
+    "commonMetadata.duration",
+    "commonMetadata.directors",
+    "commonMetadata.actors",
+    "commonMetadata.studios",
+    "commonMetadata.publishers",
+    "commonMetadata.authors",
+    "commonMetadata.platforms",
+    "commonMetadata.genres",
+    "progress",
+    "startedDate",
+    "completedDate",
+  ];
+  columnFields.forEach((columnField) =>
+    assert.ok(fieldFor(columnField), `no search field for ${columnField}`)
+  );
+
+  const names = Object.values(searchFields).flatMap((field) => field.names);
+  assert.deepEqual(
+    names.filter((name, i) => names.indexOf(name) !== i),
+    [],
+    "two fields answer to the same name, so one of them is unreachable"
+  );
+});

--- a/src/frontend/_includes/js/utils/http.js
+++ b/src/frontend/_includes/js/utils/http.js
@@ -27,6 +27,30 @@ const getEntryTypeFromUrl = () => {
   return urlParams.get('type') ?? getFirstPathnameSegment()
 }
 
+/** The list page's search query. See `utils/entry_search.js` for its syntax. */
+const getSearchFromUrl = () =>
+  new URLSearchParams(window.location.search).get(SEARCH_PARAM) ?? ''
+
+/**
+ * Puts the query in the url, so that a search can be linked to, bookmarked and
+ * come back on a reload. `replaceState` rather than `pushState`: the search
+ * fires as it is typed, and a history entry per keystroke would make the back
+ * button spell `director:nolan` backwards one letter at a time.
+ * @type {(text: string) => void}
+ */
+const setSearchInUrl = (text) => {
+  const params = new URLSearchParams(window.location.search)
+  if (text) {
+    params.set(SEARCH_PARAM, text)
+  } else {
+    params.delete(SEARCH_PARAM)
+  }
+  const query = params.toString()
+  const url = window.location.pathname +
+    (query ? `?${query}` : '') +
+    window.location.hash
+  window.history.replaceState(null, '', url)
+}
 
 Http = {
   get,
@@ -37,9 +61,14 @@ Http = {
   getToken,
   getNameFromUrl,
   getEntryTypeFromUrl,
+  getSearchFromUrl,
+  setSearchInUrl,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+/** Short, because it is the parameter a shared list url is mostly made of. */
+const SEARCH_PARAM = 'q'
 
 const getErrorStatusCode = (error) => error.response?.status ?? 500
 

--- a/src/frontend/_includes/js/utils/tables.js
+++ b/src/frontend/_includes/js/utils/tables.js
@@ -97,6 +97,50 @@ const statuses = ['InProgress', 'Completed', 'Dropped', 'Planned']
 
 const filmStatuses = ['Completed', 'Planned']
 
+/**
+ * bootstrap-table 1.12's `customSearch` is the *name of a global function*
+ * rather than a function — it calls `window[options.customSearch]` — so this
+ * has to be on `window` and its name has to be worth having there.
+ *
+ * It is called with the table as `this`, once per keystroke and again whenever
+ * a column is shown or hidden, and leaves the surviving rows in `this.data`
+ * the way the search it replaces does.
+ */
+const CUSTOM_SEARCH = 'searchListRows'
+
+/**
+ * The settings that put `utils/entry_search.js` in charge of a table's search
+ * box, for a table that wants one. The placeholder is where the field syntax
+ * is advertised: a query language nothing mentions is a query language nobody
+ * types.
+ */
+const searchSettings = () => ({
+  search: true,
+  customSearch: CUSTOM_SEARCH,
+  formatSearch: () => 'Search, e.g. director:nolan',
+})
+
+window[CUSTOM_SEARCH] = function (searchText) {
+  this.data = EntrySearch.filterEntries(
+    this.options.data,
+    searchText,
+    freeTextFields(this.columns)
+  )
+}
+
+/**
+ * A bare term is tried against the columns the table is showing. Hidden ones
+ * are what made `nolan` return films no Nolan worked on — the cast column is
+ * hidden by default — and a row that matches on something the reader cannot
+ * see is indistinguishable from a bug. The column dropdown can bring one back,
+ * and bootstrap-table re-runs the search when it does.
+ */
+const freeTextFields = (columns) =>
+  columns
+    .filter((column) => column.visible && column.searchable !== false)
+    .map((column) => EntrySearch.fieldFor(column.field))
+    .filter((field) => field !== undefined)
+
 Tables = {
   initTable,
   detailFormatter,
@@ -104,4 +148,5 @@ Tables = {
   statuses,
   filmStatuses,
   entryTypeToFullColumns,
+  searchSettings,
 }


### PR DESCRIPTION
Closes #137.

Searching a film list for `nolan` returned Goldfinger, Last Night in Soho, Underworld: Rise of the Lycans, Friends with Benefits and The Witcher: Nightmare of the Wolf alongside the Nolan films. bootstrap-table's search is a case-insensitive substring test against every searchable column — hidden ones included — run over the *rendered HTML* of the cell rather than the value behind it. Each of those five has a Nolan in its cast, and the cast column is hidden by default. (The same mechanism means `go` matches every row on the page: linked names render with `&go=Go` in the href.) And there was no way to say "the director, specifically".

So the box gets a query language. A query is a comma-separated list of terms, all of which have to match. A bare term is a case-insensitive substring, tried against the columns the table is showing. A `field:value` term is a case-insensitive **regex**, tried against that field alone:

```
nolan                          the visible columns say "nolan"
director:nolan                 films Nolan directed
title:"^the ",director:nolan   ...whose title starts with "The"
completed:^2019                finished in 2019
actor:"lee, christopher"       quotes keep spaces and commas out of the parse
year:                          an empty value keeps the rows that have a year
```

The names are `title`, `score`, `year`, `duration` (`playtime`, `pages`), `director`, `actor`, `studio`, `publisher`, `author`, `platform`, `genre`, `progress`, `started`, `completed` and `status`. Dates are matched as `YYYY-MM-DD` rather than as the epoch milliseconds they are stored as, and `title:` covers the original title as well as the translated one, since the column shows both.

Two decisions worth arguing with:

- **Only field terms are regexes.** A bare term stays a literal substring, so `spider-man (2002)` typed into the box is still a search for `spider-man (2002)` rather than a group that matches nothing. The issue asks for regex where a field is named, and that is where it is.
- **A bare term only searches the columns on show.** This is the half that fixes the report: a row that matches on something the reader cannot see is indistinguishable from a bug. The cast column can be turned back on from the dropdown, and bootstrap-table re-runs the search when it is — with Actors shown, `nolan` returns 16 films instead of 11, and the extra five are exactly the ones in the screenshot on the issue.

An unknown prefix is part of the text, so `9:00` and `re:zero` still search for themselves. A value that is not a valid regex is matched as text rather than matching nothing, because `title:^the (` is a state every query with a bracket in it is typed through, and a thrown `SyntaxError` there would empty the page mid-keystroke.

The query goes in `?q=`, so a searched list can be linked to and survives a reload: `/films/nil?q=director:nolan`. `replaceState`, not `pushState` — the search fires as it is typed, and a history entry per keystroke would make the back button spell `director:nolan` backwards one letter at a time. The sublists are one list cut up by status and share the query, since the url describes the page rather than one table on it.

**Shape.** The language itself is `utils/entry_search.js`: pure, no DOM, no jQuery, no bootstrap-table, and tested on its own. The glue is a dozen lines in `utils/tables.js` — bootstrap-table 1.12's `customSearch` is the *name* of a global function rather than a function, which is why one lands on `window` — and the url handling is in `utils/http.js`.

**Checked in a browser**, not just in tests: the built bundle served against production data. `?q=director:nolan` opens both sublists filtered and seeds both boxes; typing in one syncs the other and rewrites the url; `title:"^the ",director:nolan` gives exactly The Prestige, The Odyssey, The Dark Knight Rises and The Dark Knight; clearing the box drops `?q=` and restores all 1312 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
