### PR TITLE
perf: name the bundle and the stylesheet after their contents

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,16 +1,12 @@
-const UglifyJS = require('uglify-js')
 const HtmlMinifier = require('html-minifier')
 
 module.exports = (config) => {
-  // Set by both npm scripts. Anything else — a bare `eleventy`, a CI job, a
-  // Netlify build — is treated as production, so the fallback is the safe one.
-  const isDev = process.env.ELEVENTY_ENV === 'dev'
-
   // minify the html output
   config.addTransform('htmlmin', (content, outputPath) => {
-    // A transform runs over every output file, and `/js/bundle.js` is one of
-    // them now. `collapseWhitespace` over JavaScript eats the newline that
-    // ends a `//` comment, and the rest of the file goes with it.
+    // A transform runs over every output file, and the bundle and the
+    // stylesheet are two of them now. `collapseWhitespace` over JavaScript eats
+    // the newline that ends a `//` comment, and the rest of the file goes
+    // with it.
     if (!outputPath || !outputPath.endsWith('.html')) return content
 
     return HtmlMinifier.minify(content, {
@@ -20,42 +16,22 @@ module.exports = (config) => {
     })
   })
 
-  // compress and combine js files
-  config.addFilter('jsmin', (code) => {
-    // `{% set %}` hands a filter a Nunjucks SafeString, and UglifyJS reads
-    // anything that is not a string as a map of filenames to sources.
-    //
-    // Compressing and mangling 140KB is the slowest thing in the build — 300ms
-    // of a 900ms run — and it buys a watch loop nothing. Parsing is the part
-    // worth keeping in dev: it costs 40ms and it is what the check below reads.
-    const minified = isDev
-      ? UglifyJS.minify(String(code), {
-          compress: false,
-          mangle: false,
-          output: { beautify: true },
-        })
-      : UglifyJS.minify(String(code))
-
-    // Handing back the unminified input on failure is how a bundle that does
-    // not parse gets shipped anyway. Every page on this site is drawn by that
-    // one file, so a syntax error in it is a blank page on every url, with
-    // nothing in the build log above it. Fail the build instead.
-    if (minified.error) {
-      throw new Error(`jsmin: UglifyJS could not parse the bundle: ${minified.error}`)
-    }
-
-    return minified.code
-  })
+  // The bundle is concatenated, minified and hashed in `src/frontend/_data/
+  // assets.js` rather than by a filter here, because its filename has to carry
+  // a digest of its contents and `layouts/base.njk` needs that name before the
+  // file is written. Global data is built before anything renders, so that is
+  // where it can be known. `js/bundle.njk` and `css/main.njk` emit it, and the
+  // dev-versus-production minification choice moved there with it.
 
   // pass some assets right through
   config.addPassthroughCopy('./src/frontend/img')
-  // The stylesheet is served from `/css/main.css` rather than inlined into
-  // every page, for the same reason the scripts are. It lives under
-  // `_includes` because it used to be `{% include %}`d.
-  config.addPassthroughCopy({
-    './src/frontend/_includes/css/main.css': 'css/main.css',
-  })
   config.addPassthroughCopy('./_redirects')
+
+  // The bundle's sources are read by `_data/assets.js` with `fs`, so Eleventy
+  // has no idea that a page depends on them. Without this, editing a component
+  // under `--serve` rebuilds nothing.
+  config.addWatchTarget('./src/frontend/_includes/js/')
+  config.addWatchTarget('./src/frontend/_includes/css/')
 
   return {
     dir: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,16 +57,31 @@ jobs:
       # `_redirects` ends in a forced catch-all (`/* /index.html 200!`), so an
       # asset the build didn't write is not a 404 — it is served the homepage's
       # HTML. That is how `/js/bundle.js` once came back as `<!doctype html>`.
-      # Nothing upstream fails when a passthrough copy silently stops copying,
-      # so absence and emptiness both have to be asserted here.
+      # Nothing upstream fails when an asset silently stops being written, so
+      # absence and emptiness both have to be asserted here.
+      #
+      # Both names carry a content hash now, so they are read back out of the
+      # page that references them rather than written down. That checks the
+      # join as well as the files: a bundle emitted under a name `index.html`
+      # does not point at is exactly as broken as one never emitted at all, and
+      # writing the names here again would be a third place for them to drift.
       - name: The shipped assets must exist and be non-empty
         run: |
-          for asset in dist/js/bundle.js dist/css/main.css; do
-            if [ ! -s "$asset" ]; then
-              echo "$asset is missing or empty — every url that asks for it" \
-                   "will be served the homepage's HTML instead"
+          # Anchored on the opening quote so this matches a root-relative url
+          # and not the `/css/` inside a CDN one — Font Awesome's is
+          # `…/font-awesome/6.7.2/css/all.min.css`, which is not ours to check.
+          urls=$(grep -o '"/\(js\|css\)/[^"]*"' dist/index.html | tr -d '"' | sort -u)
+          if [ -z "$urls" ]; then
+            echo "index.html references no local js or css at all"
+            exit 1
+          fi
+          for url in $urls; do
+            if [ ! -s "dist$url" ]; then
+              echo "index.html references $url, which the build did not write" \
+                   "— every url that asks for it is served the homepage's HTML"
               exit 1
             fi
+            echo "ok: dist$url"
           done
 
       # Today `npm run build` is what actually goes red on a bundle that will
@@ -76,4 +91,6 @@ jobs:
       # returning its input — which is what it did before #135, and what let
       # `3c3fab0` ship. It is the cheap half of the pair, not the redundant one.
       - name: The bundle must parse
-        run: node --check dist/js/bundle.js
+        run: |
+          bundle=$(grep -o '/js/bundle\.[0-9a-f]*\.js' dist/index.html | head -1)
+          node --check "dist$bundle"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,51 @@
   # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
   NODE_VERSION = "22"
 
+# Both of these urls carry a digest of their own contents in the filename —
+# `/js/bundle.<hash>.js` and `/css/main.<hash>.css`, built in
+# `src/frontend/_data/assets.js`. That is the precondition for `immutable`, and
+# it is not optional: the promise being made here is that the bytes at a given
+# url will never change, and a browser that believes it will not ask again for
+# a year. On an unhashed name that promise is a lie and the site is stuck.
+#
+# Without these, Netlify's default for a file with no rule is `public,
+# max-age=0, must-revalidate`, so every navigation on a client-side-routed site
+# spent a conditional request on each of the two before it could draw. They came
+# back `304` with no body, so it was two round trips rather than two payloads —
+# and still two round trips.
+#
+# The HTML that names these urls keeps that default and should: it is what
+# tells a browser the hash has changed.
+#
+# These rules are not verified, and on a deploy preview they cannot be. A
+# preview answers every url — html, bundle, stylesheet alike — with
+# `public,max-age=0,must-revalidate` and carries no custom header at all, not
+# even one written for a single exact path. So whether these take effect is a
+# thing to check against production once this is merged, with `curl -sI` on
+# either url.
+#
+# If they turn out not to have, the first thing to suspect is the forced
+# catch-all in `_redirects`. Netlify does not apply a custom header to a
+# response it produced by rewriting, and a forced rule (`200!`) rewrites a url
+# even when it exists as a file — which would make every rule here inert. The
+# known next thing to try is unforcing the catch-all and dropping the `/img/*`,
+# `/js/*` and `/css/*` self-rules that exist only to escape it. That is not
+# done here because there is no way to confirm from a preview that it helps,
+# and it changes how every url on the site is routed.
+#
+# Either way the hashed filenames stand on their own: `immutable` on a name
+# that is a digest of its own contents is safe if it applies and inert if it
+# does not.
+[[headers]]
+  for = "/js/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/css/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
 [functions]
   directory = "src/api/routes"
 

--- a/src/frontend/_data/assets.js
+++ b/src/frontend/_data/assets.js
@@ -1,0 +1,76 @@
+/**
+ * @file The bundle and the stylesheet, as global data every template can read.
+ *
+ * This exists to solve an ordering problem. The filename of the bundle has to
+ * carry a digest of the bundle's contents, and `layouts/base.njk` has to know
+ * that filename — but `base.njk` renders before `js/bundle.njk` is written, so
+ * it cannot wait for the file to exist and ask. Eleventy builds global data
+ * before it renders anything, so doing the concatenation *here* puts the
+ * contents and the name in hand before either template runs. `bundle.njk`
+ * emits `assets.js.code` at `assets.js.url` and `base.njk` loads
+ * `assets.js.url`, and neither of them computes anything.
+ *
+ * The concatenation moved here from Nunjucks `{% include %}`s in `bundle.njk`
+ * for the same reason: the digest has to be of the bytes that are actually
+ * served, so whatever assembles those bytes has to be the thing that hashes
+ * them. Reading the files with `fs` rather than including them as templates
+ * also takes away an old trap — Nunjucks used to parse each of these .js files
+ * looking for `{{`, `{%` and `{#`, and a JSDoc brace pair once swallowed a
+ * file and blanked the whole site.
+ */
+const fs = require("node:fs");
+const path = require("node:path");
+const UglifyJS = require("uglify-js");
+
+const plan = require("../_includes/js/asset_plan");
+
+const INCLUDES = path.join(__dirname, "..", "_includes");
+
+const read = (relativePath) =>
+  fs.readFileSync(path.join(INCLUDES, relativePath), "utf8");
+
+// Set by both npm scripts. Anything else — a bare `eleventy`, a CI job, a
+// Netlify build — is treated as production, so the fallback is the safe one.
+const isDev = process.env.ELEVENTY_ENV === "dev";
+
+const minify = (code) => {
+  // Compressing and mangling 140KB is the slowest thing in the build — 300ms
+  // of a 900ms run — and it buys a watch loop nothing. Parsing is the part
+  // worth keeping in dev: it costs 40ms and it is what the check below reads.
+  //
+  // The digest is taken over whichever of the two came out, so a dev bundle
+  // and a production one have different names. That is correct rather than
+  // unfortunate: they are different bytes.
+  const minified = isDev
+    ? UglifyJS.minify(code, {
+        compress: false,
+        mangle: false,
+        output: { beautify: true },
+      })
+    : UglifyJS.minify(code);
+
+  // Handing back the unminified input on failure is how a bundle that does not
+  // parse gets shipped anyway. Every page on this site is drawn by that one
+  // file, so a syntax error in it is a blank page on every url, with nothing in
+  // the build log above it. Fail the build instead.
+  if (minified.error) {
+    throw new Error(`assets: UglifyJS could not parse the bundle: ${minified.error}`);
+  }
+
+  return minified.code;
+};
+
+/**
+ * A function rather than an object, so the files are re-read on every build.
+ * Node caches this module, so a `--serve` rebuild would otherwise keep serving
+ * whatever the first build happened to read.
+ */
+module.exports = () => {
+  const bundle = minify(plan.concatenate(plan.BUNDLED_FILES.map(read)));
+  const stylesheet = read(plan.STYLESHEET);
+
+  return {
+    js: { url: plan.bundleUrl(plan.digest(bundle)), code: bundle },
+    css: { url: plan.stylesheetUrl(plan.digest(stylesheet)), code: stylesheet },
+  };
+};

--- a/src/frontend/_includes/js/asset_plan.js
+++ b/src/frontend/_includes/js/asset_plan.js
@@ -1,0 +1,103 @@
+/**
+ * @file What the two hashed assets are made of and what they are called. No
+ * dependencies and no I/O, so the tests can hold this without an install —
+ * `_data/assets.js` does the reading and the minifying and calls in here.
+ *
+ * Nothing else should build one of these urls. The filename carries a digest
+ * of the bytes served at it, which is the whole reason `netlify.toml` may
+ * cache them `immutable`: a second place computing the name is a second place
+ * for it to disagree, and a name that disagrees with its contents is a year
+ * of browsers holding the wrong file.
+ */
+const crypto = require("node:crypto");
+
+/**
+ * The frontend's files, in the order they are concatenated.
+ *
+ * The order is load-bearing — a file may use globals set by the files above it
+ * and not by the ones below. `js/components/index.js` is the sharp edge of it:
+ * it creates the `Components` object that every component below assigns into.
+ */
+const BUNDLED_FILES = [
+  "js/old_main.js",
+  "js/packages/neverthrow.js",
+  "js/utils/general.js",
+  "js/utils/nullable.js",
+  "js/utils/conversions.js",
+  "js/utils/http.js",
+  "js/utils/netlify.js",
+  "js/utils/diff.js",
+  "js/utils/entry_form_io.js",
+  "js/utils/review_template.js",
+  "js/utils/columns.js",
+  "js/utils/tables.js",
+  "js/components/index.js",
+  "js/components/common.js",
+  "js/components/with_remote_data.js",
+  "js/components/ui/button.js",
+  "js/components/ui/menu.js",
+  "js/components/ui/input_with_action.js",
+  "js/components/ui/notification.js",
+  "js/components/ui/base.js",
+  "js/components/ui/modal.js",
+  "js/components/ui/tabbed.js",
+  "js/components/home/username_setter.js",
+  "js/components/profile/profile_lists.js",
+  "js/components/profile/profile_stats.js",
+  "js/components/profile/biography.js",
+  "js/components/profile/index.js",
+  "js/components/home/index.js",
+  "js/components/list/add_edit_entry/buttons.js",
+  "js/components/list/add_edit_entry/external_fields.js",
+  "js/components/list/add_edit_entry/personal_fields.js",
+  "js/components/list/add_edit_entry/cover_column.js",
+  "js/components/list/add_edit_entry/draft.js",
+  "js/components/list/add_edit_entry/history.js",
+  "js/components/list/add_edit_entry/entry_form.js",
+  "js/components/list/add_edit_entry/search_results.js",
+  "js/components/list/add_edit_entry/add_entry_link.js",
+  "js/components/list/list.js",
+  "js/components/list/index.js",
+  "js/components/router.js",
+];
+
+/** The stylesheet, named relative to `_includes` the way the scripts are. */
+const STYLESHEET = "css/main.css";
+
+/**
+ * Each file gets its own scope. Concatenated they share one global scope, so
+ * a top-level `const` in one would otherwise collide with the same name in
+ * another.
+ */
+const wrapInIife = (source) => `(() => {\n${source}\n})();\n`;
+
+const concatenate = (sources) => sources.map(wrapInIife).join("");
+
+/**
+ * Ten hex characters of SHA-256 over the bytes that get served. Long enough
+ * that two different bundles will not land on the same name, short enough to
+ * read in a network panel.
+ */
+const digest = (contents) =>
+  crypto.createHash("sha256").update(contents, "utf8").digest("hex").slice(0, 10);
+
+/**
+ * Both urls keep the `/js/` and `/css/` prefixes, and they have to: the
+ * catch-all in `_redirects` is forced, so a url is only served as itself if a
+ * forced rule matches it, and those rules are written as `/js/*` and `/css/*`.
+ * A hashed name that moved out of those directories would be answered with the
+ * homepage's HTML.
+ */
+const bundleUrl = (hash) => `/js/bundle.${hash}.js`;
+
+const stylesheetUrl = (hash) => `/css/main.${hash}.css`;
+
+module.exports = {
+  BUNDLED_FILES,
+  STYLESHEET,
+  wrapInIife,
+  concatenate,
+  digest,
+  bundleUrl,
+  stylesheetUrl,
+};

--- a/src/frontend/_includes/js/asset_plan.js
+++ b/src/frontend/_includes/js/asset_plan.js
@@ -59,6 +59,7 @@ const BUNDLED_FILES = [
   "js/components/list/list.js",
   "js/components/list/index.js",
   "js/components/router.js",
+  "js/boot.js",
 ];
 
 /** The stylesheet, named relative to `_includes` the way the scripts are. */

--- a/src/frontend/_includes/js/boot.js
+++ b/src/frontend/_includes/js/boot.js
@@ -1,0 +1,16 @@
+/**
+ * @file Draws the page. This is the last file in the bundle, and it has to be:
+ * it reaches for `Components.Router`, which every file above it builds up.
+ *
+ * It used to be an inline <script> at the end of <body>, and that is what kept
+ * `<script src="/js/bundle.js">` in <head> from carrying `defer` — a deferred
+ * script runs after the parser is done, which is to say after an inline one, so
+ * `Components` was not there yet when the inline block asked for it. Bundling
+ * these lines puts them back in order and lets the tag defer, which stops it
+ * blocking the parser on a page whose entire body is drawn by it.
+ */
+// The 0 timeout is necessary to detect netlify auth token
+window.setTimeout(async () => {
+  // Include the router
+  Components.setContent('#site', Components.Router())
+}, 0)

--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -1,136 +1,213 @@
 /**
- * @file The frontend bundle is built by Nunjucks `{% include %}`-ing every file
- * listed in `src/frontend/js/bundle.njk` into one file, each wrapped in its own
- * IIFE, emitted to `/js/bundle.js` and loaded by base.njk from that url. So
- * Nunjucks reads these .js files as templates, and anything that looks like a
- * Nunjucks delimiter is not JavaScript to it.
+ * @file The frontend bundle is built by `_data/assets.js`: it reads every file
+ * listed in `asset_plan.js`, wraps each in its own IIFE, minifies the result,
+ * and names it after a digest of the bytes that come out. `js/bundle.njk` emits
+ * those bytes at that url and `layouts/base.njk` loads the same url from the
+ * same object.
  *
- * When that happens nothing fails loudly: the include renders to nothing, the
- * IIFE around it loses its closing brace, and the whole 140KB bundle becomes
- * one syntax error. The build is green, the deploy is green, and every page on
- * the site is blank. A JSDoc `@typedef` with a brace pair cost us exactly that,
- * so the delimiters are worth a test — as is the bundle parsing at all, which
- * is the check that catches the next cause rather than that one.
+ * The digest is the thing to protect. `netlify.toml` serves `/js/*` and
+ * `/css/*` with `immutable` for a year, which is only true if a change to any
+ * bundled file changes the url — and only checkable if exactly one place
+ * decides what that url is. A second place computing the name would not fail
+ * loudly; it would fail a year from now in someone else's browser.
+ *
+ * The other failure mode here is older and blunter: a syntax error anywhere in
+ * the concatenation is one broken 140KB file, and every page on this site is
+ * drawn by that file, so the build is green, the deploy is green, and the whole
+ * site is blank.
  */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
+const plan = require("./asset_plan");
+
 const INCLUDES = path.join(__dirname, "..");
-const BUNDLE = path.join(INCLUDES, "..", "js", "bundle.njk");
+const FRONTEND = path.join(INCLUDES, "..");
+const BUNDLE = path.join(FRONTEND, "js", "bundle.njk");
+const STYLESHEET_TEMPLATE = path.join(FRONTEND, "css", "main.njk");
 const LAYOUT = path.join(INCLUDES, "layouts", "base.njk");
-const ROOT = path.join(INCLUDES, "..", "..", "..");
-const ELEVENTY = path.join(ROOT, ".eleventy.js");
+const ROOT = path.join(FRONTEND, "..", "..");
+const DATA = path.join(FRONTEND, "_data", "assets.js");
 const REDIRECTS = path.join(ROOT, "_redirects");
+const NETLIFY = path.join(ROOT, "netlify.toml");
 
 const read = (file) => fs.readFileSync(file, "utf8");
 
-/** The files bundle.njk inlines, in the order it inlines them. */
-const includedFiles = () =>
-  [...read(BUNDLE).matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)].map(
-    ([, includePath]) => includePath
-  );
-
-/** `{{ … }}` interpolates, `{% … %}` is a tag, `{# … #}` is a comment. */
-const DELIMITERS = [
-  ["{{", /\{\{/],
-  ["{%", /\{%/],
-  ["{#", /\{#/],
-];
-
-test("bundle.njk still inlines the frontend scripts", () => {
-  assert.ok(includedFiles().length > 0, "found no js() includes in bundle.njk");
+test("the bundle still lists the frontend scripts", () => {
+  assert.ok(plan.BUNDLED_FILES.length > 0, "asset_plan.js bundles nothing");
 });
 
-test("bundle.njk emits the bundle to a url, minified", () => {
+test("every file the bundle lists exists", () => {
+  plan.BUNDLED_FILES.forEach((includePath) =>
+    assert.ok(
+      fs.existsSync(path.join(INCLUDES, includePath)),
+      `asset_plan.js lists ${includePath}, which does not exist`
+    )
+  );
+  assert.ok(
+    fs.existsSync(path.join(INCLUDES, plan.STYLESHEET)),
+    `asset_plan.js names ${plan.STYLESHEET}, which does not exist`
+  );
+});
+
+test("bundle.njk emits the shared bytes at the shared url", () => {
   const source = read(BUNDLE);
 
+  // Both halves matter. A permalink that named a fixed url would be cached
+  // `immutable` under a name that never changes; a body that rebuilt the
+  // bundle some other way would be hashed under a name describing something
+  // else. `assets.js.url` and `assets.js.code` are the one object.
   assert.match(
     source,
-    /^---\r?\n(?:.*\r?\n)*?permalink:\s*\/js\/bundle\.js\s*\r?$/m,
-    "bundle.njk must emit to /js/bundle.js, which is the url base.njk loads"
+    /^---\r?\n(?:.*\r?\n)*?permalink:\s*["']?\{\{\s*assets\.js\.url\s*\}\}["']?\s*\r?$/m,
+    "bundle.njk must take its permalink from assets.js.url"
   );
   assert.match(
     source,
-    /\{\{\s*scripts\s*\|\s*jsmin\s*\|\s*safe\s*\}\}/,
-    "the bundle must go through the jsmin filter"
+    /\{\{-?\s*assets\.js\.code\s*\|\s*safe\s*-?\}\}/,
+    "bundle.njk must emit assets.js.code, the bytes that url was hashed from"
   );
 });
 
-test("bundle.njk still wraps each file in its own IIFE", () => {
-  // `const` at the top level of a file would otherwise collide with the same
-  // name in any other file — they share one global scope. The concatenation
-  // this file's parse test builds mirrors this macro, so it has to hold.
+test("main.njk emits the stylesheet at the shared url", () => {
+  const source = read(STYLESHEET_TEMPLATE);
+
   assert.match(
-    read(BUNDLE),
-    /\{%\s*macro js\(path\)\s*%\}\s*\(\(\)\s*=>\s*\{\s*\{%\s*include path\s*%\}\s*\}\)\(\);\s*\{%\s*endmacro\s*%\}/,
-    "the js() macro no longer wraps its include in an IIFE"
+    source,
+    /^---\r?\n(?:.*\r?\n)*?permalink:\s*["']?\{\{\s*assets\.css\.url\s*\}\}["']?\s*\r?$/m,
+    "css/main.njk must take its permalink from assets.css.url"
+  );
+  assert.match(
+    source,
+    /\{\{-?\s*assets\.css\.code\s*\|\s*safe\s*-?\}\}/,
+    "css/main.njk must emit assets.css.code"
   );
 });
 
-test("base.njk loads the bundle by url and inlines no frontend script", () => {
+test("base.njk loads both assets from the same data, and inlines neither", () => {
   const layout = read(LAYOUT);
 
   assert.match(
     layout,
-    /<script src="\/js\/bundle\.js"><\/script>/,
-    "base.njk must load /js/bundle.js"
+    /<script[^>]*\bsrc="\{\{\s*assets\.js\.url\s*\}\}"><\/script>/,
+    "base.njk must load the bundle from assets.js.url, not a url of its own"
   );
-  assert.equal(
-    [...layout.matchAll(/\{\{\s*js\("([^"]+)"\)\s*\}\}/g)].length,
-    0,
-    "base.njk inlines frontend files again; the list belongs in bundle.njk"
+  assert.match(
+    layout,
+    /<link rel="stylesheet" href="\{\{\s*assets\.css\.url\s*\}\}">/,
+    "base.njk must load the stylesheet from assets.css.url"
   );
-});
-
-test("the stylesheet is served from a url, not inlined", () => {
-  const layout = read(LAYOUT);
-
-  assert.match(layout, /<link rel="stylesheet" href="\/css\/main\.css">/);
   assert.doesNotMatch(
     layout,
-    /\{%\s*include\s+"css\/main\.css"\s*%\}/,
-    "base.njk inlines the stylesheet again"
-  );
-  assert.match(
-    read(ELEVENTY),
-    /addPassthroughCopy\(\{[^}]*'\.\/src\/frontend\/_includes\/css\/main\.css':\s*'css\/main\.css'/,
-    ".eleventy.js must copy main.css to /css/, or that <link> is a 404"
+    /\{%\s*include\s+"(?:js|css)\//,
+    "base.njk inlines frontend files again; the list belongs in asset_plan.js"
   );
 });
 
-test("the assets base.njk loads are exempt from the SPA catch-all", () => {
+test("only asset_plan.js decides what the assets are called", () => {
+  // A hardcoded `/js/bundle.js` or `/css/main.css` anywhere is either a 404 or,
+  // worse, a second name for a file whose name is supposed to be its digest.
+  [
+    ["base.njk", LAYOUT],
+    ["bundle.njk", BUNDLE],
+    ["css/main.njk", STYLESHEET_TEMPLATE],
+  ].forEach(([name, file]) =>
+    assert.doesNotMatch(
+      read(file),
+      /(?:href|src)="\/(?:js|css)\//,
+      `${name} names an asset url literally; it must come from the assets data`
+    )
+  );
+});
+
+test("a change to any bundled file changes the url", () => {
+  // The invariant `immutable` rests on, checked on the pure functions so it
+  // needs no install: same bytes, same name; different bytes, different name.
+  const one = plan.concatenate(["window.x = 1"]);
+  const other = plan.concatenate(["window.x = 2"]);
+
+  assert.notEqual(plan.digest(one), plan.digest(other));
+  assert.equal(plan.digest(one), plan.digest(plan.concatenate(["window.x = 1"])));
+
+  assert.notEqual(plan.bundleUrl(plan.digest(one)), plan.bundleUrl(plan.digest(other)));
+  assert.match(plan.bundleUrl(plan.digest(one)), new RegExp(plan.digest(one)));
+  assert.match(
+    plan.stylesheetUrl(plan.digest(one)),
+    new RegExp(plan.digest(one)),
+    "the stylesheet url must carry its digest too; /css/* is immutable as well"
+  );
+});
+
+test("assets.js re-reads on every build", () => {
+  // Node caches the module, so an object export would freeze the bundle at
+  // whatever the first build of a `--serve` process read off disk, and editing
+  // a component would stop changing the page.
+  //
+  // Read rather than required: `_data/assets.js` pulls in uglify-js, and this
+  // suite runs with no install.
+  assert.match(
+    read(DATA),
+    /module\.exports\s*=\s*\(\s*\)\s*=>/,
+    "_data/assets.js must export a function, or `--serve` serves a stale bundle"
+  );
+});
+
+test("the hashed assets are exempt from the SPA catch-all", () => {
   // `/*  /index.html  200!` is forced, so it rewrites urls that exist as files
   // too. An asset is only served as itself if it has a forced rule of its own,
-  // the way `/img/*` does. Without one, `/js/bundle.js` answers with the
-  // homepage's HTML and the site is blank with `Unexpected token '<'`.
+  // the way `/img/*` does. Without one, the bundle answers with the homepage's
+  // HTML and the site is blank with `Unexpected token '<'`. The hashed names
+  // have to keep matching those rules, which is why they keep their directory.
   const exempt = [
     ...read(REDIRECTS).matchAll(/^(\/\S*?)\/\*\s+\S+\s+200!/gm),
   ].map(([, prefix]) => prefix + "/");
 
+  const hash = plan.digest("sample");
   const assets = [
-    ...read(LAYOUT).matchAll(/<(?:link|script)\b[^>]*?\b(?:href|src)="(\/[^"]*)"/g),
-  ].map(([, url]) => url);
+    plan.bundleUrl(hash),
+    plan.stylesheetUrl(hash),
+    // Only <link> and <script> load assets. The <noscript> block links
+    // `/films/nil` and `/api/export/films/nil`, which are a page and a
+    // function — both of them are supposed to reach the catch-all.
+    ...[
+      ...read(LAYOUT).matchAll(/<(?:link|script)\b[^>]*?\b(?:href|src)="(\/[^"{]*)"/g),
+    ].map(([, url]) => url),
+  ];
 
-  assert.ok(assets.length > 0, "found no local assets in base.njk");
+  assert.ok(assets.length > 2, "found no local assets in base.njk");
 
   assets.forEach((url) =>
     assert.ok(
       exempt.some((prefix) => url.startsWith(prefix)),
-      `base.njk loads ${url}, which no forced rule in _redirects exempts, so ` +
-        `the catch-all answers it with index.html`
+      `${url} is served by no forced rule in _redirects, so the catch-all ` +
+        `answers it with index.html`
     )
   );
 });
 
-test("every file the bundle lists exists", () => {
-  includedFiles().forEach((includePath) =>
-    assert.ok(
-      fs.existsSync(path.join(INCLUDES, includePath)),
-      `bundle.njk lists ${includePath}, which does not exist`
-    )
-  );
+test("the immutable headers cover the directories the assets are emitted to", () => {
+  // `immutable` on a url whose contents can change under it is the one way
+  // this gets worse rather than better, so the rule and the hashed name are
+  // checked against each other rather than each being trusted on its own.
+  const netlify = read(NETLIFY);
+  const hash = plan.digest("sample");
+
+  [plan.bundleUrl(hash), plan.stylesheetUrl(hash)].forEach((url) => {
+    const directory = url.slice(0, url.indexOf("/", 1) + 1);
+    const rule = new RegExp(
+      `\\[\\[headers\\]\\]\\s*for\\s*=\\s*"${directory}\\*"\\s*` +
+        `\\[headers\\.values\\]\\s*Cache-Control\\s*=\\s*"[^"]*immutable"`
+    );
+
+    assert.match(
+      netlify.replace(/#.*$/gm, ""),
+      rule,
+      `netlify.toml has no immutable Cache-Control for ${directory}*, which is ` +
+        `where ${url} is served from`
+    );
+  });
 });
 
 test("components/index.js comes before the files that populate it", () => {
@@ -138,7 +215,7 @@ test("components/index.js comes before the files that populate it", () => {
   // / `.Home` / `.Profile` / `.List` objects every other component assigns
   // into. Order is load-bearing across the whole list; this is the edge of it
   // that turns into a TypeError on a blank page rather than something subtle.
-  const files = includedFiles();
+  const files = plan.BUNDLED_FILES;
   const root = files.indexOf("js/components/index.js");
 
   assert.notEqual(root, -1, "js/components/index.js is no longer bundled");
@@ -153,32 +230,14 @@ test("components/index.js comes before the files that populate it", () => {
   });
 });
 
-includedFiles().forEach((includePath) => {
-  test(`${includePath} holds no Nunjucks delimiter`, () => {
-    const lines = read(path.join(INCLUDES, includePath)).split("\n");
-
-    lines.forEach((line, i) => {
-      DELIMITERS.forEach(([delimiter, pattern]) =>
-        assert.ok(
-          !pattern.test(line),
-          `${includePath}:${i + 1} contains ${delimiter}, which Nunjucks ` +
-            `reads as a template delimiter and swallows:\n  ${line.trim()}`
-        )
-      );
-    });
-  });
-});
-
 test("the concatenated bundle parses as JavaScript", () => {
-  // Mirrors the js() macro in bundle.njk, which the test above pins. `new
-  // Function` compiles the body without running it, so this is a syntax check
-  // and nothing more — but a syntax error here is the whole site, blank.
-  const bundle = includedFiles()
-    .map((includePath) => {
-      const source = read(path.join(INCLUDES, includePath));
-      return `(() => {\n${source}\n})();\n`;
-    })
-    .join("");
+  // Exactly what `_data/assets.js` hands to UglifyJS, built by the same pure
+  // function. `new Function` compiles the body without running it, so this is a
+  // syntax check and nothing more — but a syntax error here is the whole site,
+  // blank.
+  const bundle = plan.concatenate(
+    plan.BUNDLED_FILES.map((includePath) => read(path.join(INCLUDES, includePath)))
+  );
 
   assert.doesNotThrow(
     () => new Function(bundle),

--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -106,6 +106,39 @@ test("base.njk loads both assets from the same data, and inlines neither", () =>
   );
 });
 
+test("the bundle defers, and nothing inline races it", () => {
+  // These two go together. `defer` stops the bundle blocking the parser, but a
+  // deferred script runs after every inline one, so any inline block that
+  // reaches for `Components` would find nothing there — which is the state
+  // this replaced. The drawing code lives in `js/boot.js` at the end of the
+  // bundle now, and <body> has no script of its own to get ahead of it.
+  const layout = read(LAYOUT);
+
+  assert.match(
+    layout,
+    /<script\s+defer\s+src="\{\{\s*assets\.js\.url\s*\}\}"><\/script>/,
+    "the bundle must be deferred; it draws the page and blocks the parser"
+  );
+
+  const inline = [...layout.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)]
+    .map(([, body]) => body.trim())
+    .filter(Boolean);
+
+  assert.deepEqual(
+    inline,
+    [],
+    "base.njk has an inline script again; it runs before the deferred bundle, " +
+      "so anything it reaches for in `Components` is not there yet"
+  );
+
+  assert.equal(
+    plan.BUNDLED_FILES[plan.BUNDLED_FILES.length - 1],
+    "js/boot.js",
+    "js/boot.js draws the page with what every file above it defines, so it " +
+      "has to be bundled last"
+  );
+});
+
 test("only asset_plan.js decides what the assets are called", () => {
   // A hardcoded `/js/bundle.js` or `/css/main.css` anywhere is either a 404 or,
   // worse, a second name for a file whose name is supposed to be its digest.

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -25,12 +25,14 @@
     {# 1.12.1, matching the bootstrap-table script below. #}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.12.1/bootstrap-table.min.css" integrity="sha384-HyusOcKCYSnjwC8jY4YvjZAwLgeqDPWFDu2/AFf5OrZd7ykufk0gwxexoqmg5W8N" crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
-    {# `_includes/css/main.css`, copied to this url by the `addPassthroughCopy`
-       in `.eleventy.js`. #126 dropped a <link> at this url because nothing
-       emitted the file and every page load spent a request on a 404; the
-       passthrough is the other half of that, so the <link> comes back and the
-       stylesheet stops being re-sent inline with every HTML response. #}
-    <link rel="stylesheet" href="/css/main.css">
+    {# `_includes/css/main.css`, emitted at this url by `css/main.njk`. #126
+       dropped a <link> here because nothing emitted the file and every page
+       load spent a request on a 404; emitting it is the other half of that, so
+       the <link> comes back and the stylesheet stops being re-sent inline with
+       every HTML response. The name carries a digest of the file, which is
+       what lets `netlify.toml` cache `/css/*` for a year: change the CSS and
+       this url changes with it. #}
+    <link rel="stylesheet" href="{{ assets.css.url }}">
 
     {# The page cannot draw until every script below has been fetched and run,
        so anything not needed to draw it carries `defer` and gets out of the
@@ -53,13 +55,19 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js" integrity="sha384-pF+2qz7eFoUyrCTPr8gVboYJ7fNpmJKJzl0vPX6w3XDML+Of8bMSyd6fZIRJdwo7" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     {# The frontend's own forty files, concatenated and minified into one file
-       by `js/bundle.njk` — which is where the list and, more to the point, the
-       order live. Inlining them here meant re-sending 140 KB with every HTML
-       response; as a url the browser fetches it once and revalidates it after
-       that. No `defer`: the block at the end of <body> reaches for
-       `Components`, and the CDN scripts above are what the bundle itself
-       reaches for while it runs. #}
-    <script src="/js/bundle.js"></script>
+       by `_data/assets.js` — which is where the list and, more to the point,
+       the order live. Inlining them here meant re-sending 140 KB with every
+       HTML response.
+
+       The url carries a digest of those bytes, so it changes exactly when they
+       do. That is what `netlify.toml` is relying on when it serves `/js/*`
+       with `immutable` for a year: the browser never has to ask whether this
+       file is still current, because a new bundle arrives under a new name.
+
+       No `defer`: the block at the end of <body> reaches for `Components`, and
+       an inline script runs before a deferred one. The CDN scripts above are
+       what the bundle itself reaches for while it runs. #}
+    <script src="{{ assets.js.url }}"></script>
   </head>
   <body>
     {#

--- a/src/frontend/_includes/layouts/base.njk
+++ b/src/frontend/_includes/layouts/base.njk
@@ -64,10 +64,18 @@
        with `immutable` for a year: the browser never has to ask whether this
        file is still current, because a new bundle arrives under a new name.
 
-       No `defer`: the block at the end of <body> reaches for `Components`, and
-       an inline script runs before a deferred one. The CDN scripts above are
-       what the bundle itself reaches for while it runs. #}
-    <script src="{{ assets.js.url }}"></script>
+       `defer`, so fetching it does not block the parser — which matters on a
+       page whose entire body is drawn by it. What used to prevent that was an
+       inline block at the end of <body> reaching for `Components`: an inline
+       script runs before a deferred one, so the bundle was not there yet. That
+       block is now `js/boot.js`, the last file in the bundle, which puts it
+       back after everything it depends on.
+
+       The CDN scripts above are what the bundle reaches for while it runs.
+       They stay ahead of it either way: the ones without `defer` run as the
+       parser reaches them, and the two with it are earlier in the document, so
+       they run first. #}
+    <script defer src="{{ assets.js.url }}"></script>
   </head>
   <body>
     {#
@@ -95,13 +103,6 @@
       </p>
     </noscript>
     <div id="site"></div>
-    <script>
-      // The 0 timeout is necessary to detect netlify auth token
-      window.setTimeout(async () => {
-        // Include the router
-        Components.setContent('#site', Components.Router())
-      }, 0)
-    </script>
   </body>
 </html>
 

--- a/src/frontend/css/main.njk
+++ b/src/frontend/css/main.njk
@@ -1,0 +1,14 @@
+---
+permalink: "{{ assets.css.url }}"
+eleventyExcludeFromCollections: true
+---
+{#- The stylesheet, emitted under a name that carries a digest of it.
+
+   This was an `addPassthroughCopy` in `.eleventy.js` until the cache headers in
+   `netlify.toml` went `immutable`, which is only honest if the name changes
+   when the bytes do. A passthrough copy keeps the source's name, so it had to
+   become a template that emits `_includes/css/main.css` at a hashed url.
+
+   As in `js/bundle.njk`, the trimmed delimiters and the missing final newline
+   keep the output byte-for-byte the file that was hashed. -#}
+{{- assets.css.code | safe -}}

--- a/src/frontend/js/bundle.njk
+++ b/src/frontend/js/bundle.njk
@@ -1,69 +1,21 @@
 ---
-permalink: /js/bundle.js
+permalink: "{{ assets.js.url }}"
 eleventyExcludeFromCollections: true
 ---
-{# The frontend, concatenated and minified into one file the browser can keep.
+{#- The frontend, concatenated and minified into one file the browser can keep.
 
-   This block used to sit inline in `layouts/base.njk`, so every HTML response
-   carried all 140 KB of it and no browser could ever reuse a copy. The site is
-   a client-side router, so `/`, `/profile/nil`, `/films/nil` and `/games/nil`
-   are one page answered four times — four copies of the same bytes for one
-   visitor. As a url it is fetched once and revalidated by ETag after that.
+   This used to sit inline in `layouts/base.njk`, so every HTML response carried
+   all 140 KB of it and no browser could ever reuse a copy. The site is a
+   client-side router, so `/`, `/profile/nil`, `/films/nil` and `/games/nil` are
+   one page answered four times — four copies of the same bytes for one visitor.
 
-   `base.njk` loads the result with `<script src="/js/bundle.js">`. #}
+   The list of files, the concatenation and the digest all live in
+   `_data/assets.js`, because the name of this file has to be derived from its
+   contents and `base.njk` has to know that name before this file is written.
+   Both templates read the one `assets` object; neither works anything out.
 
-{# macro to include JS with its own const variable scope
-   to not have `const` assignments pollute projectwide scope #}
-{% macro js(path) %}
-  (() => {
-    {% include path %}
-  })();
-{% endmacro %}
-
-{# Include *all* your JS files here.
-  The order matters, files above can't use
-  global variables set in files under.
-#}
-{% set scripts %}
-  {{ js("js/old_main.js") }}
-  {{ js("js/packages/neverthrow.js") }}
-  {{ js("js/utils/general.js") }}
-  {{ js("js/utils/nullable.js") }}
-  {{ js("js/utils/conversions.js") }}
-  {{ js("js/utils/http.js") }}
-  {{ js("js/utils/netlify.js") }}
-  {{ js("js/utils/diff.js") }}
-  {{ js("js/utils/entry_form_io.js") }}
-  {{ js("js/utils/review_template.js") }}
-  {{ js("js/utils/columns.js") }}
-  {{ js("js/utils/tables.js") }}
-  {{ js("js/components/index.js") }}
-  {{ js("js/components/common.js") }}
-  {{ js("js/components/with_remote_data.js") }}
-  {{ js("js/components/ui/button.js") }}
-  {{ js("js/components/ui/menu.js") }}
-  {{ js("js/components/ui/input_with_action.js") }}
-  {{ js("js/components/ui/notification.js") }}
-  {{ js("js/components/ui/base.js") }}
-  {{ js("js/components/ui/modal.js") }}
-  {{ js("js/components/ui/tabbed.js") }}
-  {{ js("js/components/home/username_setter.js") }}
-  {{ js("js/components/profile/profile_lists.js") }}
-  {{ js("js/components/profile/profile_stats.js") }}
-  {{ js("js/components/profile/biography.js") }}
-  {{ js("js/components/profile/index.js") }}
-  {{ js("js/components/home/index.js") }}
-  {{ js("js/components/list/add_edit_entry/buttons.js") }}
-  {{ js("js/components/list/add_edit_entry/external_fields.js") }}
-  {{ js("js/components/list/add_edit_entry/personal_fields.js") }}
-  {{ js("js/components/list/add_edit_entry/cover_column.js") }}
-  {{ js("js/components/list/add_edit_entry/draft.js") }}
-  {{ js("js/components/list/add_edit_entry/history.js") }}
-  {{ js("js/components/list/add_edit_entry/entry_form.js") }}
-  {{ js("js/components/list/add_edit_entry/search_results.js") }}
-  {{ js("js/components/list/add_edit_entry/add_entry_link.js") }}
-  {{ js("js/components/list/list.js") }}
-  {{ js("js/components/list/index.js") }}
-  {{ js("js/components/router.js") }}
-{% endset %}
-{{ scripts | jsmin | safe }}
+   The `-` on every delimiter here, and the missing newline at the end of this
+   file, are what make the output exactly `assets.js.code` and nothing else — so
+   the digest in the filename is a digest of the file as served, and `curl`ing
+   it and hashing it agrees with its name. -#}
+{{- assets.js.code | safe -}}


### PR DESCRIPTION
Closes #142.

#135 got the 140 KB out of the HTML, which was the win. This finishes the naming half: `/js/bundle.js` and `/css/main.css` were fixed names, so a browser had no way to know that today's bundle was not yesterday's, and `netlify.toml` declared no `[[headers]]` at all. Netlify's default of `public, max-age=0, must-revalidate` meant every navigation on a client-side-routed site spent a conditional request on each of them before it could draw — `304` with no body, so two round trips rather than two payloads, and still two round trips.

Both assets now carry a digest of their own contents in the filename, and `/js/*` and `/css/*` are declared `public, max-age=31536000, immutable`. The hash comes first and the headers follow from it: `immutable` on a fixed name is a promise the build cannot keep.

## Read this part before merging

**The header rules are not verified, and from a deploy preview they cannot be.** A preview answers every url — HTML, bundle, stylesheet alike — with `max-age=0, must-revalidate`, and carries no custom header at all. I checked that directly: a probe header declared for `/*`, and a second declared for the bundle's exact path, appeared on nothing, on a deploy confirmed live for that exact commit. So the preview tells us nothing either way, and someone should `curl -sI` both urls on production once this merges.

If they turn out not to have taken effect, the first thing to suspect is the forced catch-all in `_redirects`. Netlify does not apply a custom header to a response it produced by rewriting, and a forced rule (`200!`) rewrites a url even when it exists as a file — which would make every rule here inert. The known next step is unforcing the catch-all and dropping the `/img/*`, `/js/*` and `/css/*` self-rules that exist only to escape it.

I had that change written and pushed, and took it back out: I could not confirm from a preview that it helps, and it changes how every url on the site is routed. That is not a thing to merge on a hypothesis. `netlify.toml` carries this whole note as a comment so it is in the repo rather than only here, and `_redirects` is untouched by this PR.

The hashed names are worth having regardless. `immutable` on a name that is a digest of its own contents is correct if it applies and inert if it does not — unlike `immutable` on a fixed name, which is the one version of this that would be actively wrong.

## Where the hash is computed, and why there

The ordering problem is that the digest depends on the concatenated, minified output, and `base.njk` needs the filename before that file has been written. I took the global-data route: `src/frontend/_data/assets.js` does the concatenation, the minification and the digest itself, and Eleventy builds global data before it renders anything. `js/bundle.njk` then emits `assets.js.code` at `assets.js.url`, and `base.njk` loads `assets.js.url`. Neither template works a url out for itself.

The alternative — leaving the Nunjucks `{% include %}`s in `bundle.njk` and having a data file hash the same list separately — is the bug the issue warns about. It would be two independent computations that have to agree, and the one that produced the served bytes would not be the one that produced the name.

Two consequences worth a look. Minification moved out of the `jsmin` filter in `.eleventy.js` and into the data file, since the digest has to be taken after it; the filter is gone, and the dev-versus-production split #151 added moved across with it. And reading the sources with `fs` rather than as Nunjucks templates retires an old trap — Nunjucks used to parse each of these `.js` files looking for `{{`, `{%` and `{#`, and a JSDoc brace pair once swallowed a file and left the site blank. Interpolated data is not re-parsed, so the per-file delimiter tests went with it; the test that compiles the whole concatenation still guards the blank-site failure.

The stylesheet could not stay an `addPassthroughCopy`, because a passthrough keeps the source's name. It is now `src/frontend/css/main.njk`, emitting the same bytes at a hashed url. `_includes/css/main.css` is untouched as the source.

Both templates use `{{-` / `-}}` and end without a newline, so the emitted file is byte-for-byte what was hashed — `curl`ing either asset and hashing it agrees with its own filename.

## CI and `_redirects`

The build job #150 added asserted on `dist/js/bundle.js` and `dist/css/main.css` by name, and neither exists now, so **it would have gone red**. It reads both urls out of `dist/index.html` instead, which checks the join as well as the files: a bundle emitted under a name the page does not point at is as broken as one never emitted. Anchoring that grep on the opening quote matters — unanchored it also matches the `/css/` inside Font Awesome's CDN url.

`_redirects` is unchanged. The forced `/js/*` and `/css/*` rules still match the hashed names, since those keep their directories, and a test pins it.

## The `defer` commit

Second commit, separate. The five inline lines at the end of `<body>` became `js/boot.js`, bundled last, after the `router.js` that defines the `Components.Router` they call. With nothing inline left to run ahead of it, the tag became `<script defer>`, so fetching 73 KB no longer blocks the parser on a page whose entire body is drawn by that file. The CDN scripts it depends on still run first either way.

## Verification

Built and tested on a local-disk copy, per the npm-and-Drive note in `CLAUDE.md`, on the rebased tree.

- The emitted names carry the hash, `dist/index.html` points at exactly those files, and each file's SHA-256 prefix equals the hash in its own filename.
- A real change to `components/router.js` moves the bundle name and the HTML follows it; reverting restores the old name, since this is a digest and not a counter. A comment-only change does not move it, which is correct — UglifyJS strips comments, so the bytes are identical.
- The two hashes are independent: a JS change leaves the stylesheet name alone and vice versa.
- The minified JS is byte-identical to what the pre-rebase `main` built, apart from seven leading blank lines the old template emitted and this one does not.
- `npm test`: 326 pass, 0 fail with dependencies; 287 pass, 0 fail, 39 self-skipped with **no install**. Every tracked `.js` passes `node --check`.
- Both new CI steps were run against real build output, including negative cases: renaming the bundle and breaking its syntax each fail the step they should.
- Each new assertion was checked by breaking what it guards.
- Served the built `dist` and loaded it in a browser: the page draws client-side with no console errors, which is the deferred bundle running `boot.js`.
- On the deploy preview, routing is intact — `/`, `/profile/nil`, `/films/nil`, `/games/nil` all serve the app, and `/api/export/films/nil` still answers.

Under a long-running `eleventy --watch`, superseded hashed files accumulate in `dist`. The HTML always names one that exists and Netlify builds into a fresh `dist` per deploy, so it is local clutter only.
