### PR TITLE
chore: upgrade jose to the last version this runtime can require

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.2.3",
         "html-minifier": "^4.0.0",
         "igdb-api-node": "^5.0.1",
-        "jose": "^2.0.2",
+        "jose": "^4.15.9",
         "mongodb": "^6.20.0",
         "neverthrow": "^4.3.1",
         "node-themoviedb": "^0.2.8",
@@ -288,14 +288,6 @@
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -1744,15 +1736,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.2.tgz",
-      "integrity": "sha512-yD93lsiMA1go/qxSY/vXWBodmIZJIxeB7QhFi8z1yQ3KUwKENqI9UA8VCHlQ5h3x1zWuWZjoY87ByQzkQbIrQg==",
-      "dependencies": {
-        "@panva/asn1.js": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0 < 13 || >=13.7.0"
-      },
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -18239,14 +18226,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/openid-client/node_modules/jose": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
-      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/openid-client/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -19024,11 +19003,6 @@
         "@netlify/node-cookies": "^0.1.0",
         "urlpattern-polyfill": "8.0.2"
       }
-    },
-    "@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@sindresorhus/is": {
       "version": "4.3.0",
@@ -20015,12 +19989,9 @@
       "integrity": "sha512-ZFar/L4ngX7wZh2QX+Fiftmuf0igWJsrJtfizrovWifF1gAWkfmRa5Z1m0LQZbm0hKCHRDYhLRSLFrSqNe4EJA=="
     },
     "jose": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.2.tgz",
-      "integrity": "sha512-yD93lsiMA1go/qxSY/vXWBodmIZJIxeB7QhFi8z1yQ3KUwKENqI9UA8VCHlQ5h3x1zWuWZjoY87ByQzkQbIrQg==",
-      "requires": {
-        "@panva/asn1.js": "^1.0.0"
-      }
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -32035,11 +32006,6 @@
         "oidc-token-hash": "^5.0.1"
       },
       "dependencies": {
-        "jose": {
-          "version": "4.10.0",
-          "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
-          "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw=="
-        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dotenv": "^17.2.3",
     "html-minifier": "^4.0.0",
     "igdb-api-node": "^5.0.1",
-    "jose": "^2.0.2",
+    "jose": "^4.15.9",
     "mongodb": "^6.20.0",
     "neverthrow": "^4.3.1",
     "node-themoviedb": "^0.2.8",

--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -1,7 +1,7 @@
 // file mostly copypasted from:
 // https://github.com/jamesqquick/netlify-auth0-rbac-integration-demo/blob/master/functions/AuthUtils.js
 const { Issuer, generators } = require("openid-client")
-const { JWT } = require("jose")
+const { SignJWT, jwtVerify } = require("jose")
 const cookie = require("cookie")
 
 const NETLIFY_JWT_EXPIRATION_SECONDS = 14 * 24 * 3600
@@ -10,6 +10,15 @@ const LOGIN_COOKIE_MAX_AGE = 30 * 60
 const AUTH0_LOGIN_COOKIE_NAME = "auth0_login_cookie"
 const NETLIFY_COOKIE_NAME = "nf_jwt"
 const isRunningLocally = process.env.NETLIFY_DEV === "true"
+
+/* HS256 signs with bytes, not with a string, and the secret is read at call
+   time rather than at import time so a function that never touches a token
+   does not care whether TOKEN_SECRET is set. */
+const tokenSecret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
+
+/* Naming the algorithm on the way in is what stops a caller choosing it for
+   us by sending a token whose header says something else. */
+const VERIFY_OPTIONS = { algorithms: ["HS256"] }
 
 const getOpenIDClient = async () => {
   const issuer = await Issuer.discover(`https://${process.env.AUTH0_DOMAIN}`)
@@ -34,12 +43,11 @@ const signNetlifyJWT = async ({ aud, sub, roles }) => {
       authorization: { roles },
     },
   }
-  return await JWT.sign(tokenPayload, process.env.TOKEN_SECRET, {
-    algorithm: "HS256",
-    header: {
-      typ: "JWT",
-    },
-  })
+  /* Netlify insists on `typ`, and the payload carries its own `exp` and
+     `iat`, so none of `SignJWT`'s claim setters are wanted here. */
+  return await new SignJWT(tokenPayload)
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .sign(tokenSecret())
 }
 
 //copy over appropriate properties from the original token data
@@ -212,7 +220,7 @@ const handleRenew = async (event) => {
   try {
     /* A token still inside its renewal window verifies fine, so a failure here
        means the session is genuinely over and the user has to log in again. */
-    claims = JWT.verify(currentToken, process.env.TOKEN_SECRET)
+    claims = (await jwtVerify(currentToken, tokenSecret(), VERIFY_OPTIONS)).payload
   } catch (err) {
     return {
       statusCode: 401,

--- a/src/api/controllers/auth_token.test.js
+++ b/src/api/controllers/auth_token.test.js
@@ -1,0 +1,116 @@
+/**
+ * @file The session token, against the real `jose` rather than a stand-in.
+ *
+ * Every other controller test replaces `jose` with something that takes the
+ * token at its word, because none of them is about the token. This one is,
+ * and it exists because nothing was: `getUserId` used to *throw* on a token
+ * that failed to verify rather than answer `Err`, which reached the caller
+ * as a 502, and an expired session is the ordinary way to arrive there.
+ *
+ * It needs the dependencies, so it **skips itself** when they aren't
+ * installed — which is how CI runs the suite.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('jose')
+    require('neverthrow')
+    require('ramda')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
+process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+
+const jose = dependenciesInstalled ? require('jose') : undefined
+const { getUserId } = dependenciesInstalled ? require('./utils') : {}
+
+const secret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
+
+/** A token shaped like the one `signNetlifyJWT` mints. */
+const sign = ({ sub = 'auth0|somebody', exp, key = secret() } = {}) => {
+  const iat = Math.floor(Date.now() / 1000)
+  return new jose.SignJWT({
+    exp: exp ?? iat + 14 * 24 * 3600,
+    iat,
+    updated_at: iat,
+    aud: 'memo',
+    sub,
+    app_metadata: { authorization: { roles: ['user'] } },
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(key)
+}
+
+const asEvent = (token) => ({
+  headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+})
+
+test('a valid token answers with its subject', options, async () => {
+  const result = await getUserId(asEvent(await sign({ sub: 'auth0|nil' })))
+
+  assert.equal(result.isOk(), true)
+  assert.equal(result._unsafeUnwrap(), 'auth0|nil')
+})
+
+test('a token that does not verify is unauthorized, not an exception', options, async (t) => {
+  // The whole point of the file. `Result.map` does not catch, so each of these
+  // used to throw out of the controller and out of the handler, and Netlify
+  // answered 502 — including for the expired token, which is what an ordinary
+  // session becomes after a fortnight.
+  const iat = Math.floor(Date.now() / 1000)
+  const otherKey = new TextEncoder().encode('not the secret we sign with')
+
+  const cases = {
+    'no Authorization header': undefined,
+    'not a JWT at all': 'nonsense',
+    'three segments of junk': 'a.b.c',
+    'signed with another key': await sign({ key: otherKey }),
+    'expired an hour ago': await sign({ exp: iat - 3600 }),
+  }
+
+  for (const [name, token] of Object.entries(cases)) {
+    await t.test(name, async () => {
+      const result = await getUserId(asEvent(token))
+
+      assert.equal(result.isErr(), true)
+      assert.equal(result._unsafeUnwrapErr().error, 'UnauthorizedError')
+    })
+  }
+})
+
+test('the algorithm is ours to choose, not the token\'s', options, async () => {
+  // Without `algorithms` on the way in, a token gets to nominate how it should
+  // be checked. `alg: none` is the version of that with no signature at all.
+  const [, payload] = (await sign()).split('.')
+  const header = Buffer.from('{"alg":"none","typ":"JWT"}').toString('base64url')
+
+  const result = await getUserId(asEvent(`${header}.${payload}.`))
+
+  assert.equal(result.isErr(), true)
+})
+
+test('nothing the token said reaches the caller', options, async () => {
+  // `detail` is for the log; `message` is what a stranger is told. An
+  // unauthorized error names neither the claim that failed nor the subject.
+  const result = await getUserId(asEvent(await sign({ sub: 'auth0|private-id' })))
+  const expired = await getUserId(
+    asEvent(await sign({ sub: 'auth0|private-id', exp: 1 }))
+  )
+
+  assert.equal(result.isOk(), true)
+  assert.equal(expired._unsafeUnwrapErr().message, undefined)
+  assert.equal(
+    JSON.stringify(expired._unsafeUnwrapErr()).includes('auth0|private-id'),
+    false,
+  )
+})

--- a/src/api/controllers/bio.js
+++ b/src/api/controllers/bio.js
@@ -6,19 +6,19 @@
 const responses = require('../utils/responses')
 const { combine } = require('neverthrow')
 const { getUserId, getReqBody } = require('./utils')
-const { pair, toPromise } = require('../utils/general')
+const { pair, toAsync, toPromise } = require('../utils/general')
 const db = require('../utils/db/')
 
 /** @type {(event: Event, context: Context) => Promise<Response>} */
 const setBio = (event) => toPromise(
   combine(pair([
     getUserId(event),
-    getReqBody(event)
+    toAsync(getReqBody(event))
   ]))
     // A valid token for a `sub` with no user document — which is every account
     // between signing up and `setOwnName` running — is a 404 rather than the
     // 502 that destructuring the db module's `{}` used to give. See #139.
-    .asyncAndThen(([uid, { newBio }]) =>
+    .andThen(([uid, { newBio }]) =>
       db.findOneByFieldOrFail_('users', 'userId', uid)
         .map(({ ref }) => [ref, newBio])
     )

--- a/src/api/controllers/entries.js
+++ b/src/api/controllers/entries.js
@@ -37,10 +37,10 @@ const getAllEntriesForUser = (event) => toPromise(
 const createNewUserListEntry = (event) => toPromise(
   combine(triplet([
     getUserId(event),
-    getReqBody(event),
-    toEntryCollection(getSegment(0, event)),
+    toAsync(getReqBody(event)),
+    toAsync(toEntryCollection(getSegment(0, event))),
   ]))
-    .asyncMap(createEntry)
+    .map(createEntry)
     .mapErr(responses.fromError)
 )
 
@@ -49,7 +49,7 @@ const updateEntry = (event) => toPromise(
   toEntryCollection(getSegment(0, event))
     .asyncAndThen((col) =>
       combine(quad([
-        toAsync(getUserId(event)),
+        getUserId(event),
         toAsync(getReqBody(event)),
         okAsync(col),
         db.findOneByRef_(col, getSegment(1, event)),
@@ -64,7 +64,7 @@ const deleteEntry = (event) => toPromise(
   toEntryCollection(getSegment(0, event))
     .asyncAndThen((col) =>
       combine(triplet([
-        toAsync(getUserId(event)),
+        getUserId(event),
         okAsync(col),
         db.findOneByRef_(col, getSegment(1, event)),
       ]))

--- a/src/api/controllers/entries.test.js
+++ b/src/api/controllers/entries.test.js
@@ -158,7 +158,11 @@ class MongoClient {
 const loadModule = Module._load
 Module._load = function (request, ...args) {
   if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
-  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  // jose verifies asynchronously from v4 on, and answers with the payload
+  // wrapped rather than the payload itself. A test's token is its user id.
+  if (request === 'jose') {
+    return { jwtVerify: async (token) => ({ payload: { sub: token } }) }
+  }
   return loadModule.call(this, request, ...args)
 }
 

--- a/src/api/controllers/name.js
+++ b/src/api/controllers/name.js
@@ -4,7 +4,7 @@
 /** @typedef {import('../utils/errors').Error} Error */
 const { combine, okAsync, ResultAsync } = require('neverthrow')
 const { findOneByField_, updateByRef_, create_ } = require('../utils/db')
-const { pair, toPromise } = require('../utils/general')
+const { pair, toAsync, toPromise } = require('../utils/general')
 const responses = require('../utils/responses')
 const { getUserId, getReqBody, getSegment } = require('./utils')
 const feErrors = require('../utils/frontend_errors')
@@ -12,7 +12,7 @@ const feErrors = require('../utils/frontend_errors')
 /** @type {(event: Event) => Promise<Response>} */
 const findOwnName = (event) => toPromise(
   getUserId(event)
-    .asyncAndThen((userId) => findOneByField_('users', 'userId', userId))
+    .andThen((userId) => findOneByField_('users', 'userId', userId))
     .map(({ data }) => data
       ? responses.ok({ username: data.username })
       : responses.ok(feErrors.noUsernameSet())
@@ -40,9 +40,9 @@ const getUserIdFromName = (event) => toPromise(
 const setOwnName = (event) => toPromise(
   combine(pair([
     getUserId(event),
-    getReqBody(event)
+    toAsync(getReqBody(event))
   ]))
-    .asyncAndThen(assignNameIfNotTaken)
+    .andThen(assignNameIfNotTaken)
     .mapErr(responses.fromError)
 )
 

--- a/src/api/controllers/name.test.js
+++ b/src/api/controllers/name.test.js
@@ -117,7 +117,11 @@ class MongoClient {
 const loadModule = Module._load
 Module._load = function (request, ...args) {
   if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
-  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  // jose verifies asynchronously from v4 on, and answers with the payload
+  // wrapped rather than the payload itself. A test's token is its user id.
+  if (request === 'jose') {
+    return { jwtVerify: async (token) => ({ payload: { sub: token } }) }
+  }
   return loadModule.call(this, request, ...args)
 }
 

--- a/src/api/controllers/revisions.js
+++ b/src/api/controllers/revisions.js
@@ -28,7 +28,7 @@ const {
   toEntryType,
   toReviewCollection,
 } = require('./utils')
-const { triplet, toAsync, toPromise, warn } = require('../utils/general')
+const { triplet, toPromise, warn } = require('../utils/general')
 const {
   toSnapshot,
   hasChanges,
@@ -189,7 +189,7 @@ const withOwnedEntry = (event, respond) => toPromise(
   toEntryCollection(getSegment(0, event))
     .asyncAndThen((collection) =>
       combine(triplet([
-        toAsync(getUserId(event)),
+        getUserId(event),
         okAsync(collection),
         db.findOneByRef_(collection, getSegment(1, event)),
       ]))

--- a/src/api/controllers/revisions.test.js
+++ b/src/api/controllers/revisions.test.js
@@ -117,7 +117,11 @@ class MongoClient {
 const loadModule = Module._load
 Module._load = function (request, ...args) {
   if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
-  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  // jose verifies asynchronously from v4 on, and answers with the payload
+  // wrapped rather than the payload itself. A test's token is its user id.
+  if (request === 'jose') {
+    return { jwtVerify: async (token) => ({ payload: { sub: token } }) }
+  }
   return loadModule.call(this, request, ...args)
 }
 

--- a/src/api/controllers/stats.test.js
+++ b/src/api/controllers/stats.test.js
@@ -111,7 +111,11 @@ class MongoClient {
 const loadModule = Module._load
 Module._load = function (request, ...args) {
   if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
-  if (request === 'jose') return { JWT: { verify: (token) => ({ sub: token }) } }
+  // jose verifies asynchronously from v4 on, and answers with the payload
+  // wrapped rather than the payload itself. A test's token is its user id.
+  if (request === 'jose') {
+    return { jwtVerify: async (token) => ({ payload: { sub: token } }) }
+  }
   return loadModule.call(this, request, ...args)
 }
 

--- a/src/api/controllers/utils.js
+++ b/src/api/controllers/utils.js
@@ -7,13 +7,42 @@ const errors = require('../utils/errors')
 const db = require('../utils/db')
 const workTypes = require('../utils/work_types')
 const { validateExists } = require('../utils/general')
-const { JWT } = require("jose")
+const { identity } = require('ramda')
+const { jwtVerify } = require("jose")
 
-/** @type {(event: Event) => Result<string, Error>} */
+/* HS256 verifies against bytes, not a string, and the secret is read at call
+   time so that importing this module does not require it to be set. Naming
+   the algorithm is what stops a caller picking one for us in the token's own
+   header. */
+const tokenSecret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
+const VERIFY_OPTIONS = { algorithms: ['HS256'] }
+
+/**
+ * The `sub` of the bearer token, or an unauthorized error.
+ *
+ * `ResultAsync` rather than `Result` because verification is a promise from
+ * jose v4 onward. That is the whole reason this returns what it returns, and
+ * why every caller reaches it through `combine` on a list of `ResultAsync`.
+ *
+ * It also fixes something the synchronous version got wrong. `Result.map`
+ * does not catch, so a token that failed to verify did not become an `Err` —
+ * it threw out of here, out of the controller, and out of the async handler,
+ * and Netlify answered 502. Only a *missing* Authorization header ever
+ * produced the 401. An expired session is the common case of that: every
+ * authenticated request answered 502 until the user worked out they had to
+ * log in again. `ResultAsync.fromPromise` catches the rejection, so a bad
+ * token, a tampered one and an expired one are all 401 now. See #139 for the
+ * same shape of bug one layer down.
+ *
+ * @type {(event: Event) => ResultAsync<string, Error>}
+ */
 const getUserId = (event) =>
-   validateExists(event.headers?.authorization)
+  validateExists(event.headers?.authorization)
     .map((authString) => authString.replace('Bearer ', ''))
-    .map((jwt) => JWT.verify(jwt, process.env.TOKEN_SECRET).sub)
+    .asyncAndThen((jwt) =>
+      ResultAsync.fromPromise(jwtVerify(jwt, tokenSecret(), VERIFY_OPTIONS), identity)
+    )
+    .map(({ payload }) => payload.sub)
     .mapErr(errors.unauthorized)
 
 /** @type {(segmentIndex: number, event: Event) => string} */


### PR DESCRIPTION
The last of the six in #144, rebased onto `main` after #169. **Closes #144.**

`jose` `^2.0.2` → `^4.15.9`. v2 has been unmaintained for years.

## Why v4 and not 5 or 6

The first version of this PR went to 6, and #169 is the reason it does not now. jose dropped its CommonJS build at v5: the `exports` map has no `require` condition, so `require("jose")` in a CommonJS function throws `ERR_REQUIRE_ESM` on the deployed functions runtime — while the module is being read, before any handler runs, which is why that failure mode takes out every route at once rather than one path.

That is exactly what my `uuid` bump in #162 did to this site, and I got it wrong here for the same reason: `require(esm)` works from Node 22.12, so the suite, the CI install and the build all loaded jose 6 happily on a Node 22 binary I checked against deliberately. The functions runtime is the only place the difference shows, and I had no way to see it from here. I should have weighted that risk far higher on #162 than I did, and flagging it in the first draft of this PR was not the same as not shipping it.

The guard #169 added catches it now. On this branch at jose 6:

```
$ node --no-experimental-require-module -e "require('./src/api/routes/auth.js')"
const { jwtVerify } = require("jose")
                      ^
Error [ERR_REQUIRE_ESM]
```

and at jose 4, all ten routes:

```
ok: src/api/routes/auth.js
ok: src/api/routes/bio.js
… ok: src/api/routes/works.js
```

v4 is the last release with a `require` condition, and it already has the promise-based API that 5 and 6 kept — so the code in this diff is the code those versions want, and going to them later is a packaging problem, not another rewrite. `crypto` has no equivalent to stand in the way `randomUUID` did for `uuid`.

## The API change

`JWT.sign` and `JWT.verify` were synchronous and are gone from v4 onward. The replacements are `new SignJWT(payload).setProtectedHeader({ alg, typ }).sign(key)` and `jwtVerify(token, key)`, both promises, and HS256 takes the secret as bytes rather than as a string. In `auth.js` that is the whole diff.

## The ripple

`getUserId` returns `ResultAsync` now. Six call sites across four controllers reach it through `combine`, and neverthrow has one `combine` for a list of `Result` and another for a list of `ResultAsync` — no mixed list. So each list it appears in became all-async: `toAsync` moves from wrapping `getUserId` to wrapping whichever sync sibling it was combined with, and the `asyncAndThen` / `asyncMap` that followed become `andThen` / `map`. `revisions.js` loses its `toAsync` import entirely.

## The bug this fixes

`Result.map` does not catch. So `JWT.verify` throwing never produced an `Err` — it threw out of `getUserId`, out of the controller, and out of the async handler, and Netlify answered **502**. Only a *missing* `Authorization` header ever became a 401.

The expired case is not exotic: it is what every session becomes after a fortnight, on every authenticated request, until the user works out for themselves that logging in again fixes it. Measured against `main`, with real jose 2:

```
no header:       Err({"error":"UnauthorizedError"})     -> 401
garbage token:   THREW JWTMalformed                     -> 502
expired token:   THREW JWTExpired                       -> 502
wrong signature: THREW JWSVerificationFailed            -> 502
```

`ResultAsync.fromPromise` catches the rejection, so all four are 401 now. Same shape as #139, one layer up.

Verification also names the algorithm on the way in (`{ algorithms: ['HS256'] }`), so a token cannot nominate how it should be checked.

## What I verified

Against real jose 4, driving the real `getUserId` and the real `handleRenew`, **under `--no-experimental-require-module`** so the loader matches production:

- **A cookie minted by the old jose 2 code still verifies under the new one.** This is what decides whether merging logs everybody out mid-session, and it does not.
- **A token minted by the new code still verifies under jose 2**, so a rollback does not either.
- The new token is what Netlify expects: protected header exactly `{"alg":"HS256","typ":"JWT"}`, payload `app_metadata, aud, exp, iat, sub, updated_at`, roles as `{"authorization":{"roles":["user"]}}`, expiry slid a fortnight forward.
- `handleRenew` — 200 and a fresh `nf_jwt` on a live token, 401 plus the clearing cookie on an expired one, 401 on no token.
- The four failure modes above, and `alg: none`, all `Err(UnauthorizedError)`.
- All ten routes load under the #169 guard.

`auth_token.test.js` is new and pins the parts of that which do not need a tenant. It uses the real `jose`, unlike every other controller test — the stand-in they install is exactly what let this go unnoticed. 344 pass with dependencies, 339/45-skipped without, and its 9 also pass under `--no-experimental-require-module`. Worth knowing that CI does *not* run it: the `test` job is install-free by design and the `build` job installs but only builds. Adding `npm test` to the build job would fix that for every dependency-requiring test in the repo, and belongs in its own PR.

`npm ci`, `npm run build` in both modes, `dist/` identical to `main`'s.

## What I could not verify

**The Auth0 round-trip.** `handleLogin` and `handleCallback` go through `openid-client` to a real tenant. Untouched here except that the callback mints its cookie with `SignJWT` — the same bytes, per the checks above — but please click login, reload and log out on the deploy preview before merging. Given #169 I would not take my word for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
