### PR TITLE
docs(db_maintenance): record that the indexes are applied

### DIFF
--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -85,6 +85,20 @@ node scripts/ensure_indexes.js --apply
 Flags: `--only=users,entryRevisions` (collection names, not the `films,books`
 types the other scripts take), `--json=path`.
 
+**These are applied to production, as of 2026-08-18 (UTC): all 23 of them.**
+Nineteen were already in place before that date, from whenever #121 was first
+run — nothing recorded it, which is what #147 was about. The four compound
+`*Entries.userId_1_updatedDate_-1__id_1` indexes were created on that date,
+over the snapshot `snapshot-2026-08-18T03-19-34-608Z`, and the winning plan
+for the list query went from a blocking `SORT` to
+`IXSCAN -> FETCH -> LIMIT` on all four entry collections.
+
+A dry run today therefore prints `23 index(es) already exist, 0 would be
+created, 0 conflict`, and that is what "applied" looks like from the outside.
+If it ever reports something to create, either `index_plan.js` has grown an
+entry or an index was dropped behind its back — both worth knowing before you
+reach for `--apply`.
+
 Which indexes, and why each one, is declared in `index_plan.js` — every entry
 names the queries that want it, because an index nobody can name a query for
 is an index to delete. Most are single ascending fields: almost every query


### PR DESCRIPTION
The other half of #147, and the half that keeps it from being asked again. #153 declared the compound index; this records that the indexes are actually in the database, which is the thing nobody could tell from the repository.

They are, all 23 of them. Nineteen already were before today — so #121 was applied at some point and simply never written down — and the four compound `*Entries.userId_1_updatedDate_-1__id_1` indexes were created today over `snapshot-2026-08-18T03-19-34-608Z`. Details and full output are on #147.

The note deliberately says what a dry run prints *today* and what a different answer would mean, rather than just "done on a date". A record that only says an action happened goes stale silently; one that says what you should see if you check is one the next person can re-verify in ten seconds by running the script.

## What was verified

The list query's winning plan lost its blocking sort, which is the whole point of the exercise:

```
index-served   filmEntries     IXSCAN(userId_1_updatedDate_-1__id_1) -> FETCH -> LIMIT -> EQ_LOOKUP(_id_)
index-served   tvShowEntries   IXSCAN(userId_1_updatedDate_-1__id_1) -> FETCH -> LIMIT -> EQ_LOOKUP(_id_)
index-served   gameEntries     IXSCAN(userId_1_updatedDate_-1__id_1) -> FETCH -> LIMIT -> EQ_LOOKUP(_id_)
index-served   bookEntries     IXSCAN(userId_1_updatedDate_-1__id_1) -> FETCH -> LIMIT -> EQ_LOOKUP(_id_)
```

That is the winning plan specifically — the rejected plans still contain the `userId_1` + `SORT` version, which is what the planner is now declining to use. Explained against the busiest user's 1518 film entries.

Per `CLAUDE.md`: snapshot first (verified — 14 collections, 11812 documents, manifest counts, file counts, live `countDocuments()` and every SHA-256 in agreement), dry run read, `--apply`, then re-run to confirm a no-op and re-count. No document counts changed, which for an index build is what "nothing moved" looks like. `npm test` passes, 352 tests; this PR is a `.md` change only.

## One thing this turned up, unrelated

The post-apply check for entries pointing at a work that no longer exists found 5 film, 3 TV, 8 game and 7 book entries dangling. Those are not from this: the same counts are present in the pre-apply snapshot, and creating an index cannot orphan a reference. Flagging it because I went looking and found it, not because it belongs to this PR.

Refs #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
