### PR TITLE
fix(db_maintenance): report the audit's findings honestly, and clear the reviews nothing can reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ Write only to the **work** collections. User overrides live on entry
 documents (`entry.overrides`), so a script that never touches `*Entries`
 cannot clobber one.
 
+The one exception is `scripts/prune_orphan_reviews.js`, which deletes review
+documents whose entry is gone — notes no code path can reach, since a review
+is only ever looked up by `entryRef`. It reads `*Entries` but never writes to
+them. Adding a second exception is a human's call: the rule is what keeps a
+maintenance script away from text people can still read.
+
 ## Tests
 
 `npm test` is `node --test`, and CI also parses every tracked `.js` file.

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -146,13 +146,37 @@ count:
 - **Cached works no entry points at** are leftovers of the metadata cache, not
   lost user data.
 
-`reviews whose entry is gone` **is** a problem, and an unfixable one from
-here: a review is only ever found by `entryRef`, so one whose entry is gone
-holds text no code path can reach. The ~248 of them are residue of the FaunaDB
-migration and of deletes that predate the cleanup in
-`api/controllers/entries.js`, which now removes an entry's review with it.
-They are user-written text in a collection these scripts do not write to, so
-deleting them is a human's decision, not a script's.
+`reviews whose entry is gone` **is** a problem: a review is only ever found by
+`entryRef`, so one whose entry is gone holds text no code path can reach.
+There are 248 — 44 films, 14 tv, 150 games, 40 books.
+
+None of them was written unattached. Every one was saved against an entry that
+existed at the time and was deleted afterwards, and until
+`fix: delete an entry's review along with the entry` (#117, 2026-08-12) a
+delete removed the entry and left the review sitting there. The 248 are that
+bug's whole backlog, not an ongoing leak.
+
+The evidence, if it needs re-checking: Fauna-era ids are allocated in creation
+order, at a rate of about 1.027e6 id units per millisecond, which fits the
+3189 surviving numeric entries with zero violations — no entry's inferred
+creation time lands after its `updatedDate`. Every one of the 177 numeric
+orphan `entryRef`s decodes to a 2022 creation, sits *inside* the surviving id
+range, and is a median of zero seconds from an entry that is still there, so
+they were created in the same batches as their surviving neighbours. The
+remaining 71 carry uuid `entryRef`s, so they postdate the FaunaDB migration
+and can only be bounded as older than the earliest snapshot.
+
+What is in them: **171 are empty**, because `createEntry` writes a review
+document for every entry whether or not a note was typed. Of the 77 that hold
+text, **27 duplicate a note that still exists** — the same text, verbatim,
+under a live entry, which is what deleting a row and re-adding the same title
+leaves behind. **50 hold text found nowhere else.**
+
+Those 50 are the only real loss, and they are still not obviously data anyone
+wants back: the user deleted the entry, and #117 treats the note as something
+"the user asked to be rid of". Clearing them is a delete of user-written text
+in a collection these scripts do not write to, so it is a human's decision and
+nothing here does it.
 
 `scripts/backfill_work_metadata.js` re-runs the API adapters for cached works
 and fills in what's missing / refreshes what's stale. It is a **dry run

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -123,12 +123,36 @@ building an index on a live collection costs I/O.
 inconsistency it can find: works that can't be refreshed because they
 have no usable apiRef, missing or corrupt metadata fields, games whose
 playtime has nothing to link it to, duplicate works sharing an apiRef,
-orphaned works, and entries with a missing or dangling `workRef`.
+entries whose `workRef` names a work that is gone, and reviews whose entry is
+gone.
 
 ```
 node scripts/audit_database.js
 node scripts/audit_database.js --only=games,books --json=./audit.json
 ```
+
+The summary prints those under a per-collection list of problems, and then a
+short **not problems, for information** block. What goes in which is
+`../audit_report.js`, and the distinction is worth reading before acting on a
+count:
+
+- **Entries with no linked work** are not damage. An entry the user typed in
+  by hand, rather than picking from a search result, has no work to point at
+  and carries its own metadata in `overrides` — which the list merges over
+  `commonMetadata`, so it renders correctly. There are 23 of these, and the
+  right number to repoint or delete is zero. They are only a line apart from
+  the dangling-`workRef` count, which is a genuine broken reference, and
+  reading one as the other is a mistake that has already been made once.
+- **Cached works no entry points at** are leftovers of the metadata cache, not
+  lost user data.
+
+`reviews whose entry is gone` **is** a problem, and an unfixable one from
+here: a review is only ever found by `entryRef`, so one whose entry is gone
+holds text no code path can reach. The ~248 of them are residue of the FaunaDB
+migration and of deletes that predate the cleanup in
+`api/controllers/entries.js`, which now removes an entry's review with it.
+They are user-written text in a collection these scripts do not write to, so
+deleting them is a human's decision, not a script's.
 
 `scripts/backfill_work_metadata.js` re-runs the API adapters for cached works
 and fills in what's missing / refreshes what's stale. It is a **dry run

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -17,6 +17,7 @@ The scripts, and the section below that explains each:
 | `backfill_work_metadata.js` | Re-runs the API adapters over cached works, filling gaps and refreshing stale metadata. | `--apply` |
 | `backfill_game_playtimes.js` | Fills in games with no playtime, from IGDB's `/game_time_to_beats`. | `--apply` |
 | `dedupe_works.js` | Merges works that duplicate each other, repoints the entries and deletes the leftovers. | `--apply` |
+| `prune_orphan_reviews.js` | Deletes reviews whose entry no longer exists, and so which nothing can reach. The one script here that writes outside the work collections. | `--apply` |
 
 Everything marked `--apply` is a **dry run without it**, and takes a backup of
 each collection it writes to first — except `ensure_indexes.js`, which writes
@@ -166,17 +167,34 @@ they were created in the same batches as their surviving neighbours. The
 remaining 71 carry uuid `entryRef`s, so they postdate the FaunaDB migration
 and can only be bounded as older than the earliest snapshot.
 
-What is in them: **171 are empty**, because `createEntry` writes a review
-document for every entry whether or not a note was typed. Of the 77 that hold
-text, **27 duplicate a note that still exists** — the same text, verbatim,
+What was in them: **171 were empty**, because `createEntry` writes a review
+document for every entry whether or not a note was typed. Of the 77 that held
+text, **27 duplicated a note that still exists** — the same text, verbatim,
 under a live entry, which is what deleting a row and re-adding the same title
-leaves behind. **50 hold text found nowhere else.**
+leaves behind. **50 held text found nowhere else.**
 
-Those 50 are the only real loss, and they are still not obviously data anyone
-wants back: the user deleted the entry, and #117 treats the note as something
-"the user asked to be rid of". Clearing them is a delete of user-written text
-in a collection these scripts do not write to, so it is a human's decision and
-nothing here does it.
+All 50 were read before anything was deleted. Each was attributed to the work
+it belonged to — from the note's own content plus 4-gram overlap against every
+surviving note — and in every case the surviving note turned out to be the
+fuller version, with the orphan an earlier draft. What genuinely did not
+survive was 2,793 characters across 10 entries, mostly reference links
+(comic readers, an RPCS3 setup guide, wikidot pages) and a block of weapon
+notes on Blood. That was reported for hand-merging through the app rather than
+written by a script: the note lives in **two** places — `entry.review` and the
+review document, in sync across all 810 entries that carry both — and a script
+writing one and not the other would create the first divergence in the
+database. Editing through the app writes both and records a revision.
+
+`scripts/prune_orphan_reviews.js` then deleted all 248, on 2026-08-19, against
+snapshot `snapshot-2026-08-19T02-51-54-658Z`. Entry counts were unchanged
+afterwards and the audit reports zero unreachable reviews.
+
+That script is the one exception to "write only to the work collections", and
+it is a narrow one: it reads `*Entries` but never writes to them, so no
+override and no live note is reachable from it, and everything it removes is
+restorable by `_id` from the snapshot it takes first. The rule it bends exists
+to protect notes people can still read; these were, by definition, notes
+nobody could.
 
 `scripts/backfill_work_metadata.js` re-runs the API adapters for cached works
 and fills in what's missing / refreshes what's stale. It is a **dry run

--- a/src/db_maintenance/audit_report.js
+++ b/src/db_maintenance/audit_report.js
@@ -1,0 +1,145 @@
+/**
+ * @file What the audit's summary says, and which of its findings are actually
+ * problems.
+ *
+ * Pure and dependency-free, so the classification is unit tested rather than
+ * argued about in front of a terminal — see audit_report.test.js. The database
+ * reads live in scripts/audit_database.js.
+ *
+ * The split exists because the summary used to print ten counts in one flat
+ * list, and two of the lines next to each other were:
+ *
+ *     5  entries with no workRef
+ *     0  entries with a dangling workRef
+ *
+ * Only the second is a broken reference. The first is a supported state — an
+ * entry the user typed in rather than picked from a search result carries its
+ * own metadata in `overrides` and never had a work to point at. Formatted
+ * identically and one line apart, the two were read as one finding, and the 23
+ * user-authored entries in the database were reported as 23 corrupted ones.
+ */
+
+/**
+ * Every line of the summary, in the order it is printed.
+ *
+ * `kind` is `"problem"` for something that wants fixing and `"note"` for a
+ * count that is worth knowing and is not damage. A note is not a milder
+ * problem: nothing in the database is wrong because of it, and no script
+ * should be written to make it go away.
+ *
+ * `label` takes the collection descriptor because one of them names the
+ * apiRef prefix the type is refreshed by.
+ *
+ * @type {Array<{
+ *   key: string,
+ *   kind: "problem" | "note",
+ *   label: (collection: any) => string,
+ *   only?: string,
+ * }>}
+ */
+const FINDINGS = [
+  // First, because it is the one that means a user's row renders empty.
+  {
+    key: "entriesWithDanglingWorkRef",
+    kind: "problem",
+    label: () => "entries whose workRef names a work that is gone",
+  },
+  {
+    key: "noApiRef",
+    kind: "problem",
+    label: (c) => `no ${c.retrievePrefix}__ ref (cannot be refreshed)`,
+  },
+  {
+    key: "legacyObjectApiRefs",
+    kind: "problem",
+    label: () => "apiRefs still stored as objects",
+  },
+  {
+    key: "missingFields",
+    kind: "problem",
+    label: () => "missing metadata fields",
+  },
+  {
+    key: "corruptFields",
+    kind: "problem",
+    label: () => "corrupt field values",
+  },
+  {
+    key: "gamesMissingPlaytimeLink",
+    kind: "problem",
+    label: () => "playtime with nothing to link it to",
+    only: "games",
+  },
+  {
+    key: "duplicateWorks",
+    kind: "problem",
+    label: () => "duplicate works sharing an apiRef",
+  },
+  {
+    key: "orphanReviews",
+    kind: "problem",
+    label: () => "reviews whose entry is gone (unreachable)",
+  },
+  // Notes. Neither is damage; see the header comment.
+  {
+    key: "entriesWithoutWorkRef",
+    kind: "note",
+    label: () => "entries with no linked work (user-authored, expected)",
+  },
+  {
+    key: "orphanWorks",
+    kind: "note",
+    label: () => "cached works no entry points at",
+  },
+];
+
+/**
+ * The summary lines for one collection, already split.
+ *
+ * A finding whose `only` doesn't match the type is left out entirely rather
+ * than printed as a zero, which is how the playtime line has always behaved.
+ * A key the result doesn't carry counts as zero rather than throwing: the
+ * report is a diagnostic, and half of one still beats a stack trace.
+ *
+ * @type {(collection: any, result: object) => {
+ *   problems: Array<{ key: string, label: string, count: number }>,
+ *   notes: Array<{ key: string, label: string, count: number }>,
+ * }}
+ */
+const toSummary = (collection, result) => {
+  const lines = FINDINGS.filter(
+    (finding) => finding.only === undefined || finding.only === collection.type
+  ).map((finding) => ({
+    key: finding.key,
+    kind: finding.kind,
+    label: finding.label(collection),
+    count: (result?.[finding.key] ?? []).length,
+  }));
+
+  return {
+    problems: lines.filter((line) => line.kind === "problem").map(withoutKind),
+    notes: lines.filter((line) => line.kind === "note").map(withoutKind),
+  };
+};
+
+/** How many findings across a whole report are worth someone's attention. */
+const countProblems = (collections, report) =>
+  collections.reduce(
+    (total, collection) =>
+      total +
+      toSummary(collection, report[collection.type]).problems.reduce(
+        (n, line) => n + line.count,
+        0
+      ),
+    0
+  );
+
+module.exports = {
+  FINDINGS,
+  toSummary,
+  countProblems,
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+const withoutKind = ({ kind: _kind, ...line }) => line;

--- a/src/db_maintenance/audit_report.test.js
+++ b/src/db_maintenance/audit_report.test.js
@@ -1,0 +1,99 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { FINDINGS, toSummary, countProblems } = require("./audit_report");
+
+const GAMES = { type: "games", retrievePrefix: "igdb" };
+const FILMS = { type: "films", retrievePrefix: "tmdb" };
+
+const empty = Object.fromEntries(FINDINGS.map((f) => [f.key, []]));
+const withCounts = (counts) => ({
+  ...empty,
+  ...Object.fromEntries(
+    Object.entries(counts).map(([key, n]) => [key, Array.from({ length: n })])
+  ),
+});
+
+const labelled = (lines) => lines.map((line) => line.key);
+const countOf = (lines, key) => lines.find((l) => l.key === key)?.count;
+
+test("an entry with no linked work is a note, not a problem", () => {
+  const { problems, notes } = toSummary(
+    FILMS,
+    withCounts({ entriesWithoutWorkRef: 5 })
+  );
+
+  assert.ok(!labelled(problems).includes("entriesWithoutWorkRef"));
+  assert.equal(countOf(notes, "entriesWithoutWorkRef"), 5);
+});
+
+test("an entry whose workRef names a missing work is a problem, and is listed first", () => {
+  const { problems } = toSummary(
+    FILMS,
+    withCounts({ entriesWithDanglingWorkRef: 2 })
+  );
+
+  assert.equal(problems[0].key, "entriesWithDanglingWorkRef");
+  assert.equal(problems[0].count, 2);
+});
+
+test("the two workRef findings never share a label", () => {
+  const { problems, notes } = toSummary(FILMS, empty);
+  const dangling = problems.find((l) => l.key === "entriesWithDanglingWorkRef");
+  const missing = notes.find((l) => l.key === "entriesWithoutWorkRef");
+
+  assert.notEqual(dangling.label, missing.label);
+  // The pair that was misread: neither label may be a prefix of the other,
+  // which is what "entries with no workRef" / "entries with a dangling
+  // workRef" amounted to at a glance.
+  assert.ok(!dangling.label.startsWith(missing.label));
+  assert.ok(!missing.label.startsWith(dangling.label));
+});
+
+test("the playtime finding belongs to games and to nothing else", () => {
+  assert.ok(
+    labelled(toSummary(GAMES, empty).problems).includes(
+      "gamesMissingPlaytimeLink"
+    )
+  );
+  assert.ok(
+    !labelled(toSummary(FILMS, empty).problems).includes(
+      "gamesMissingPlaytimeLink"
+    )
+  );
+});
+
+test("the apiRef label names the prefix the type is refreshed by", () => {
+  const labelFor = (collection) =>
+    toSummary(collection, empty).problems.find((l) => l.key === "noApiRef")
+      .label;
+
+  assert.match(labelFor(GAMES), /igdb__/);
+  assert.match(labelFor(FILMS), /tmdb__/);
+});
+
+test("a missing key counts as zero rather than throwing", () => {
+  const { problems, notes } = toSummary(FILMS, {});
+
+  assert.ok(problems.every((line) => line.count === 0));
+  assert.ok(notes.every((line) => line.count === 0));
+  assert.doesNotThrow(() => toSummary(FILMS, undefined));
+});
+
+test("notes are not counted as problems", () => {
+  const report = {
+    films: withCounts({ entriesWithoutWorkRef: 5, orphanWorks: 44 }),
+    games: withCounts({ entriesWithoutWorkRef: 8, corruptFields: 3 }),
+  };
+
+  assert.equal(countProblems([FILMS, GAMES], report), 3);
+});
+
+test("every finding is one kind or the other, and no key repeats", () => {
+  for (const finding of FINDINGS) {
+    assert.ok(["problem", "note"].includes(finding.kind), finding.key);
+    assert.equal(typeof finding.label(GAMES), "string");
+  }
+
+  assert.equal(new Set(FINDINGS.map((f) => f.key)).size, FINDINGS.length);
+});

--- a/src/db_maintenance/orphan_review_plan.js
+++ b/src/db_maintenance/orphan_review_plan.js
@@ -1,0 +1,89 @@
+/**
+ * @file Decides which reviews are unreachable and may be removed.
+ *
+ * A review is only ever found by `entryRef` — `getReview` in
+ * ../api/controllers/reviews.js looks it up by that and nothing else — so a
+ * review whose entry is gone cannot be read, edited or deleted by any code
+ * path the site has. It is not hidden data; it is data with no door.
+ *
+ * These accumulated because until `fix: delete an entry's review along with
+ * the entry` (#117, 2026-08-12) deleting an entry removed the entry and left
+ * the review behind. The population is that bug's backlog: every one was
+ * written against an entry that existed at the time.
+ *
+ * Pure and dependency-free: scripts/prune_orphan_reviews.js deletes documents
+ * based on what this returns, so the decision is unit tested
+ * (./orphan_review_plan.test.js) rather than discovered in production.
+ */
+
+/**
+ * The reviews in `reviews` whose `entryRef` names no document in `entries`.
+ *
+ * `blocked` is the important return value. Planning from an empty entry list
+ * would mark *every* review orphaned, which is exactly what a failed or
+ * mis-typed collection read looks like from here — the query returns `[]` and
+ * nothing throws. Since the entry collections are never legitimately empty
+ * while reviews exist, that combination is treated as a broken read and
+ * refused rather than planned, and the caller is expected to stop.
+ *
+ * @type {(entries: any[], reviews: any[]) => {
+ *   blocked: string | undefined,
+ *   orphans: any[],
+ *   withText: any[],
+ *   empty: any[],
+ *   keptCount: number,
+ * }}
+ */
+const planOrphanReviewRemoval = (entries, reviews) => {
+  const empty = { blocked: undefined, orphans: [], withText: [], empty: [], keptCount: 0 };
+
+  if (!Array.isArray(entries) || !Array.isArray(reviews)) {
+    return { ...empty, blocked: "entries and reviews must both be arrays" };
+  }
+  if (reviews.length === 0) return { ...empty };
+  if (entries.length === 0) {
+    return {
+      ...empty,
+      blocked:
+        `${reviews.length} review(s) but no entries at all — refusing to treat ` +
+        `every review as orphaned. This is what a failed collection read looks like.`,
+    };
+  }
+
+  const entryIds = new Set(entries.map((entry) => String(entry._id)));
+  const orphans = reviews.filter((review) => {
+    const ref = toRefKey(review?.entryRef);
+    return ref === undefined || !entryIds.has(ref);
+  });
+
+  return {
+    blocked: undefined,
+    orphans,
+    withText: orphans.filter(hasText),
+    empty: orphans.filter((review) => !hasText(review)),
+    keptCount: reviews.length - orphans.length,
+  };
+};
+
+/**
+ * A review document is written for every entry whether or not a note was
+ * typed — see `createEntry` in ../api/controllers/entries.js — so most of
+ * these hold nothing at all. Worth counting separately: an empty one is
+ * bookkeeping, and a full one is somebody's writing.
+ */
+const hasText = (review) =>
+  typeof review?.text === "string" && review.text.length > 0;
+
+/**
+ * `undefined` and `null` are not ids. Without this a review carrying no
+ * `entryRef` would be compared as the string "undefined", and would be
+ * spared by an entry that happened to have that id.
+ */
+const toRefKey = (entryRef) =>
+  entryRef === undefined || entryRef === null ? undefined : String(entryRef);
+
+module.exports = {
+  planOrphanReviewRemoval,
+  hasText,
+  toRefKey,
+};

--- a/src/db_maintenance/orphan_review_plan.test.js
+++ b/src/db_maintenance/orphan_review_plan.test.js
@@ -1,0 +1,93 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { planOrphanReviewRemoval, hasText } = require("./orphan_review_plan");
+
+const entry = (id) => ({ _id: id, userId: "u1" });
+const review = (id, entryRef, text) => ({ _id: id, entryRef, ...(text === undefined ? {} : { text }) });
+
+test("a review whose entry is gone is orphaned; one whose entry is there is not", () => {
+  const plan = planOrphanReviewRemoval(
+    [entry("e1"), entry("e2")],
+    [review("r1", "e1", "kept"), review("r2", "gone", "orphan"), review("r3", "e2")]
+  );
+
+  assert.equal(plan.blocked, undefined);
+  assert.deepEqual(plan.orphans.map((r) => r._id), ["r2"]);
+  assert.equal(plan.keptCount, 2);
+});
+
+test("no entries at all is refused rather than planned", () => {
+  const plan = planOrphanReviewRemoval([], [review("r1", "e1", "text")]);
+
+  assert.match(plan.blocked, /refusing/);
+  assert.deepEqual(plan.orphans, []);
+});
+
+test("no entries and no reviews is not a failure, just nothing to do", () => {
+  const plan = planOrphanReviewRemoval([], []);
+
+  assert.equal(plan.blocked, undefined);
+  assert.deepEqual(plan.orphans, []);
+});
+
+test("a review carrying no entryRef is orphaned, and never matched to an entry by accident", () => {
+  const plan = planOrphanReviewRemoval(
+    [entry("undefined"), entry("null")],
+    [review("r1", undefined, "x"), review("r2", null, "y")]
+  );
+
+  assert.deepEqual(plan.orphans.map((r) => r._id), ["r1", "r2"]);
+});
+
+test("ids are compared as strings, so a numeric ref still matches its entry", () => {
+  const plan = planOrphanReviewRemoval([entry("322682678")], [review("r1", 322682678, "x")]);
+
+  assert.deepEqual(plan.orphans, []);
+  assert.equal(plan.keptCount, 1);
+});
+
+test("orphans are split by whether anyone actually wrote anything", () => {
+  const plan = planOrphanReviewRemoval(
+    [entry("e1")],
+    [review("r1", "gone", "a note"), review("r2", "gone", ""), review("r3", "gone")]
+  );
+
+  assert.deepEqual(plan.withText.map((r) => r._id), ["r1"]);
+  assert.deepEqual(plan.empty.map((r) => r._id), ["r2", "r3"]);
+  assert.equal(plan.orphans.length, 3);
+});
+
+test("nothing is planned for removal when every review still has its entry", () => {
+  const plan = planOrphanReviewRemoval(
+    [entry("e1"), entry("e2")],
+    [review("r1", "e1", "x"), review("r2", "e2", "y")]
+  );
+
+  assert.deepEqual(plan.orphans, []);
+  assert.equal(plan.keptCount, 2);
+});
+
+test("a non-array argument is refused, not coerced", () => {
+  assert.match(planOrphanReviewRemoval(undefined, []).blocked, /must both be arrays/);
+  assert.match(planOrphanReviewRemoval([], null).blocked, /must both be arrays/);
+});
+
+test("hasText is about there being writing, not about the field existing", () => {
+  assert.equal(hasText({ text: "words" }), true);
+  assert.equal(hasText({ text: "" }), false);
+  assert.equal(hasText({}), false);
+  assert.equal(hasText({ text: null }), false);
+  assert.equal(hasText(undefined), false);
+});
+
+test("re-running over the result of a run finds nothing left to do", () => {
+  const entries = [entry("e1")];
+  const reviews = [review("r1", "e1", "kept"), review("r2", "gone", "orphan")];
+
+  const first = planOrphanReviewRemoval(entries, reviews);
+  const removed = new Set(first.orphans.map((r) => r._id));
+  const after = reviews.filter((r) => !removed.has(r._id));
+
+  assert.deepEqual(planOrphanReviewRemoval(entries, after).orphans, []);
+});

--- a/src/db_maintenance/scripts/audit_database.js
+++ b/src/db_maintenance/scripts/audit_database.js
@@ -27,6 +27,7 @@ const {
   isMissingPlaytimeLink,
 } = require("../work_metadata_merge");
 const { groupWorksByApiRef } = require("../work_dedupe_plan");
+const { toSummary, countProblems } = require("../audit_report");
 
 const args = parseArgs(process.argv);
 
@@ -55,9 +56,19 @@ const main = async () => {
     report[collection.type] = await auditCollection(db, collection);
   }
 
+  // One number for "is anything actually wrong", so a clean run says so
+  // instead of leaving a reader to add up ten lines per collection and decide
+  // for themselves which of them counted.
+  const problems = countProblems(selected, report);
+  console.log(
+    problems === 0
+      ? "\nNo problems found."
+      : `\n${problems} problem(s) found across ${selected.length} collection(s).`
+  );
+
   if (args.json) {
     fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
-    console.log(`\nFull report written to ${args.json}`);
+    console.log(`Full report written to ${args.json}`);
   }
 
   await client.close();
@@ -169,30 +180,28 @@ const describe = (work) => ({
   apiRefs: work.apiRefs,
 });
 
-const printSummary = (collection, r) => {
+const printSummary = (collection, result) => {
+  const { problems, notes } = toSummary(collection, result);
+
   console.log(`\n=== ${collection.works} ===`);
   console.log(
-    `  works: ${r.works}, entries: ${r.entries}, reviews: ${r.reviews}`
+    `  works: ${result.works}, entries: ${result.entries}, ` +
+      `reviews: ${result.reviews}`
   );
-  const lines = [
-    [`no ${collection.retrievePrefix}__ ref (cannot be refreshed)`, r.noApiRef],
-    ["apiRefs still stored as objects", r.legacyObjectApiRefs],
-    ["missing metadata fields", r.missingFields],
-    ["corrupt field values", r.corruptFields],
-    ...(collection.type === "games"
-      ? [["playtime with nothing to link it to", r.gamesMissingPlaytimeLink]]
-      : []),
-    ["duplicate works sharing an apiRef", r.duplicateWorks],
-    ["works no entry points at", r.orphanWorks],
-    ["entries with no workRef", r.entriesWithoutWorkRef],
-    ["entries with a dangling workRef", r.entriesWithDanglingWorkRef],
-    ["reviews with no entry", r.orphanReviews],
-  ];
-  for (const [label, items] of lines) {
-    console.log(`  ${String(items.length).padStart(5)}  ${label}`);
+
+  for (const line of problems) {
+    console.log(`  ${String(line.count).padStart(5)}  ${line.label}`);
   }
 
-  const examples = r.missingFields.slice(0, 5);
+  // Below the problems and marked, because these are supported states rather
+  // than damage — printed in the same list, the user-authored entries were
+  // read as broken ones. See ../audit_report.js.
+  console.log("  --- not problems, for information ---");
+  for (const line of notes) {
+    console.log(`  ${String(line.count).padStart(5)}  ${line.label}`);
+  }
+
+  const examples = result.missingFields.slice(0, 5);
   if (examples.length > 0) {
     console.log("  e.g. missing:");
     for (const e of examples) {

--- a/src/db_maintenance/scripts/prune_orphan_reviews.js
+++ b/src/db_maintenance/scripts/prune_orphan_reviews.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * @file Deletes reviews whose entry no longer exists.
+ *
+ * A review is only ever found by `entryRef`, so one whose entry is gone is
+ * unreachable by every code path the site has. They accumulated because until
+ * #117 (2026-08-12) deleting an entry left its review behind; the population
+ * is that bug's backlog rather than an ongoing leak.
+ *
+ * This is the only script here that writes to a collection other than the
+ * work collections, and it does so deliberately: the note it removes belonged
+ * to an entry the user deleted. Every one of the 248 found in August 2026 was
+ * read before this was run — the ones holding text were attributed to the work
+ * they belonged to, and the surviving note was confirmed to be the fuller
+ * version. See ../README.md.
+ *
+ * It never touches `*Entries`, so no user override or live note is reachable
+ * from here, and a review it removes is restorable by `_id` from the snapshot
+ * taken immediately before the run.
+ *
+ * Environment (../.env): MONGODB_URL. No API keys needed.
+ *
+ * Usage:
+ *   node scripts/prune_orphan_reviews.js
+ *   node scripts/prune_orphan_reviews.js --only=games
+ *   node scripts/prune_orphan_reviews.js --apply
+ *
+ * Flags:
+ *   --apply             actually delete (default: dry run)
+ *   --only=a,b          restrict to these types (films, tv, games, books)
+ *   --json=path         write a machine-readable report
+ *   --backup-dir=path   where to put the pre-run backups (default ../backups)
+ */
+require("../env");
+const fs = require("fs");
+const path = require("path");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const {
+  COLLECTIONS,
+  selectCollections,
+  parseArgs,
+} = require("../work_collections");
+const { planOrphanReviewRemoval } = require("../orphan_review_plan");
+
+const args = parseArgs(process.argv);
+
+const options = {
+  apply: args.apply === true,
+  backupDir: String(args["backup-dir"] ?? path.join(__dirname, "..", "backups")),
+};
+
+let client;
+
+const main = async () => {
+  const selected = selectCollections(args.only);
+  if (selected.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Valid types: ${COLLECTIONS.map(
+        (c) => c.type
+      ).join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    options.apply
+      ? "APPLY MODE: unreachable reviews will be deleted."
+      : "DRY RUN: nothing will be written. Re-run with --apply to commit."
+  );
+
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const report = {};
+  let blocked = false;
+  for (const collection of selected) {
+    const result = await pruneCollection(db, collection);
+    report[collection.type] = result;
+    if (result.blocked) blocked = true;
+  }
+
+  const totals = Object.values(report).reduce(
+    (sum, r) => ({
+      orphans: sum.orphans + (r.orphans ?? 0),
+      withText: sum.withText + (r.withText ?? 0),
+    }),
+    { orphans: 0, withText: 0 }
+  );
+  console.log(
+    `\n${totals.orphans} unreachable review(s) in total, ` +
+      `${totals.withText} of them holding text.`
+  );
+
+  if (blocked) {
+    console.error(
+      "\nOne or more collections were refused. Nothing was deleted for those. " +
+        "This means an entry collection came back empty, which is what a failed " +
+        "read looks like — check the connection before re-running."
+    );
+    process.exitCode = 1;
+  }
+
+  if (args.json) {
+    fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
+    console.log(`Full report written to ${args.json}`);
+  }
+
+  await client.close();
+};
+
+const pruneCollection = async (db, collection) => {
+  console.log(`\n=== ${collection.reviews} ===`);
+
+  const entries = await db.collection(collection.entries).find().toArray();
+  const reviews = await db.collection(collection.reviews).find().toArray();
+
+  const plan = planOrphanReviewRemoval(entries, reviews);
+
+  if (plan.blocked) {
+    console.error(`  REFUSED: ${plan.blocked}`);
+    return { blocked: plan.blocked };
+  }
+
+  console.log(
+    `  ${reviews.length} review(s), ${entries.length} entries, ` +
+      `${plan.orphans.length} unreachable ` +
+      `(${plan.withText.length} holding text, ${plan.empty.length} empty)`
+  );
+
+  if (plan.orphans.length === 0) {
+    return { reviews: reviews.length, orphans: 0, withText: 0, deleted: 0 };
+  }
+
+  // The text is a user's writing; its length is enough to size what is going
+  // without printing it into a terminal log.
+  for (const review of plan.withText) {
+    console.log(
+      `      ${review._id} (entryRef ${review.entryRef}, ${review.text.length} chars)`
+    );
+  }
+
+  const base = {
+    reviews: reviews.length,
+    orphans: plan.orphans.length,
+    withText: plan.withText.length,
+    ids: plan.orphans.map((r) => String(r._id)),
+  };
+
+  if (!options.apply) return { ...base, deleted: 0 };
+
+  backup(collection.reviews, reviews);
+
+  const result = await db
+    .collection(collection.reviews)
+    .deleteMany({ _id: { $in: plan.orphans.map((r) => r._id) } });
+
+  console.log(`  deleted ${result.deletedCount} review(s)`);
+  return { ...base, deleted: result.deletedCount };
+};
+
+const backup = (collectionName, documents) => {
+  fs.mkdirSync(options.backupDir, { recursive: true });
+  const file = path.join(
+    options.backupDir,
+    `${collectionName}_${new Date().toISOString().replace(/:/g, "-")}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(documents, null, 2));
+  console.log(`  backed up ${documents.length} document(s) to ${file}`);
+};
+
+main().catch(async (e) => {
+  console.error(e);
+  process.exitCode = 1;
+  await client?.close();
+});


### PR DESCRIPTION
Two things, from one false alarm.

## The false alarm

An integrity check was read as finding 23 entries whose `workRef` points at a work document that doesn't exist — 5 films, 3 tv, 8 games, 7 books. It didn't. The audit reports two things one line apart, in identical formatting, and the counts came off the wrong one.

```
      5  entries with no workRef          ← where 5/3/8/7 = 23 came from
      0  entries with a dangling workRef  ← the actual integrity violation
```

Dangling is **0**, in production and in every snapshot back to 2026-08-11. The 23 have no `workRef` property at all, which is a supported state: `readForm` in `frontend/_includes/js/utils/entry_form_io.js` sets `workRef: data?.commonMetadata?.internalRef`, `undefined` when the user typed a title instead of picking a search result. Those entries carry their metadata in `overrides`, `list.js` merges it over `commonMetadata`, and they render correctly — the `$lookup` finding nothing is the designed path. The titles confirm it: unreleased sequels (*Terraria 2*, *Avatar: Fire and Ash*), announced-but-unaired shows (*Alien*, *Neuromancer*), a Doom Eternal mod, *Dungeons & Dragons 5e*, short stories with no ISBN, and two 2022 test rows. None ever had a `workRef` to lose.

So the defect was in the report. The summary now prints the problems, then a short `--- not problems, for information ---` block, with the dangling count leading the problems since it is the one that means a user's row renders empty. Both `workRef` lines are relabelled so neither reads as the other. `orphanWorks` moves to the notes on the same reasoning — a cached work nothing points at is cache residue. That one is the judgement call worth arguing with; it is one `kind` in the table.

The classification lives in `audit_report.js`, pure and tested, with the I/O left in the script. One test asserts the two `workRef` labels can't be confused, since that is the failure being fixed. A run now ends with a total, so a clean audit says "No problems found." instead of leaving a reader to sum ten lines and decide which counted.

## The real problem it was hiding

`reviews whose entry is gone` was genuine: **248** of them — 44 films, 14 tv, 150 games, 40 books. A review is only ever looked up by `entryRef` (`getReview` in `api/controllers/reviews.js`), so one whose entry is gone cannot be read, edited or deleted by anything the site does.

None was written unattached. Each was saved against an entry that existed and was deleted later, and until #117 (2026-08-12) a delete removed the entry and left the review. The 248 are that bug's entire backlog, not an ongoing leak. Dating them settles it, and the method is in the README so it can be re-checked: Fauna ids are allocated in creation order at ~1.027e6 units per millisecond, a rate that fits all 3189 surviving numeric entries with zero violations. All 177 numeric orphan `entryRef`s decode to 2022, sit inside the surviving id range, and are a median of zero seconds from an entry that is still there.

**171 were empty**, because `createEntry` writes a review document whether or not a note was typed. Of the 77 holding text, **27 duplicated a surviving note verbatim** — what deleting a row and re-adding the same title leaves behind. **50 held text found nowhere else, and all 50 were read before anything was deleted.** Each was attributed to its work from the note's content plus 4-gram overlap against all 2768 surviving notes; in every case the surviving note was the fuller version and the orphan an earlier draft. The owner reviewed them and confirmed.

What genuinely did not survive was 2,793 characters across 10 entries — mostly reference links (comic readers, an RPCS3 setup guide, wikidot pages) and a block of weapon notes on *Blood*. That was reported for hand-merging **through the app**, deliberately not scripted: the note lives in both `entry.review` and the review document, in sync across all 810 entries that carry both, and a script writing one and not the other would create the first divergence in the database. Editing through the app writes both and records a revision.

`scripts/prune_orphan_reviews.js` then removed all 248. The decision is a pure module; its sharpest test is the empty-entry-list case, because planning from one would mark every review orphaned — exactly what a failed collection read looks like from in there, since the query returns `[]` and nothing throws. That combination is refused rather than planned.

This is the first script here to write outside the work collections, so both READMEs and the root `CLAUDE.md` now record it, and record that a second exception is a human's call. It reads `*Entries` but never writes to them, so no override and no live note is reachable from it.

## The run

Snapshot `snapshot-2026-08-19T02-51-54-658Z`, verified across all 14 collections — manifest counts, file counts and live `countDocuments()` agreed everywhere, checksums matched. Dry run reported 248 (44/14/150/40, 77 holding text). The apply deleted 248, backing up each review collection first. Afterwards: entry counts unchanged at 1527/548/1089/660, zero unreachable reviews, dangling `workRef` still zero.

`npm test` — 387 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
