### PR TITLE
fix: declare the cache headers where Netlify reads them

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,6 +26,10 @@ module.exports = (config) => {
   // pass some assets right through
   config.addPassthroughCopy('./src/frontend/img')
   config.addPassthroughCopy('./_redirects')
+  // `_headers` has to sit in the publish directory to be read at all. The
+  // `[[headers]]` block in `netlify.toml` is the other way to declare these and
+  // it never applied on this site; see the note in the file itself.
+  config.addPassthroughCopy('./_headers')
 
   // The bundle's sources are read by `_data/assets.js` with `fs`, so Eleventy
   // has no idea that a page depends on them. Without this, editing a component

--- a/_headers
+++ b/_headers
@@ -1,0 +1,42 @@
+# Both of these urls carry a digest of their own contents in the filename —
+# `/js/bundle.<hash>.js` and `/css/main.<hash>.css`, built in
+# `src/frontend/_data/assets.js`. That is the precondition for `immutable`: the
+# promise is that the bytes at a given url will never change, and a browser that
+# believes it will not ask again for a year. On an unhashed name that promise is
+# a lie and the site is stuck; on a digest it is simply true.
+#
+# Netlify's default for a file with no rule is `public, max-age=0,
+# must-revalidate`, so every navigation on a client-side-routed site spends a
+# conditional request on each of these before it can draw. They come back `304`
+# with no body — two round trips rather than two payloads, and still two round
+# trips.
+#
+# These rules live here rather than in `netlify.toml` because the `[[headers]]`
+# block there never worked. #157 declared exactly these two rules that way and
+# production went on answering the hashed bundle `max-age=0, must-revalidate`;
+# #164 unforced the catch-all on the theory that the rewrite was eating them,
+# and production did not budge. Netlify's own deploy summary reports "Header
+# rules" as `skipping` on every one of those deploys, while "Redirect rules"
+# reports `pass` — and redirects are the thing this repo declares as a file in
+# the publish directory. Declared here instead, both rules arrive: a deploy
+# preview serves the hashed bundle and stylesheet `max-age=31536000,
+# immutable`, and Netlify's "Header rules" check flips from `skipping` to
+# `pass`. So a preview can check this, and is worth checking — it is only
+# `netlify.toml`'s version of these rules that was invisible everywhere.
+#
+# The forced catch-all in `_redirects` does not interfere: `/js/*` is a forced
+# rewrite and the header arrives on it regardless, which is what #164 was
+# wrong about.
+#
+# `.eleventy.js` copies this into `dist/` the same way it copies `_redirects`.
+# It has to be in the publish directory to be read at all; a `_headers` sitting
+# at the repo root does nothing.
+#
+# The HTML that names these urls keeps Netlify's default and should: it is what
+# tells a browser the hash has changed.
+
+/js/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/css/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/_redirects
+++ b/_redirects
@@ -1,25 +1,11 @@
-# Netlify does not apply a custom header to a response it produced by rewriting,
-# and a forced rule (`200!`) rewrites a url even when it exists as a file. With
-# the catch-all forced, every response on this site was a rewrite — which is why
-# the `[[headers]]` block #157 added to `netlify.toml` did nothing whatsoever.
-# After it merged, production went on answering `/js/bundle.<hash>.js` with
-# `public,max-age=0,must-revalidate`, exactly as it had before the rules existed.
-# Nothing reports this: the deploy is green and the header is simply absent.
-#
-# Unforced, the catch-all does what it was always meant to. A url that exists as
-# a file is served as that file, and gets the headers written for it; a url that
-# does not exist — which is every client-side route — is rewritten to the app.
-# The `/img/*`, `/js/*` and `/css/*` rules that mapped those three directories
-# to themselves existed only to escape the forced catch-all, and go with it.
-#
-# The HTML is still rewritten and so still uncacheable, which is the right way
-# round: it is the thing that names the hashed assets, so it has to be
-# re-fetched for a browser to find out they changed.
-
-# This file is copied into the publish directory, because that is where Netlify
-# reads it from. The forced catch-all used to hide it by accident; now that the
-# catch-all serves files that exist, it is hidden on purpose.
-/_redirects	/index.html	200!
+# The catch-all at the bottom is forced (`200!`), so it rewrites even urls
+# that do exist as files. Every static asset therefore needs a forced rule of
+# its own, mapping it to itself, or it is served the HTML of the homepage:
+# `/js/bundle.js` came back as `<!doctype html>` and the whole site was a
+# blank page with `Unexpected token '<'` in the console.
+/img/*	/img/:splat	200!
+/js/*	/js/:splat	200!
+/css/*	/css/:splat	200!
 
 # The functions answer at `/.netlify/functions/*`, which is not a url anyone
 # would type or hand to a language model. `/api/*` is the one the README and
@@ -27,4 +13,4 @@
 # doesn't matter which of the two Netlify reports as the request path.
 /api/*	/.netlify/functions/:splat	200
 
-/*	/index.html	200
+/*	/index.html	200!

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,49 +15,15 @@
   # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
   NODE_VERSION = "22"
 
-# Both of these urls carry a digest of their own contents in the filename —
-# `/js/bundle.<hash>.js` and `/css/main.<hash>.css`, built in
-# `src/frontend/_data/assets.js`. That is the precondition for `immutable`, and
-# it is not optional: the promise being made here is that the bytes at a given
-# url will never change, and a browser that believes it will not ask again for
-# a year. On an unhashed name that promise is a lie and the site is stuck.
-#
-# Without these, Netlify's default for a file with no rule is `public,
-# max-age=0, must-revalidate`, so every navigation on a client-side-routed site
-# spent a conditional request on each of the two before it could draw. They came
-# back `304` with no body, so it was two round trips rather than two payloads —
-# and still two round trips.
-#
-# The HTML that names these urls keeps that default and should: it is what
-# tells a browser the hash has changed.
-#
-# These rules did nothing at all when they first shipped, and nothing said so.
-# Netlify does not apply a custom header to a response it produced by
-# rewriting, and the catch-all in `_redirects` was forced (`200!`), which
-# rewrites a url even when it exists as a file — so every response on this site
-# was a rewrite and every rule here was dead. Production went on answering the
-# hashed bundle `public,max-age=0,must-revalidate` with these declared, exactly
-# as it had before they existed.
-#
-# Unforcing the catch-all is what turned them on; `_redirects` carries the
-# reasoning. The dependency runs the other way to how it reads: this block is
-# inert unless a file is served as a file, so a forced rule reintroduced above
-# the catch-all would switch it off again silently. A test pins that.
-#
-# Worth knowing that a deploy preview cannot be used to check any of this. A
-# preview answers every url with `max-age=0, must-revalidate` and carries no
-# custom header at all, not even one written for a single exact path, so the
-# only way to see whether a change here worked is `curl -sI` against
-# production after it merges.
-[[headers]]
-  for = "/js/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
-  for = "/css/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+# There is deliberately no `[[headers]]` block here. #157 declared
+# `Cache-Control` for `/js/*` and `/css/*` this way and it never applied:
+# production kept answering the hashed bundle `public,max-age=0,
+# must-revalidate`, and Netlify's deploy summary reported "Header rules" as
+# `skipping` every time, while "Redirect rules" reported `pass`. The rules live
+# in `_headers`, a file in the publish directory the way `_redirects` is, and
+# declared there they arrive: both assets come back `immutable` and that check
+# passes. Moving them back here would switch the caching off silently, without
+# failing a build or a test.
 
 [functions]
   directory = "src/api/routes"

--- a/src/frontend/_includes/js/bundle.test.js
+++ b/src/frontend/_includes/js/bundle.test.js
@@ -32,6 +32,8 @@ const ROOT = path.join(FRONTEND, "..", "..");
 const DATA = path.join(FRONTEND, "_data", "assets.js");
 const REDIRECTS = path.join(ROOT, "_redirects");
 const NETLIFY = path.join(ROOT, "netlify.toml");
+const HEADERS = path.join(ROOT, "_headers");
+const ELEVENTY = path.join(ROOT, ".eleventy.js");
 
 const read = (file) => fs.readFileSync(file, "utf8");
 
@@ -187,28 +189,15 @@ test("assets.js re-reads on every build", () => {
   );
 });
 
-test("the SPA catch-all is not forced, so the assets are served as files", () => {
-  // This is the whole reason netlify.toml's headers do anything. Netlify does
-  // not put a custom header on a response it produced by rewriting, and a
-  // forced rule rewrites a url even when it exists as a file — so a forced
-  // catch-all made every response on the site a rewrite, and every header rule
-  // inert. That is not hypothetical: it is what #157 shipped, and production
-  // answered the hashed bundle `max-age=0, must-revalidate` regardless.
-  //
-  // Unforced, a file that exists is served as itself and keeps its headers.
-  const redirects = read(REDIRECTS);
-
-  assert.match(
-    redirects,
-    /^\/\*\s+\/index\.html\s+200\s*$/m,
-    "the catch-all must be `/*  /index.html  200` and must not be forced; " +
-      "forced, it rewrites the hashed assets and netlify.toml's Cache-Control " +
-      "silently stops applying to anything"
-  );
-
-  // A forced rule above it would do the same to whatever it covers, which is
-  // exactly what the `/js/*` and `/css/*` self-rules used to do.
-  const forced = [...redirects.matchAll(/^(\S+)\s+\S+\s+200!/gm)].map(([, from]) => from);
+test("the hashed assets are exempt from the SPA catch-all", () => {
+  // `/*  /index.html  200!` is forced, so it rewrites urls that exist as files
+  // too. An asset is only served as itself if it has a forced rule of its own,
+  // the way `/img/*` does. Without one, the bundle answers with the homepage's
+  // HTML and the site is blank with `Unexpected token '<'`. The hashed names
+  // have to keep matching those rules, which is why they keep their directory.
+  const exempt = [
+    ...read(REDIRECTS).matchAll(/^(\/\S*?)\/\*\s+\S+\s+200!/gm),
+  ].map(([, prefix]) => prefix + "/");
 
   const hash = plan.digest("sample");
   const assets = [
@@ -225,38 +214,57 @@ test("the SPA catch-all is not forced, so the assets are served as files", () =>
   assert.ok(assets.length > 2, "found no local assets in base.njk");
 
   assets.forEach((url) =>
-    forced.forEach((from) => {
-      const pattern = new RegExp(`^${from.replace(/[.]/g, "\\$&").replace(/\*$/, ".*")}$`);
-      assert.ok(
-        !pattern.test(url),
-        `_redirects forces ${from}, which covers ${url}; a rewritten response ` +
-          `is served without the Cache-Control netlify.toml gives it`
-      );
-    })
+    assert.ok(
+      exempt.some((prefix) => url.startsWith(prefix)),
+      `${url} is served by no forced rule in _redirects, so the catch-all ` +
+        `answers it with index.html`
+    )
   );
 });
 
 test("the immutable headers cover the directories the assets are emitted to", () => {
-  // `immutable` on a url whose contents can change under it is the one way
-  // this gets worse rather than better, so the rule and the hashed name are
-  // checked against each other rather than each being trusted on its own.
-  const netlify = read(NETLIFY);
+  // `immutable` on a url whose contents can change under it is the one way this
+  // gets worse rather than better, so the rule and the hashed name are checked
+  // against each other rather than each being trusted on its own.
+  const headers = read(HEADERS).replace(/^\s*#.*$/gm, "");
   const hash = plan.digest("sample");
 
   [plan.bundleUrl(hash), plan.stylesheetUrl(hash)].forEach((url) => {
     const directory = url.slice(0, url.indexOf("/", 1) + 1);
     const rule = new RegExp(
-      `\\[\\[headers\\]\\]\\s*for\\s*=\\s*"${directory}\\*"\\s*` +
-        `\\[headers\\.values\\]\\s*Cache-Control\\s*=\\s*"[^"]*immutable"`
+      `^${directory.replace("/", "\\/")}\\*\\s*$\\s*^\\s+Cache-Control:\\s*[^\\n]*immutable`,
+      "m"
     );
 
     assert.match(
-      netlify.replace(/#.*$/gm, ""),
+      headers,
       rule,
-      `netlify.toml has no immutable Cache-Control for ${directory}*, which is ` +
+      `_headers has no immutable Cache-Control for ${directory}*, which is ` +
         `where ${url} is served from`
     );
   });
+});
+
+test("_headers is the mechanism, and it reaches the publish directory", () => {
+  // Declaring these in `netlify.toml` is the other documented way and it never
+  // applied on this site: #157 shipped exactly these two rules that way and
+  // production kept answering the hashed bundle `max-age=0, must-revalidate`.
+  // Moving them back would switch the caching off without failing a thing, so
+  // the absence is asserted rather than left to memory.
+  assert.doesNotMatch(
+    read(NETLIFY).replace(/^\s*#.*$/gm, ""),
+    /\[\[headers\]\]/,
+    "netlify.toml declares [[headers]] again; those never applied here, and " +
+      "having both is two places to read one answer from"
+  );
+
+  // A `_headers` at the repo root is read by nothing. It has to be copied into
+  // the publish directory, the way `_redirects` is.
+  assert.match(
+    read(ELEVENTY),
+    /addPassthroughCopy\('\.\/_headers'\)/,
+    ".eleventy.js must copy _headers into dist/, or Netlify never sees it"
+  );
 });
 
 test("components/index.js comes before the files that populate it", () => {


### PR DESCRIPTION
Closes #142 — the caching half, which #157 declared and never delivered.

**Verified on the deploy preview**, unlike the two attempts before it:

```
$ curl -sI https://deploy-preview-165--td-memo.netlify.app/js/bundle.4ff4ba2f74.js
Cache-Control: public,max-age=31536000,immutable
$ curl -sI https://deploy-preview-165--td-memo.netlify.app/css/main.b2b0c23831.css
Cache-Control: public,max-age=31536000,immutable
```

The HTML keeps `max-age=0, must-revalidate`, which is the right way round: it is what names the hashed assets, so it is the thing that has to be re-fetched for a browser to learn they changed. Netlify's own "Header rules" check went from `skipping` to **`pass`**.

## What was actually wrong

#157 declared these two rules as a `[[headers]]` block in `netlify.toml`. Production ignored them completely. #164 unforced the catch-all in `_redirects`, on the theory that a forced rule made every response a rewrite and Netlify strips custom headers from rewritten responses. Production did not budge.

The lead both attempts walked past was in the deploy summary the whole time: **"Header rules" reported `skipping` on every deploy, while "Redirect rules" reported `pass`** — and redirects are the thing this repo declares as a *file in the publish directory*. Declared the same way, in `_headers` copied into `dist/` alongside `_redirects`, the rules arrive.

## Two things this settles, both of which I had wrong

**A deploy preview can check headers perfectly well.** I claimed it could not, based on probing `netlify.toml`-declared headers and seeing nothing. That was an overgeneralisation from a mechanism that was simply broken — a `_headers` rule shows up on a preview immediately. This was checkable all along, which is exactly why #157 could ship inert headers with nothing visible to contradict them.

**A forced rewrite does not strip a `_headers` rule.** `/js/*` is a forced rewrite in this branch and the header arrives on it regardless. So #164's premise was wrong twice over, and its routing change earns nothing; this reverts it and restores the forced catch-all with the `/img/*`, `/js/*` and `/css/*` self-rules.

## Keeping it from silently regressing

The failure mode here is that everything looks fine while the caching is off — no build failure, no test failure, no deploy warning. So:

- `netlify.toml` carries a note that there is deliberately no `[[headers]]` block, and why. A test asserts its absence, because moving the rules back there would switch caching off silently.
- A test asserts `_headers` declares an `immutable` `Cache-Control` for each directory the hashed assets are emitted to, derived from `asset_plan.js` rather than written down again.
- A test asserts `.eleventy.js` copies `_headers` into the publish directory. At the repo root it is read by nothing.

## Verification

- Preview: both assets `immutable`, HTML still revalidating, `/img/*` left on the default, `/`, `/profile/nil`, `/films/nil` and `/api/export/films/nil` all 200.
- Confirmed on a probe-free build, after the temporary probe headers used to diagnose this were removed — so what is verified is what merges.
- `npm test`: 293 pass, 0 fail with **no install**. CI `build` and `test` both pass.
- All three new guards were checked by breaking what they protect: dropping a `Cache-Control` from `_headers`, re-declaring `[[headers]]` in `netlify.toml`, and removing the passthrough copy each fail.
- `_headers` confirmed present in `dist/` after a real build.

Once this merges the same two `curl -sI` commands against `td-memo.netlify.app` should show the same thing.
