### PR TITLE
fix: validate what a request may write, not just what it may create

### DIFF
--- a/src/api/controllers/bio.js
+++ b/src/api/controllers/bio.js
@@ -8,6 +8,7 @@ const { combine } = require('neverthrow')
 const { getUserId, getReqBody } = require('./utils')
 const { pair, toAsync, toPromise } = require('../utils/general')
 const db = require('../utils/db/')
+const { biography: parseBiography } = require('../utils/parsers/users')
 
 /** @type {(event: Event, context: Context) => Promise<Response>} */
 const setBio = (event) => toPromise(
@@ -15,12 +16,19 @@ const setBio = (event) => toPromise(
     getUserId(event),
     toAsync(getReqBody(event))
   ]))
-    // A valid token for a `sub` with no user document — which is every account
-    // between signing up and `setOwnName` running — is a 404 rather than the
-    // 502 that destructuring the db module's `{}` used to give. See #139.
     .andThen(([uid, { newBio }]) =>
-      db.findOneByFieldOrFail_('users', 'userId', uid)
-        .map(({ ref }) => [ref, newBio])
+      // Validated before the write, not just on the way into a `create_` that
+      // this path never reaches: `updateByRef_` stores what it is handed, so
+      // `newBio` had no bound on its length or even its type. See #172.
+      toAsync(parseBiography(newBio ?? null))
+        // A valid token for a `sub` with no user document — which is every
+        // account between signing up and `setOwnName` running — is a 404
+        // rather than the 502 that destructuring the db module's `{}` used to
+        // give. See #139.
+        .andThen((bio) =>
+          db.findOneByFieldOrFail_('users', 'userId', uid)
+            .map(({ ref }) => [ref, bio])
+        )
     )
     .andThen(([ref, newBio]) =>
       db.updateByRef_('users', ref.id, { biography: newBio })

--- a/src/api/controllers/entries.js
+++ b/src/api/controllers/entries.js
@@ -18,6 +18,7 @@ const {
 } = require('./utils')
 const { triplet, quad, toPromise, toAsync, throwIt } = require('../utils/general')
 const db = require('../utils/db/')
+const updateParsers = require('../utils/parsers/updates')
 const { toResponse } = require('../utils/db/into_safe_values')
 const { recordRevision, discardDraft, discardHistory } = require('./revisions')
 const { toSnapshot } = require('../utils/revision_history')
@@ -149,12 +150,20 @@ const deleteEntry_ = async (col, entry) => {
 const updateEntry_ = async (uid, body, col, entry) => {
   if (entry.data.userId !== uid) return responses.unauthorized()
 
-  const { review, ...entryWithoutReview } = body
+  const { review, ...rest } = body
   // `review` is only absent when the request genuinely omitted it (e.g. a save
   // that didn't include the comments field). An explicit empty string is a
   // real value and must still clear the review. Treating "absent" as "clear"
   // previously nulled out review text on unrelated saves.
   const reviewProvided = review !== undefined
+
+  // `updateByRef_` writes what it is handed, so this is the only thing between
+  // the request body and the document. Without it a caller could set `userId`
+  // and move the entry into someone else's list, and the form's own
+  // `commonMetadata: null` was being stored on every save. See #171.
+  const parsed = updateParsers[col](rest)
+  if (parsed.isErr()) return responses.fromError(parsed.error)
+  const entryWithoutReview = parsed.value
 
   const reviewCollection = toReviewCollection(col)
 
@@ -194,8 +203,12 @@ const updateEntry_ = async (uid, body, col, entry) => {
       // half-saves: the score and the dates say one thing, the comments
       // another. A stale note beside a fresh entry at least looks like what
       // it is.
+      //
+      // `entryWithoutReview` and not `body`: the note is written to the
+      // reviews collection just below, and a second copy of it on the entry is
+      // what put 1.9 MB of duplicated note into production. #171, #176.
       const updated = await orThrow(db.updateByRef_(col, entry.ref.id, {
-        ...(reviewProvided ? body : entryWithoutReview),
+        ...entryWithoutReview,
         updatedDate: Date.now(),
       }, session))
 

--- a/src/api/controllers/entries.test.js
+++ b/src/api/controllers/entries.test.js
@@ -340,3 +340,86 @@ test('a save that goes through writes both halves and clears the draft', options
   assert.equal(history.length, 1)
   assert.equal(history[0].snapshot.review, 'the note as it was')
 })
+
+///////////////////////////////////////////////////////////////////////////////
+// What a PATCH is allowed to put in the document. `_updateOneByRef` writes
+// what it is handed and parses nothing, so before #171 the request body was
+// the update. These drive the real handler and assert on the store, because
+// the whole question is what ended up in it.
+
+test('a save cannot hand the entry to another user', options, async () => {
+  seedSavedEntry()
+
+  const { statusCode } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form({ userId: 'u2' }),
+  })
+
+  // The save itself is legitimate — u1 owns this entry — so it goes through.
+  // The one field it may not touch is the one every ownership check reads.
+  assert.equal(statusCode, 200)
+  assert.equal(store.filmEntries[0].userId, 'u1')
+  assert.equal(store.filmEntries[0].status, 'Completed')
+})
+
+test('the note is stored in the reviews collection and not on the entry', options, async () => {
+  seedSavedEntry()
+
+  await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form({ review: 'a note long enough to be worth not storing twice' }),
+  })
+
+  assert.equal(
+    store.filmReviews[0].text,
+    'a note long enough to be worth not storing twice'
+  )
+  assert.equal(store.filmEntries[0].review, undefined)
+})
+
+test('commonMetadata sent by the form is not written to the entry', options, async () => {
+  seedSavedEntry()
+
+  // `form()` still sends it, which is the point: an older bundle is still a
+  // client, so the server has to drop this rather than trust the form to stop.
+  await call(entries, 'PATCH', 'entries/films/e1', { as: 'u1', body: form() })
+
+  assert.ok(!('commonMetadata' in store.filmEntries[0]))
+})
+
+test('a field nobody defined is dropped rather than stored', options, async () => {
+  seedSavedEntry()
+
+  await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form({ somethingInvented: 'x'.repeat(1000) }),
+  })
+
+  assert.ok(!('somethingInvented' in store.filmEntries[0]))
+})
+
+test('a field of the wrong type is a 400, and nothing is written', options, async () => {
+  seedSavedEntry()
+
+  const { statusCode } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u1',
+    body: form({ score: 'nine' }),
+  })
+
+  assert.equal(statusCode, 400)
+  assert.equal(store.filmEntries[0].status, 'InProgress')
+  assert.equal(store.filmEntries[0].score, 7)
+  assert.equal(store.filmReviews[0].text, 'the note as it was')
+})
+
+test('an ownership check still runs before any of this', options, async () => {
+  seedSavedEntry()
+
+  const { statusCode } = await call(entries, 'PATCH', 'entries/films/e1', {
+    as: 'u2',
+    body: form(),
+  })
+
+  assert.equal(statusCode, 401)
+  assert.equal(store.filmEntries[0].status, 'InProgress')
+})

--- a/src/api/controllers/name.js
+++ b/src/api/controllers/name.js
@@ -8,6 +8,7 @@ const { pair, toAsync, toPromise } = require('../utils/general')
 const responses = require('../utils/responses')
 const { getUserId, getReqBody, getSegment } = require('./utils')
 const feErrors = require('../utils/frontend_errors')
+const { username: parseUsername } = require('../utils/parsers/users')
 
 /** @type {(event: Event) => Promise<Response>} */
 const findOwnName = (event) => toPromise(
@@ -65,10 +66,21 @@ module.exports = {
  * @type {([userId, req]: [string, any]) => ResultAsync<Response, Error>}
  */
 const assignNameIfNotTaken = ([userId, { newName }]) =>
-  findOneByField_('users', 'username', newName)
-    .andThen(({ data }) => data
-        ? okAsync(responses.ok(feErrors.nameTaken(newName)))
-        : assignName(userId, newName).map(() => responses.ok())
+  // Checked here rather than only on the way into the database, because the
+  // rename path writes through `updateByRef_`, which parses nothing: the
+  // `max(16).min(2)` alphanumeric rule in the users parser only ever ran for
+  // an account claiming its first name. A name is also read back out and
+  // interpolated into the profile page. See #172.
+  //
+  // Before the lookup as well as before the write — `{ newName: { $ne: null } }`
+  // reaching `findOneByField_` is a filter, not a name.
+  toAsync(parseUsername(newName))
+    .andThen((name) =>
+      findOneByField_('users', 'username', name)
+        .andThen(({ data }) => data
+            ? okAsync(responses.ok(feErrors.nameTaken(name)))
+            : assignName(userId, name).map(() => responses.ok())
+        )
     )
 
 /** @type {(userId: string, newName: string) => ResultAsync<any, Error>} */

--- a/src/api/controllers/name.test.js
+++ b/src/api/controllers/name.test.js
@@ -1,6 +1,12 @@
 /**
- * @file Claiming a username, driven through the real Netlify handler against
- * an in-memory Mongo.
+ * @file The two fields a request may write onto a user document — the username
+ * and the biography — driven through the real Netlify handlers against an
+ * in-memory Mongo.
+ *
+ * Both live here rather than in a file each because they are the same write:
+ * `name.js` and `bio.js` both reach `updateByRef_`, which parses nothing, and
+ * both therefore need the users parser run by hand on the way in. One fake
+ * Mongo serves both.
  *
  * The point of these is that a 200 from `POST /api/name` means the name was
  * written — the previous version answered 200 while writing nothing — so they
@@ -126,11 +132,20 @@ Module._load = function (request, ...args) {
 }
 
 const name = dependenciesInstalled ? require('../routes/name') : undefined
+const bio = dependenciesInstalled ? require('../routes/bio') : undefined
+const { MAX_BIOGRAPHY_LENGTH } = dependenciesInstalled
+  ? require('../utils/parsers/users')
+  : { MAX_BIOGRAPHY_LENGTH: 0 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-const call = async (method, url, { as, body } = {}) => {
-  const response = await name.handler(
+const call = (method, url, options) => callRoute(name, method, url, options)
+
+const callBio = (body, { as } = { as: 'u1' }) =>
+  callRoute(bio, 'POST', 'bio', { as, body })
+
+const callRoute = async (route, method, url, { as, body } = {}) => {
+  const response = await route.handler(
     {
       httpMethod: method,
       path: `/.netlify/functions/${url}`,
@@ -218,4 +233,104 @@ test('a write that fails is not answered with a 200', options, async () => {
   } finally {
     writesFail = false
   }
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The rule in the users parser, on the path that never ran it. `create_`
+// parses and `updateByRef_` does not, so `max(16).min(2)` alphanumeric applied
+// to an account claiming its first name and to no rename after it. #172.
+
+const refusedNames = {
+  'markup, which the profile page interpolates': '<img src=x onerror=alert(1)>',
+  'a name longer than the limit': 'a'.repeat(17),
+  'a name shorter than the limit': 'a',
+  'punctuation that is not alphanumeric': 'nil.moe',
+  'a space': 'two words',
+  'the empty string': '',
+}
+
+for (const [what, newName] of Object.entries(refusedNames)) {
+  test(`a rename refuses ${what}`, options, async () => {
+    seed()
+
+    const { statusCode } = await call('POST', 'name', {
+      as: 'u1',
+      body: { newName },
+    })
+
+    assert.equal(statusCode, 400)
+    assert.equal(store.users[0].username, 'oldname')
+  })
+}
+
+test('a rename refuses a value that is not a string at all', options, async () => {
+  seed()
+
+  // `{ $ne: null }` reaching `findOneByField_` is a filter rather than a name:
+  // it matches whatever user happens to be there and answers "taken". It has
+  // to be refused before the lookup, not just before the write.
+  const { statusCode } = await call('POST', 'name', {
+    as: 'u1',
+    body: { newName: { $ne: null } },
+  })
+
+  assert.equal(statusCode, 400)
+  assert.equal(store.users[0].username, 'oldname')
+})
+
+test('an ordinary rename still goes through', options, async () => {
+  seed()
+
+  const { statusCode } = await call('POST', 'name', {
+    as: 'u1',
+    body: { newName: 'nil2' },
+  })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.users[0].username, 'nil2')
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The biography, which reaches `updateByRef_` the same way and had no bound on
+// its length or even its type. #172.
+
+test('a biography is written when it is a string within the limit', options, async () => {
+  seed()
+
+  const { statusCode } = await callBio({ newBio: '# hello\n\nsome *markdown*' })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.users[0].biography, '# hello\n\nsome *markdown*')
+})
+
+test('clearing a biography is allowed', options, async () => {
+  seed()
+  store.users[0].biography = 'something'
+
+  const { statusCode } = await callBio({ newBio: '' })
+
+  assert.equal(statusCode, 200)
+  assert.equal(store.users[0].biography, '')
+})
+
+test('a biography past the limit is refused and nothing is written', options, async () => {
+  seed()
+  store.users[0].biography = 'what was there before'
+
+  const { statusCode } = await callBio({
+    newBio: 'a'.repeat(MAX_BIOGRAPHY_LENGTH + 1),
+  })
+
+  assert.equal(statusCode, 400)
+  assert.equal(store.users[0].biography, 'what was there before')
+})
+
+test('a biography of the wrong type is refused', options, async () => {
+  seed()
+  store.users[0].biography = 'what was there before'
+
+  const { statusCode } = await callBio({ newBio: { $ne: null } })
+
+  assert.equal(statusCode, 400)
+  assert.equal(store.users[0].biography, 'what was there before')
 })

--- a/src/api/utils/parsers/books.js
+++ b/src/api/utils/parsers/books.js
@@ -6,7 +6,7 @@
 const { workParser } = require('./works')
 const { validate } = require('./utils')
 const { z } = require('zod')
-const { entryParser } = require('./entries')
+const { entryParser, entryUpdateParser } = require('./entries')
 
 const bookParser = workParser.extend({
   entryType: z.literal('Book'),
@@ -23,10 +23,17 @@ const bookEntryParser = entryParser(bookParser)
 /** @type Validator<BookEntry> */
 const bookEntries = (x) => validate(bookEntryParser, x)
 
+const bookEntryUpdateParser = entryUpdateParser(bookParser)
+
+/** The fields a PATCH may set; see `entryUpdateParser`. */
+/** @type Validator<Partial<BookEntry>> */
+const bookEntryUpdates = (x) => validate(bookEntryUpdateParser, x)
+
 /** @type Validator<Book> */
 const books = (x) => validate(bookParser, x)
 
 module.exports = {
   bookEntries,
+  bookEntryUpdates,
   books,
 }

--- a/src/api/utils/parsers/entries.js
+++ b/src/api/utils/parsers/entries.js
@@ -30,6 +30,38 @@ const entryParser = (specificWorkParser) => z.object({
   updatedDate: z.number().or(z.undefined()),
 })
 
+/**
+ * What a client may set on an entry it already owns.
+ *
+ * `_create` parses what it is given and `_updateOneByRef` does not, so a PATCH
+ * body used to be `$set` onto the document exactly as it arrived. Three things
+ * came through that gap, and this closes all of them by construction — zod
+ * drops every key it was not told about:
+ *
+ * - **`userId`**, which is the field every ownership check reads. A request
+ *   that set it moved the entry into another account's list, where its owner
+ *   could no longer see it. Omitted here, so the value written stays whatever
+ *   the entry was created with.
+ * - **`review`**, whose home is the `*Reviews` collection. `updateEntry_`
+ *   writes it there and used to write a second copy onto the entry as well:
+ *   1.9 MB of duplicated note across production, which the list pipeline
+ *   carries a `$project` specifically to hide again.
+ * - **`commonMetadata`** and anything else the caller invented. The form sends
+ *   `commonMetadata: null` on every save; the work is joined on `workRef` and
+ *   the field has no business on the entry at all.
+ *
+ * Partial, because an update is a partial document — a caller changing a score
+ * sends a score. Otherwise it is `entryParser` exactly, so anything the create
+ * path accepts this accepts too.
+ *
+ * @param {ZodObject} specificWorkParser
+ */
+const entryUpdateParser = (specificWorkParser) =>
+  entryParser(specificWorkParser)
+    .omit({ userId: true, review: true })
+    .partial()
+
 module.exports = {
-  entryParser
+  entryParser,
+  entryUpdateParser,
 }

--- a/src/api/utils/parsers/films.js
+++ b/src/api/utils/parsers/films.js
@@ -6,7 +6,7 @@
 const { workParser } = require('./works')
 const { validate } = require('./utils')
 const { z } = require('zod')
-const { entryParser } = require('./entries')
+const { entryParser, entryUpdateParser } = require('./entries')
 
 const filmParser = workParser.extend({
   entryType: z.literal('Film'),
@@ -23,10 +23,17 @@ const filmEntryParser = entryParser(filmParser)
 /** @type Validator<FilmEntry> */
 const filmEntries = (x) => validate(filmEntryParser, x)
 
+const filmEntryUpdateParser = entryUpdateParser(filmParser)
+
+/** The fields a PATCH may set; see `entryUpdateParser`. */
+/** @type Validator<Partial<FilmEntry>> */
+const filmEntryUpdates = (x) => validate(filmEntryUpdateParser, x)
+
 /** @type Validator<Film> */
 const films = (x) => validate(filmParser, x)
 
 module.exports = {
   filmEntries,
+  filmEntryUpdates,
   films,
 }

--- a/src/api/utils/parsers/games.js
+++ b/src/api/utils/parsers/games.js
@@ -6,7 +6,7 @@
 const { workParser } = require('./works')
 const { validate } = require('./utils')
 const { z } = require('zod')
-const { entryParser } = require('./entries')
+const { entryParser, entryUpdateParser } = require('./entries')
 
 const gameParser = workParser.extend({
   entryType: z.literal('Game'),
@@ -24,10 +24,17 @@ const gameEntryParser = entryParser(gameParser)
 /** @type Validator<GameEntry> */
 const gameEntries = (x) => validate(gameEntryParser, x)
 
+const gameEntryUpdateParser = entryUpdateParser(gameParser)
+
+/** The fields a PATCH may set; see `entryUpdateParser`. */
+/** @type Validator<Partial<GameEntry>> */
+const gameEntryUpdates = (x) => validate(gameEntryUpdateParser, x)
+
 /** @type Validator<Game> */
 const games = (x) => validate(gameParser, x)
 
 module.exports = {
   gameEntries,
+  gameEntryUpdates,
   games,
 }

--- a/src/api/utils/parsers/tvShows.js
+++ b/src/api/utils/parsers/tvShows.js
@@ -6,7 +6,7 @@
 const { workParser } = require('./works')
 const { validate } = require('./utils')
 const { z } = require('zod')
-const { entryParser } = require('./entries')
+const { entryParser, entryUpdateParser } = require('./entries')
 
 
 const tvShowParser = workParser.extend({
@@ -25,10 +25,17 @@ const tvShowEntryParser = entryParser(tvShowParser)
 /** @type Validator<TVShowEntry> */
 const tvShowEntries = (x) => validate(tvShowEntryParser, x)
 
+const tvShowEntryUpdateParser = entryUpdateParser(tvShowParser)
+
+/** The fields a PATCH may set; see `entryUpdateParser`. */
+/** @type Validator<Partial<TVShowEntry>> */
+const tvShowEntryUpdates = (x) => validate(tvShowEntryUpdateParser, x)
+
 /** @type Validator<TVShow> */
 const tvShows = (x) => validate(tvShowParser, x)
 
 module.exports = {
   tvShowEntries,
+  tvShowEntryUpdates,
   tvShows
 }

--- a/src/api/utils/parsers/updates.js
+++ b/src/api/utils/parsers/updates.js
@@ -1,0 +1,28 @@
+/**
+ * @file The parsers for a *partial* update, keyed by collection the way
+ * ./index.js is.
+ *
+ * ./index.js holds the full-document parsers `_create` runs, and its contract
+ * is that a name there is a collection you can insert into. These are the
+ * other half: what a client is allowed to change about a document that already
+ * exists. Only the entry collections have one, because they are the only
+ * documents a request body is allowed to rewrite wholesale — a username, a
+ * biography and a draft are each a single named field, validated where they
+ * are read.
+ *
+ * `entryUpdateParser` in ./entries.js says what these permit and, more to the
+ * point, what they drop.
+ */
+/**
+ * @template T
+ * @typedef {import('./utils').Validator<T>} Validator
+ */
+/** @typedef {import('./index').ValidCollection} ValidCollection */
+
+/** @type {Record<string, Validator<any>>} */
+module.exports = {
+  filmEntries: require('./films').filmEntryUpdates,
+  gameEntries: require('./games').gameEntryUpdates,
+  tvShowEntries: require('./tvShows').tvShowEntryUpdates,
+  bookEntries: require('./books').bookEntryUpdates,
+}

--- a/src/api/utils/parsers/users.js
+++ b/src/api/utils/parsers/users.js
@@ -21,9 +21,32 @@ const scoreTallyParser = z.object({
   unrated: z.number(),
 })
 
+/**
+ * A username, defined once and used twice.
+ *
+ * `_create` parses the whole user document and `_updateOneByRef` parses
+ * nothing, so this rule applied to an account claiming its first name and to
+ * no rename after it: `assignName` branches to `create_` or `updateByRef_`,
+ * and only the first of those went through a parser. A rename could therefore
+ * be any length, any type, or markup — and `username` is interpolated into the
+ * profile page. `setOwnName` runs this by hand for that reason. See #172.
+ */
+const usernameParser = z.string().max(16).min(2).refine((val) => isAlphanumeric(val))
+
+/**
+ * A biography is markdown, rendered through `marked` and `DOMPurify` on the
+ * profile. It had no bound at all on the way in, for the same reason: `setBio`
+ * reaches `updateByRef_` directly. The limit is generous rather than tight —
+ * the longest one in production is 2356 characters — because the point is to
+ * stop an unbounded write, not to ration what anyone can say.
+ */
+const MAX_BIOGRAPHY_LENGTH = 20000
+
+const biographyParser = z.string().max(MAX_BIOGRAPHY_LENGTH).nullable()
+
 const userParser = z.object({
   userId: z.string(),
-  username: z.string().max(16).min(2).refine((val) => isAlphanumeric(val)),
+  username: usernameParser,
   stats: z.object({
     updatedDate: z.number(),
     scores: z.object({
@@ -33,7 +56,7 @@ const userParser = z.object({
       games: scoreTallyParser,
     })
   }).nullable().or(z.undefined()),
-  biography: z.string().nullable().or(z.undefined()),
+  biography: biographyParser.or(z.undefined()),
 })
 
 /** @typedef {z.infer<typeof userParser>} User
@@ -41,6 +64,15 @@ const userParser = z.object({
 /** @type Validator<User> */
 const users = (x) => validate(userParser, x)
 
+/** @type Validator<string> */
+const username = (x) => validate(usernameParser, x)
+
+/** @type Validator<string | null> */
+const biography = (x) => validate(biographyParser, x)
+
 module.exports = {
-  users
+  users,
+  username,
+  biography,
+  MAX_BIOGRAPHY_LENGTH,
 }

--- a/src/frontend/_includes/js/components/home/index.js
+++ b/src/frontend/_includes/js/components/home/index.js
@@ -1,4 +1,4 @@
-const { html } = Utils
+const { html, escapeHtml } = Utils
 const { isLoggedIn, getUserName } = Netlify
 const { ProfileLists } = Components.Profile
 const { initComponent, WithRemoteData, Redirect } = Components
@@ -35,7 +35,7 @@ const ProfileListsOrUsernameSetter = ({ error, username }) => initComponent({
 const AuthenticatedHomePage = (username) => initComponent({
   content: () => html`
     <div id="authenticated-home-page" class="row">
-      Hi ${username}! Not much here yet. Why not visit <a href="/profile/${username}">your profile</a>?
+      Hi ${escapeHtml(username)}! Not much here yet. Why not visit <a href="/profile/${escapeHtml(encodeURIComponent(username))}">your profile</a>?
     </div>
 
     <div class="row">

--- a/src/frontend/_includes/js/components/list/list.js
+++ b/src/frontend/_includes/js/components/list/list.js
@@ -1,4 +1,4 @@
-const { html, css } = Utils
+const { html, css, escapeHtml } = Utils
 const { col, initTable, detailFormatter, allColumns, statuses, entryTypeToFullColumns, editColumn, filmStatuses } = Tables
 const { typeToTitle, statusToTitle } = Conversions
 const { initComponent, WithRemoteData, appendContent, Nothing } = Components
@@ -114,7 +114,7 @@ Components.List.List = List
 const ListPageHeader = (title, username) => initComponent({
   content: () => html`
     <div class="row">
-      <h1><a href="/profile/${username}"><i class="fa fa-home"></i></a> ${title}</h1>
+      <h1><a href="/profile/${escapeHtml(encodeURIComponent(username))}"><i class="fa fa-home"></i></a> ${escapeHtml(title)}</h1>
     </div>
     <hr>
   `

--- a/src/frontend/_includes/js/components/profile/biography.js
+++ b/src/frontend/_includes/js/components/profile/biography.js
@@ -1,15 +1,15 @@
 const { getUserName, setBio } = Netlify
-const { html, css } = Utils
+const { html, css, escapeHtml } = Utils
 const { initComponent, setContent } = Components
 const { Button, showNotification } = Components.UI
 
 const Biography = (userdata) => initComponent({
   content: ({ include }) => html`
-    <h2 id="biography-heading">About ${userdata.username}</h2>
+    <h2 id="biography-heading">About ${escapeHtml(userdata.username)}</h2>
     <div id="biography-content">
       ${DOMPurify.sanitize(
         marked.parse(
-          userdata.biography ?? `*${userdata.username} has not written anything yet!*`
+          userdata.biography ?? `*${escapeHtml(userdata.username)} has not written anything yet!*`
         )
       )}
     </div>
@@ -42,7 +42,7 @@ Components.Profile.Biography = Biography
 
 const BiographyInput = (currentBio) => initComponent({
   content: ({ include }) => html`
-    <textarea id="biography-input">${currentBio ?? ''}</textarea><br>
+    <textarea id="biography-input">${escapeHtml(currentBio ?? '')}</textarea><br>
     ${include(Button({
       label: "Save",
       // TODO: the style is duplicated with add entry button, deduplicate

--- a/src/frontend/_includes/js/components/profile/profile_lists.js
+++ b/src/frontend/_includes/js/components/profile/profile_lists.js
@@ -1,7 +1,7 @@
 const { entryTypes, getEntries } = Netlify
 const { col, initTable, profileColumns } = Tables
 const { typeToTitle } = Conversions
-const { html, css } = Utils
+const { html, css, escapeHtml } = Utils
 const { UsernameSetter } = Components.Profile
 const { initComponent, WithRemoteData } = Components
 
@@ -26,7 +26,7 @@ Components.Profile.ProfileLists = ProfileLists
 const ProfileList = (username, type) => initComponent({
   content: ({ include }) => html`
     <div class="profile-list">
-      <h3><a href="/${type}/${username}">${typeToTitle[type]}</a></h3>
+      <h3><a href="/${type}/${escapeHtml(encodeURIComponent(username))}">${typeToTitle[type]}</a></h3>
       ${include(WithRemoteData({
         remoteData: getEntries(type, username, 5),
         component: (entries) => ProfileTable(type, entries)

--- a/src/frontend/_includes/js/components/profile/profile_stats.js
+++ b/src/frontend/_includes/js/components/profile/profile_stats.js
@@ -1,7 +1,7 @@
 const { entryTypes, getStats } = Netlify
 const { col } = Tables
 const { typeToTitle } = Conversions
-const { html, css, timeAgo, dateTime } = Utils
+const { html, css, timeAgo, dateTime, escapeHtml } = Utils
 const { initComponent, WithRemoteData } = Components
 const { Tabbed } = Components.UI
 
@@ -43,7 +43,7 @@ const SubStats = (username, stats) => initComponent({
 const ProfileStatsOfType = (username, type, stats) => initComponent({
   content: ({ id, include }) => html`
     <div class="profile-stats">
-      <h3><a href="/${type}/${username}">${typeToTitle[type]}</a></h3>
+      <h3><a href="/${type}/${escapeHtml(encodeURIComponent(username))}">${typeToTitle[type]}</a></h3>
       <div id=${id}></div>
       ${include(AdditionalStats(stats.scores[type]))}
     </div>

--- a/src/frontend/_includes/js/components/ui/menu.js
+++ b/src/frontend/_includes/js/components/ui/menu.js
@@ -1,5 +1,5 @@
 const { initComponent } = Components
-const { html, css } = Utils
+const { html, css, escapeHtml } = Utils
 
 const Menu = () => initComponent({
   content: ({ include }) => html`
@@ -28,7 +28,7 @@ const Menu = () => initComponent({
       .map(({ username }) => {
         if (username) {
           $('#home-menu-item').after(html`
-            <li id="home-menu-item"><a href="/profile/${username}">Profile</a></li>
+            <li id="home-menu-item"><a href="/profile/${escapeHtml(encodeURIComponent(username))}">Profile</a></li>
           `)
         }
       })

--- a/src/frontend/_includes/js/utils/columns.test.js
+++ b/src/frontend/_includes/js/utils/columns.test.js
@@ -241,5 +241,24 @@ test("a quote in a dbRef stays inside the string the attribute holds", () => {
   const rendered = Columns.edit()
     .formatter(null, { status: "Completed", dbRef: `a"b'c` }, 0)
     .trim();
-  assert.ok(rendered.includes(`onclick="window.editEntry(&quot;a\\&quot;b'c&quot;)"`));
+  assert.ok(rendered.includes(`onclick="window.editEntry(&quot;a\\&quot;b&#39;c&quot;)"`));
+});
+
+test("what the browser parses out of the edit attribute is the dbRef itself", () => {
+  const dbRef = `a"b'c`;
+  const rendered = Columns.edit()
+    .formatter(null, { status: "Completed", dbRef }, 0)
+    .trim();
+
+  // A browser HTML-decodes an attribute value and then hands the result to the
+  // JS parser, so that is the order to undo it in. Asserting on the escaped
+  // text alone cannot tell a correct escape from one that merely looks busy.
+  const decoded = rendered
+    .match(/onclick="([^"]*)"/)[1]
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+
+  const argument = decoded.slice("window.editEntry(".length, -1);
+  assert.equal(JSON.parse(argument), dbRef);
 });

--- a/src/frontend/_includes/js/utils/entry_form_io.js
+++ b/src/frontend/_includes/js/utils/entry_form_io.js
@@ -26,7 +26,11 @@ const OVERRIDE_FIELDS = [
 
 /** @type {(data: any, type: string) => any} */
 const readForm = (data, type) => ({
-  commonMetadata: null, // The work is referenced by workRef, not carried here
+  // No `commonMetadata`: the work is referenced by `workRef` and joined on the
+  // way out. Sending it as `null` was a way of saying so, but the update path
+  // stored whatever it was sent, so what it actually said was "set this entry's
+  // commonMetadata to null" — 3267 entries carry the field for that reason.
+  // The create path never did, because `_create` parses and zod drops it. #171.
   workRef: data?.commonMetadata?.internalRef,
   overrides: getOverrides(data?.apiData, type),
   status: $('#status').val(),

--- a/src/frontend/_includes/js/utils/general.js
+++ b/src/frontend/_includes/js/utils/general.js
@@ -81,7 +81,15 @@ const dateOnly = (timestamp) =>
       })
     : 'unknown'
 
-/** These strings are the user's own text, and they go into innerHTML. */
+/**
+ * These strings are the user's own text, and they go into innerHTML.
+ *
+ * `'` is escaped as well as `"`. Nothing here currently interpolates into a
+ * single-quoted attribute, so that is a guard against the next thing that
+ * does rather than a fix for something live — but the whole value of an
+ * escaper is that a caller does not have to know which quote its template
+ * happened to use.
+ */
 /** @type {(text: any) => string} */
 const escapeHtml = (text) =>
   String(text)
@@ -89,6 +97,7 @@ const escapeHtml = (text) =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 
 /**
  * A url out of the metadata, if it is one we are willing to put in an `href`


### PR DESCRIPTION
Closes #171. Closes #172.

`_create` runs the collection's parser. `_updateOneByRef` runs nothing. Three of the four write endpoints go through the second one, and each of them handed the request body to `$set` exactly as it arrived — so ownership was checked and content never was. This is that gap, closed at every call site that has one.

## What was getting through

**An entry PATCH could set `userId`.** That is the field every ownership check reads, so `{"status":"Completed","userId":"auth0|someone-else"}` on an entry you own moved it into another account's list, where the original owner could no longer see or delete it. The frontend never sends `userId`, so nothing legitimate depended on it being allowed.

**It could also invent fields, and the entry form was doing so.** `readForm` sends `commonMetadata: null` on every save, plus the note — which belongs in the `*Reviews` collection and was being written there *as well*. Measured on the 2026-08-19 snapshot: 3267 entry documents carry `commonMetadata` and 1034 carry a duplicate of their note, together 3.21 MB of the 4.32 MB those four collections occupy. `toUserEntriesPipeline` carries `{ $project: { review: 0 } }` specifically to hide half of it again.

**The username rule had the same shape of hole.** `assignName` branches to `create_` or `updateByRef_`, so `max(16).min(2)` alphanumeric applied to an account claiming its first name and to no rename after it. A username is also interpolated straight into the profile page, so a rename was a stored XSS — and per #173 `nf_jwt` is readable from `document.cookie`, which makes that a session token rather than an alert box. `setBio` reaches `updateByRef_` the same way, with no bound on the biography's length or even its type.

## The shape of the fix

Validation sits at the boundary where a request body enters, not in the db layer. The distinction that matters is not *which collection* is being written but *whether the value came from a caller*: `refreshStats` writes a `stats` blob through the same helper and legitimately may, so a blanket allowlist one layer down would have been wrong.

`entryUpdateParser` is `entryParser` minus `userId` and `review`, made `.partial()`. That relationship is the safety argument — anything the create path accepts, this accepts too, so no save that works today can start failing. zod drops every key it was not told about, which is what removes `commonMetadata` and anything else invented, without a list of banned fields to keep in step with anything.

`parsers/updates.js` holds them keyed by collection, mirroring `parsers/index.js`. Only the entry collections need one: a username, a biography and a draft are each a single named field, validated where they are read.

The form stops sending `commonMetadata`, but the server drops it regardless — an older cached bundle is still a client, and there is a test that says so.

The frontend half escapes `username` everywhere it reaches markup rather than trusting that the parser above ran. `escapeHtml` now covers `'` as well as `"`; nothing interpolates into a single-quoted attribute today, so that is a guard against the next thing that does rather than a fix for something live.

## Worth arguing with

**The escaping change alters one rendered attribute.** The edit button's `onclick` now carries `&#39;` where it carried a raw `'`. A browser HTML-decodes an attribute before the JS parser sees any of it, so what gets parsed is unchanged — there is a new test that undoes both layers in that order and asserts the argument is the `dbRef`, because asserting on escaped text alone cannot tell a correct escape from one that merely looks busy. The existing assertion was updated rather than deleted.

**`MAX_BIOGRAPHY_LENGTH` is 20000**, picked to be generous rather than tight: the longest biography in production is 2356 characters, and the point is to stop an unbounded write, not to ration what anyone can say. All six existing usernames already satisfy the rule, so nobody is locked out of renaming.

**This does not clean up the 3.21 MB already stored.** #176 is that, and it needs a maintenance script with a snapshot in front of it. This is the write site that keeps refilling it.

## Checks

`node --test` is 381 passing, up from 362. The five new entry tests and nine of the new name/bio tests were run against the pre-fix controllers first and fail there — a test that passes either way would not be testing anything. Both CI jobs were run locally against a real `npm ci`: every tracked file parses, all ten functions load under `--no-experimental-require-module`, `npm run build` writes the bundle, and every asset the built page references exists and is non-empty.

Unrelated but worth flagging, since the push surfaced it: GitHub reports 118 Dependabot advisories on `main` (1 critical, 63 high). #182 covers the ones I could see from the lockfile by hand, but the Dependabot list is the authoritative one and is a lot longer than that issue assumes.
