### PR TITLE
fix: unforce the catch-all, so the cache headers actually apply

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,11 +1,25 @@
-# The catch-all at the bottom is forced (`200!`), so it rewrites even urls
-# that do exist as files. Every static asset therefore needs a forced rule of
-# its own, mapping it to itself, or it is served the HTML of the homepage:
-# `/js/bundle.js` came back as `<!doctype html>` and the whole site was a
-# blank page with `Unexpected token '<'` in the console.
-/img/*	/img/:splat	200!
-/js/*	/js/:splat	200!
-/css/*	/css/:splat	200!
+# Netlify does not apply a custom header to a response it produced by rewriting,
+# and a forced rule (`200!`) rewrites a url even when it exists as a file. With
+# the catch-all forced, every response on this site was a rewrite — which is why
+# the `[[headers]]` block #157 added to `netlify.toml` did nothing whatsoever.
+# After it merged, production went on answering `/js/bundle.<hash>.js` with
+# `public,max-age=0,must-revalidate`, exactly as it had before the rules existed.
+# Nothing reports this: the deploy is green and the header is simply absent.
+#
+# Unforced, the catch-all does what it was always meant to. A url that exists as
+# a file is served as that file, and gets the headers written for it; a url that
+# does not exist — which is every client-side route — is rewritten to the app.
+# The `/img/*`, `/js/*` and `/css/*` rules that mapped those three directories
+# to themselves existed only to escape the forced catch-all, and go with it.
+#
+# The HTML is still rewritten and so still uncacheable, which is the right way
+# round: it is the thing that names the hashed assets, so it has to be
+# re-fetched for a browser to find out they changed.
+
+# This file is copied into the publish directory, because that is where Netlify
+# reads it from. The forced catch-all used to hide it by accident; now that the
+# catch-all serves files that exist, it is hidden on purpose.
+/_redirects	/index.html	200!
 
 # The functions answer at `/.netlify/functions/*`, which is not a url anyone
 # would type or hand to a language model. `/api/*` is the one the README and
@@ -13,4 +27,4 @@
 # doesn't matter which of the two Netlify reports as the request path.
 /api/*	/.netlify/functions/:splat	200
 
-/*	/index.html	200!
+/*	/index.html	200

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,25 +31,24 @@
 # The HTML that names these urls keeps that default and should: it is what
 # tells a browser the hash has changed.
 #
-# These rules are not verified, and on a deploy preview they cannot be. A
-# preview answers every url — html, bundle, stylesheet alike — with
-# `public,max-age=0,must-revalidate` and carries no custom header at all, not
-# even one written for a single exact path. So whether these take effect is a
-# thing to check against production once this is merged, with `curl -sI` on
-# either url.
+# These rules did nothing at all when they first shipped, and nothing said so.
+# Netlify does not apply a custom header to a response it produced by
+# rewriting, and the catch-all in `_redirects` was forced (`200!`), which
+# rewrites a url even when it exists as a file — so every response on this site
+# was a rewrite and every rule here was dead. Production went on answering the
+# hashed bundle `public,max-age=0,must-revalidate` with these declared, exactly
+# as it had before they existed.
 #
-# If they turn out not to have, the first thing to suspect is the forced
-# catch-all in `_redirects`. Netlify does not apply a custom header to a
-# response it produced by rewriting, and a forced rule (`200!`) rewrites a url
-# even when it exists as a file — which would make every rule here inert. The
-# known next thing to try is unforcing the catch-all and dropping the `/img/*`,
-# `/js/*` and `/css/*` self-rules that exist only to escape it. That is not
-# done here because there is no way to confirm from a preview that it helps,
-# and it changes how every url on the site is routed.
+# Unforcing the catch-all is what turned them on; `_redirects` carries the
+# reasoning. The dependency runs the other way to how it reads: this block is
+# inert unless a file is served as a file, so a forced rule reintroduced above
+# the catch-all would switch it off again silently. A test pins that.
 #
-# Either way the hashed filenames stand on their own: `immutable` on a name
-# that is a digest of its own contents is safe if it applies and inert if it
-# does not.
+# Worth knowing that a deploy preview cannot be used to check any of this. A
+# preview answers every url with `max-age=0, must-revalidate` and carries no
+# custom header at all, not even one written for a single exact path, so the
+# only way to see whether a change here worked is `curl -sI` against
+# production after it merges.
 [[headers]]
   for = "/js/*"
   [headers.values]

--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -187,15 +187,28 @@ test("assets.js re-reads on every build", () => {
   );
 });
 
-test("the hashed assets are exempt from the SPA catch-all", () => {
-  // `/*  /index.html  200!` is forced, so it rewrites urls that exist as files
-  // too. An asset is only served as itself if it has a forced rule of its own,
-  // the way `/img/*` does. Without one, the bundle answers with the homepage's
-  // HTML and the site is blank with `Unexpected token '<'`. The hashed names
-  // have to keep matching those rules, which is why they keep their directory.
-  const exempt = [
-    ...read(REDIRECTS).matchAll(/^(\/\S*?)\/\*\s+\S+\s+200!/gm),
-  ].map(([, prefix]) => prefix + "/");
+test("the SPA catch-all is not forced, so the assets are served as files", () => {
+  // This is the whole reason netlify.toml's headers do anything. Netlify does
+  // not put a custom header on a response it produced by rewriting, and a
+  // forced rule rewrites a url even when it exists as a file — so a forced
+  // catch-all made every response on the site a rewrite, and every header rule
+  // inert. That is not hypothetical: it is what #157 shipped, and production
+  // answered the hashed bundle `max-age=0, must-revalidate` regardless.
+  //
+  // Unforced, a file that exists is served as itself and keeps its headers.
+  const redirects = read(REDIRECTS);
+
+  assert.match(
+    redirects,
+    /^\/\*\s+\/index\.html\s+200\s*$/m,
+    "the catch-all must be `/*  /index.html  200` and must not be forced; " +
+      "forced, it rewrites the hashed assets and netlify.toml's Cache-Control " +
+      "silently stops applying to anything"
+  );
+
+  // A forced rule above it would do the same to whatever it covers, which is
+  // exactly what the `/js/*` and `/css/*` self-rules used to do.
+  const forced = [...redirects.matchAll(/^(\S+)\s+\S+\s+200!/gm)].map(([, from]) => from);
 
   const hash = plan.digest("sample");
   const assets = [
@@ -212,11 +225,14 @@ test("the hashed assets are exempt from the SPA catch-all", () => {
   assert.ok(assets.length > 2, "found no local assets in base.njk");
 
   assets.forEach((url) =>
-    assert.ok(
-      exempt.some((prefix) => url.startsWith(prefix)),
-      `${url} is served by no forced rule in _redirects, so the catch-all ` +
-        `answers it with index.html`
-    )
+    forced.forEach((from) => {
+      const pattern = new RegExp(`^${from.replace(/[.]/g, "\\$&").replace(/\*$/, ".*")}$`);
+      assert.ok(
+        !pattern.test(url),
+        `_redirects forces ${from}, which covers ${url}; a rewritten response ` +
+          `is served without the Cache-Control netlify.toml gives it`
+      );
+    })
   );
 });
 


### PR DESCRIPTION
Follow-up to #157, which closed #142 but only delivered half of it.

#157 hashed both assets and declared `/js/*` and `/css/*` `immutable` for a year. **The headers did nothing**, and still do:

```
$ curl -sI https://td-memo.netlify.app/js/bundle.4ff4ba2f74.js | grep -i cache-control
Cache-Control: public,max-age=0,must-revalidate
```

That is what production answered before those rules existed. So the two conditional round trips per navigation that #142 is actually about are still there.

## Why

Netlify does not apply a custom header to a response it produced by rewriting, and a forced rule (`200!`) rewrites a url even when it exists as a file. The catch-all was forced, so *every* response on this site was a rewrite and *every* header rule was dead on arrival. Nothing reports it — the build is green, the deploy is green, and the header is simply not on the response.

Unforced, the catch-all does what it was always meant to: a url that exists as a file is served as that file and keeps the headers written for it, and a url that does not exist — which is every client-side route — is rewritten to the app. The `/img/*`, `/js/*` and `/css/*` rules that mapped those three directories to themselves existed *only* to escape the forced catch-all, so they go too. This is three rules fewer, not one more.

The hashed names are what make it safe to serve those files directly and cache them hard, so this only became available once #157 landed.

## What else moves

`_redirects` is copied into the publish directory, because that is where Netlify reads it from. The forced catch-all was hiding it by accident, so unforcing would have published it; a rule hides it on purpose instead. `/README/` needs no equivalent — #149 dropped `md` from `templateFormats`, so it is not built.

The test that required a forced rule per asset now requires the opposite: that the catch-all is unforced, and that no forced rule shadows either asset. That inversion is the point. The condition the `Cache-Control` depends on lives in a different file from the `Cache-Control` itself, and is invisible from either one alone, so re-forcing the catch-all — or re-adding a `/js/*` self-rule out of habit — would silently switch the caching back off. Both cases fail the test now.

## What I could not check, and why this is the second attempt

**A deploy preview cannot tell these two states apart.** A preview answers every url with `max-age=0, must-revalidate` and carries no custom header at all — I confirmed that directly by declaring a probe header for `/*`, and a second for the bundle's exact path, on a deploy verified live for that exact commit. Neither appeared on anything.

That is precisely how #157 shipped headers that did nothing: there was no way to see it. It is also why I wrote this change during #157 and then took it back out, because at that point I could not distinguish "the forced catch-all is blocking headers" from "headers do not work here at all", and rerouting every url on a hypothesis is not a merge. Production has since answered that: the rules are declared, correct, and inert.

So the honest position on this PR is that it is the one remaining explanation and the fix follows from it, but the confirmation can only happen after merge:

```bash
curl -sI https://td-memo.netlify.app/js/bundle.4ff4ba2f74.js | grep -i cache-control
```

Expected `public, max-age=31536000, immutable`. If it still says `max-age=0`, the premise was wrong and this is one `git revert` — nothing else depends on it.

## Verification

Routing is the risk here, not caching, so that is what I checked. Built on a local-disk copy per `CLAUDE.md`.

- `npm test`: 333 pass, 0 fail with dependencies; 292 pass, 0 fail, 41 self-skipped with **no install**.
- The two regressions this is guarding against were introduced deliberately and both fail the test: re-forcing the catch-all, and re-adding a forced `/js/*` rule.
- Against the real `dist`, every url the build emits resolves the way it should: the two hashed assets and `/img/*` exist as files and are served as themselves; `/films/nil` and every other client-side route falls through to the catch-all; `/api/*` still reaches the functions; `/_redirects` is masked.
- Both CI steps from #150 still pass against the built output.

The one behaviour change beyond caching is that a url that exists as a file is now served rather than rewritten. After #149 the only such files are the two hashed assets, `/img/*`, `index.html` and `_redirects` — the first four are meant to be served, and the last is masked.
