### PR TITLE
chore(api): delete four db and response helpers nothing calls

### DIFF
--- a/src/api/utils/db/index.js
+++ b/src/api/utils/db/index.js
@@ -22,7 +22,7 @@
 /** @typedef {import('../parsers').ValidCollection} ValidCollection */
 /** @typedef {import('../errors').Error} Error */
 const { ResultAsync, okAsync, errAsync } = require('neverthrow')
-const { _findOne, _findMany, _countScoresByValue, _findOneByField, _findOneByRef, _findAllByFieldIn, _findAllInCollection, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
+const { _findOne, _findMany, _countScoresByValue, _findOneByField, _findOneByRef, _findAllByFieldIn, _updateOneByRef, _create, _deleteOneByRef, _deleteAllByField, _findAllUserEntriesWithMetadata } = require('./unsafe_functions')
 const { compose } = require('ramda')
 const { withTransaction } = require('./db')
 const { toResponse, toResult } = require('./into_safe_values')
@@ -31,9 +31,6 @@ const errors = require('../errors')
 
 /** @typedef {import('./queries').QueryOptions} QueryOptions */
 /** @typedef {import('mongodb').ClientSession} ClientSession */
-
-/** @type {(collection: ValidCollection, ref: string) => Promise<Response>} */
-const findOneByRef = compose(toResponse, _findOneByRef)
 
 /** @type {(collection: ValidCollection, ref: string) => ResultAsync<any, Error>} */
 const findOneByRef_ = compose(toResult, _findOneByRef)
@@ -89,9 +86,6 @@ const findAllByFieldIn_ = compose(toResult, _findAllByFieldIn)
 /** @type {(collection: ValidCollection, userId: string, limit?: number) => ResultAsync<any, Error>} */
 const findAllUserEntriesWithMetadata_ = compose(toResult, _findAllUserEntriesWithMetadata)
 
-/** @type {(collection: ValidCollection) => Promise<Response>} */
-const findAll = compose(toResponse, _findAllInCollection)
-
 /** @type {(collection: ValidCollection, ref: string, update: any, session?: ClientSession) => Promise<Response>} */
 const updateByRef = compose(toResponse, _updateOneByRef)
 
@@ -116,9 +110,7 @@ const create_ = compose(toResult, _create)
 module.exports = {
   withTransaction,
   isFound,
-  findOneByRef,
   findOneByRef_,
-  findAll,
   findOne_,
   findMany_,
   countScoresByValue_,

--- a/src/api/utils/db/unsafe_functions.js
+++ b/src/api/utils/db/unsafe_functions.js
@@ -49,10 +49,6 @@ const _findOneByField = (collection, field, value) =>
 const _findOneByRef = (collection, ref) =>
   findFirst(collection, { _id: ref })
 
-/** @type {(collection: ValidCollection) => Promise<object>} */
-const _findAllInCollection = (collection) =>
-  find(collection, {})
-
 /**
  * One query for many values of the same field, rather than one query per
  * value. A whole list's reviews are 400-odd `entryRef`s, and 400 round trips
@@ -136,7 +132,6 @@ module.exports = {
   _countScoresByValue,
   _findOneByField,
   _findOneByRef,
-  _findAllInCollection,
   _findAllByFieldIn,
   _findAllUserEntriesWithMetadata,
   _updateOneByRef,

--- a/src/api/utils/responses.js
+++ b/src/api/utils/responses.js
@@ -70,7 +70,7 @@ const fromError = (error) => {
  * `fromError` is how a failure becomes a response. The bare constructors take
  * whatever body they are given and send it, which is fine for a body written
  * on purpose and is how an error object came to be serialised into a 500 —
- * `internalError` has no callers left for that reason.
+ * so there is no bare 500 here to reach for.
  */
 module.exports = {
   JSON_CONTENT_TYPE,
@@ -80,7 +80,6 @@ module.exports = {
   unauthorized: response(401),
   notFound: response(404),
   payloadTooLarge: response(413),
-  internalError: response(500),
   fromError,
 }
 


### PR DESCRIPTION
Closes #179.

Four exports in `src/api/utils/` had no callers. Each appeared only at its own definition and in its own `module.exports` — re-verified with `grep -rn` across the whole tree, tests included, before deleting anything.

**`responses.internalError`** is the bare 500 constructor: it sends whatever body it is handed, which is how an error object came to be serialised into a 500. `fromError` replaced it, and does the two things that constructor could not — logs the error's own account of itself, and publishes only `error` and `message`. The comment above `module.exports` explained that `internalError` was unused for that reason; it now says there is no bare 500 there to reach for, which is the same warning without the dangling reference.

**`db.findAll` and `_findAllInCollection`** are `find(collection, {})` — no filter, no projection, no limit — against production collections, where `gameEntries` alone is 2.3 MB. Nothing calls it, and it is worth removing rather than leaving available.

**`db.findOneByRef`** is the `Promise<Response>` half of a pair whose `ResultAsync` half, `findOneByRef_`, is what every controller uses. The unsafe `_findOneByRef` underneath both stays, since the surviving half is built from it.

No behaviour change: nothing that ships loses a code path, only the ability to reach for these four. `npm test` passes (362 tests), `git ls-files '*.js' | xargs -n1 node --check` is clean across 153 files, and every route still loads under `node --no-experimental-require-module` — the check that behaves the way the functions runtime does.

This is the trivially separable part of #178, which proposes retiring the FaunaDB response wrapper (`toResponse`) these helpers are built on. That refactor is not attempted here; `toResponse` still has four live callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
