### PR TITLE
chore(ci): install and build, so the bundle is checked before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,46 @@ jobs:
       # the Netlify functions and the frontend globals.
       - name: Syntax check every JS file
         run: git ls-files '*.js' | xargs -n1 node --check
+
+  # The `test` job above is deliberately install-free, which leaves the build
+  # unexercised: nothing in CI has ever run `.eleventy.js`, Nunjucks, UglifyJS
+  # or the passthrough copies. That matters since #135, because the build now
+  # produces the one file every page on the site depends on, and a bundle
+  # UglifyJS cannot parse blanks every url. It used to be found on Netlify,
+  # after merge.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # Matches NODE_VERSION in netlify.toml, so a build that passes here
+          # is the build Netlify runs.
+          node-version: 22
+          cache: npm
+
+      # `ci` and not `install`: it fails outright when package.json and
+      # package-lock.json disagree, which is otherwise invisible until deploy.
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # A green build is not the same as a usable site. Eleventy reports
+      # success for a passthrough copy that quietly matched nothing, so name
+      # the files the site actually asks for.
+      - name: Check the build emitted what the site loads
+        run: |
+          for file in index.html js/bundle.js css/main.css _redirects \
+                      img/favicon.ico img/favicon.png img/memo_logo.png \
+                      img/mawaru.png; do
+            test -s "dist/$file" || { echo "missing or empty: dist/$file"; exit 1; }
+          done
+
+      # The failure `bundle.test.js` is a proxy for. That test reconstructs the
+      # concatenation from the templates as text; this is the real output of
+      # the real minifier.
+      - name: Check the bundle parses
+        run: node --check dist/js/bundle.js


### PR DESCRIPTION
Fixes #140. Based on #158 — review that one first; this branch carries its commit.

CI ran the unit suite and `node --check` over every tracked file and nothing else. Neither touches `.eleventy.js`, Nunjucks, UglifyJS or the passthrough copies, so the build only ever ran on Netlify, after merge. Since #135 that is the one file every page on the site loads: a syntax change UglifyJS cannot handle passes CI green and blanks every url, which is the failure `3c3fab0` had to restore the site from.

This adds a second job rather than steps to the existing one. The install-free property of the `test` job is deliberate — it is what says the unit-tested modules are dependency-free — and worth keeping; two jobs also say which of the two broke.

- `npm ci`, not `npm install`, so a `package-lock.json` out of step with `package.json` fails here rather than at deploy.
- `node-version: 22` with `cache: npm`, matching `NODE_VERSION` in `netlify.toml`, so a build that passes here is the build Netlify runs.
- `npm run build`.
- An assertion that the build emitted what the site actually loads. A green build is not the same thing: Eleventy reports success for a passthrough copy that quietly matched nothing, which is how #103 shipped. The job names `index.html`, `js/bundle.js`, `css/main.css`, `_redirects` and the four images and insists each is non-empty.
- `node --check dist/js/bundle.js`. This is the failure `bundle.test.js` can only approximate — that test reads the templates as text and reconstructs the concatenation itself, where this reads what the minifier actually wrote.

`dist/README/index.html` is deliberately not asserted: it is emitted today, but #141 says it should not be, and this job should not be the thing that argues with that.

## Verification

The install, the build, the file assertions and the `node --check` were all run against a local-disk copy exactly as written here. The workflow change itself is only really exercised once it runs on GitHub, which will happen on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)