### PR TITLE
docs: write down that the API cannot depend on an ES-module-only package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,57 @@ Same trick for regenerating `package-lock.json`: run
 `npm install --package-lock-only` on the local copy and copy the lockfile
 back.
 
+## The API cannot depend on an ES-module-only package
+
+**Anything `src/api/routes/**` can reach has to be requireable from
+CommonJS.** The deployed functions runtime cannot `require` an ES module.
+The failure is not a bad response from one route — the throw happens while
+the module is being read, before a handler runs, so every route 502s at
+once: entries, stats, export, auth, the lot. `uuid` 13 did that to
+production (#162, fixed by #169) and `jose` 6 would have done it again
+(#168).
+
+**Nothing local will tell you.** `require(esm)` works from Node 22.12, so
+the suite, the CI install and the build all load an ESM-only package
+perfectly happily — and this repo builds on Node 22 deliberately, so that
+agreement looks like confirmation. The functions runtime is the only place
+the difference shows, and you cannot get to it from here.
+
+So after bumping anything the API imports, ask the loader rather than
+reading the package's own metadata — an `exports` map without a `require`
+condition means ESM-only, but plenty of requireable packages have no
+`exports` map at all, and `mongodb` is one of them:
+
+```
+node --no-experimental-require-module -e "require('<pkg>')"
+```
+
+That flag turns off the `require(esm)` support the runtime does not have,
+which is the whole trick. `.github/workflows/ci.yml` runs the same check
+over every route:
+
+```
+node --no-experimental-require-module -e "require('./src/api/routes/entries.js')"
+```
+
+It is there because this has now cost one outage and nearly a second, and
+it is the only thing in CI that behaves the way production does.
+
+**When a package goes ESM-only, the fix is on our side, not theirs.** Take
+the last version that still ships CommonJS — `jose` stays on 4 for exactly
+this, and the code it wants is the code 5 and 6 want, so the eventual move
+is packaging and not a rewrite — or drop the dependency for a platform
+built-in, which is what `crypto.randomUUID` did for `uuid`.
+
+Two ways out exist if that ever stops being enough, neither of them small:
+`node_bundler = "esbuild"` in `netlify.toml` inlines ESM at build time so
+the runtime never sees it (`mongodb` is the one to watch there — optional
+native dependencies and dynamic requires are what `external_node_modules`
+is for); or the functions become ES modules themselves, which is what
+Netlify now recommends, but the controller tests mock their dependencies by
+monkey-patching `Module._load`, so that is a test-harness rewrite before it
+is anything else.
+
 ## Credentials
 
 `src/db_maintenance/.env` holds `MONGODB_URL`, `TWITCH_CLIENT_ID`,


### PR DESCRIPTION
Follows #169 and #168. Documentation only — no code, no dependency change.

`uuid` 13 took every API route down in #162, #169 restored it, and `jose` 6 was about to do the same in #168. Twice in one week, and nothing in the repo said anywhere that the API cannot depend on an ES-module-only package. This writes it down where `CLAUDE.md` already keeps the traps that cost someone a day.

## Why this is worth a section rather than a line

The rule is easy. What makes it bite is that **checking locally looks like it passed**. `require(esm)` has worked since Node 22.12, and this repo pins Node 22 on purpose, so the test suite, the CI install and the build all load an ESM-only package perfectly happily. I checked jose 6 against a real Node 22.23 binary before opening #168 specifically because I did not want to assume — and it told me exactly the wrong thing, because the deployed functions runtime is the only place the difference shows and there is no way to reach it from a laptop.

## The check it documents

`node --no-experimental-require-module -e "require('<pkg>')"` — ask the loader, not the package.

The first version of this section suggested reading the `exports` map for a `require` condition instead. That is wrong in a way worth mentioning, because it is the obvious thing to reach for: absence of a `require` condition does mean ESM-only, but plenty of requireable packages ship no `exports` map at all. `mongodb` is one, and the metadata check calls it ESM-only. A check that cries wolf on the most load-bearing dependency in the repo is a check nobody will run twice. Verified the documented one instead:

```
jose         requireable
mongodb      requireable
neverthrow   requireable
jose@6       ESM-ONLY (would 502)
```

## What it says to do about it

Both times the answer has been neither "pin forever" nor "upgrade anyway": take the last version that still ships CommonJS (`jose` 4, whose API is the one 5 and 6 kept, so the eventual move is packaging rather than a rewrite), or drop the dependency for a platform built-in (`crypto.randomUUID` for `uuid`).

It also names the two real escape hatches and why each is its own project:

- **`node_bundler = "esbuild"`** inlines ESM at build time so the runtime never sees it. I verified this works — a bundled function loads and runs under `--no-experimental-require-module` with jose deleted from `node_modules` outright, where the current default (`zisi`, which copies the function verbatim and ships `node_modules` beside it) throws `ERR_REQUIRE_ESM`. But it changes how all ten functions are built, and `mongodb` — optional native dependencies, dynamic requires — is the one that would have to be proved. That is `external_node_modules` territory and its own PR, on its own evidence.
- **ESM functions**, which is what Netlify's docs now recommend. The controller tests mock their dependencies by monkey-patching `Module._load`, so that is a test-harness rewrite before it is anything else.

## On the underlying cause — which is not settled

I first wrote here that Lambda's `nodejs22.x` is deliberately built without `--experimental-require-module` and that `NODE_OPTIONS` cannot turn it on. That came from an AWS re:Post thread I had only seen summarised, and having now read it, it does not support the claim. The only answer there is machine-generated, carries a -1, is labelled as not reviewed by an expert, and **the person who asked the question replied to say it is wrong** — that it conflates two different sections of the AWS blog post, one of which says the `NODE_OPTIONS` flag *should* work.

What the thread does contain, first-hand from the asker, is an observation that matches ours exactly: on `nodejs22.x` running Node 22.14.0, `process.features.require_module` is `false` and `require` of an ESM package throws `ERR_REQUIRE_ESM`. That corroborates what #169 saw in production, and it is the whole basis for the rule.

So the mechanism is open. Nobody in that thread establishes whether it is a deliberate build choice, a `NODE_OPTIONS` plumbing problem, or something Netlify does in between. This section of `CLAUDE.md` states only the observable rule and no reason, which turns out to be the right call rather than a cautious one.

It also means the question is answerable rather than merely arguable: `process.features.require_module` is a direct read of whether a given runtime supports this. A throwaway function on a deploy preview returning that and `process.version` would settle whether we need esbuild at all, or whether this is a configuration we are getting wrong. Happy to do that as a separate experiment if it is worth knowing.

Sources: [Netlify — configuration for functions](https://docs.netlify.com/build/functions/configuration/), [Node.js 22.12.0 release notes](https://nodejs.org/en/blog/release/v22.12.0), [Netlify support — ESBuild warning with mongoose](https://answers.netlify.com/t/functions-esbuild-warning-when-using-mongoose-module/39824), [netlify/cli #6445](https://github.com/netlify/cli/issues/6445). The [AWS re:Post thread](https://repost.aws/questions/QUybbyCc3EROmwOuU8qx6eog/experimental-require-module-not-being-respected-in-node22-x-lambda-runtime) is cited only for the asker's first-hand observation, not for its answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
