### PR TITLE
fix(db_maintenance): index findDraft's three fields, and correct two whys that name queries they cannot serve

### DIFF
--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -94,11 +94,15 @@ over the snapshot `snapshot-2026-08-18T03-19-34-608Z`, and the winning plan
 for the list query went from a blocking `SORT` to
 `IXSCAN -> FETCH -> LIMIT` on all four entry collections.
 
-A dry run today therefore prints `23 index(es) already exist, 0 would be
-created, 0 conflict`, and that is what "applied" looks like from the outside.
-If it ever reports something to create, either `index_plan.js` has grown an
-entry or an index was dropped behind its back — both worth knowing before you
-reach for `--apply`.
+`index_plan.js` has since grown a twenty-fourth,
+`entryRevisions.entryRef_1_kind_1_userId_1` (#180), which has **not** been
+applied. A dry run today therefore prints `23 index(es) already exist, 1 would
+be created, 0 conflict`, and creating it is a second `--apply` for a human to
+approve. Once that happens this paragraph should say 24 and 0.
+
+If a dry run ever reports something to create that isn't that one, either
+`index_plan.js` has grown another entry or an index was dropped behind its
+back — both worth knowing before you reach for `--apply`.
 
 Which indexes, and why each one, is declared in `index_plan.js` — every entry
 names the queries that want it, because an index nobody can name a query for
@@ -123,6 +127,20 @@ equality match on one field, and `_id` is indexed by MongoDB already.
   blocking one in front of the `$limit`. The plain `{ userId: 1 }` index is
   kept beside it even though a compound index serves its own prefix — see the
   comment in `index_plan.js`.
+- **`entryRevisions` has a compound index too**, `{ entryRef: 1, kind: 1,
+  userId: 1 }`, because `findDraft` matches on all three — and it is the
+  hottest read here, running once every 2.5 seconds while an edit form is
+  open. On `{ entryRef: 1 }` alone the seek lands on the entry and the server
+  filters the rest in memory, up to 50 documents each carrying a whole
+  snapshot. `findRevisions` matches `{ entryRef, kind }`, this index's prefix,
+  so the one index serves both.
+- **The four `*Entries.workRef_1` indexes have no query behind them.** They
+  were declared for the `$lookup` in the list query, which uses the index on
+  the *foreign* side of the join (`works._id`), and nothing else filters on
+  `workRef` — the maintenance scripts that care about it group in Node from a
+  full read. They are declared honestly rather than dropped, because dropping
+  an index is a human's call and undeclaring one would only leave it live and
+  unexplained. See the comment in `index_plan.js` and #180.
 - **`apiRefs` is an array**, so its index is a *multikey* index. That is
   correct, not something to fix: `findCachedWork` asks
   `{ apiRefs: "igdb__1234" }`, an equality match against one element, which

--- a/src/db_maintenance/index_plan.js
+++ b/src/db_maintenance/index_plan.js
@@ -11,9 +11,11 @@
  * ascending field named after the field one of those calls is given. `_id` is
  * already indexed by MongoDB itself.
  *
- * The exception is the entry list, which sorts as well as matches, and wants a
- * compound index so that the sort can be *served* rather than performed. See
- * the `updatedDate` entry below.
+ * Two exceptions want a compound index. The entry list sorts as well as
+ * matches, and a compound index lets the sort be *served* rather than
+ * performed — see the `updatedDate` entry below. `findDraft` matches on three
+ * fields rather than one, and a compound index takes it from a seek plus an
+ * in-memory filter to a single seek — see the `entryRevisions` entries.
  *
  * The collection names come from ../api/utils/work_types.js, which is pure
  * too, so this file stays testable without an install.
@@ -89,20 +91,66 @@ const DESIRED_INDEXES = [
     key: { userId: 1, updatedDate: -1, _id: 1 },
     why: "the sort and limit in toUserEntriesPipeline — every list load and every profile load",
   })),
+  // These four are declared without a query behind them, which is the opposite
+  // of what this file asks for, so here is the whole of it.
+  //
+  // They were justified by "the local side of the $lookup in
+  // _findAllUserEntriesWithMetadata", and a `$lookup` uses an index on the
+  // *foreign* side: `toUserEntriesPipeline` joins `localField: 'workRef'` to
+  // `foreignField: '_id'` on the works collection, so the index that serves it
+  // is `works._id`, which MongoDB maintains itself. The local field is read off
+  // documents the `$match` and the `$sort` have already chosen; there is
+  // nothing left for an index on it to do.
+  //
+  // Nor does anything else ask for one. `workRef` appears in exactly three
+  // places outside the pipeline, and none of them is a filter on it:
+  // dedupe_works.js repoints entries at a survivor with
+  // `updateMany({ _id: { $in: ids } }, ...)`, having grouped them by `workRef`
+  // in Node from a full `find()` (see work_dedupe_plan.js); audit_database.js
+  // and backfill_game_playtimes.js do the same reading in memory.
+  //
+  // So the trade as it stands is four indexes maintained on every entry write,
+  // and nothing reads them. That is an index to drop by the rule at the top of
+  // this file — but dropping one is a human's call (CLAUDE.md) and nothing here
+  // drops anything anyway: deleting the entry would only leave the indexes live
+  // and no longer declared, which is worse than either. So they stay declared,
+  // honestly, until someone decides. See #180.
   ...ENTRY_COLLECTIONS.map((collection) => ({
     collection,
     key: { workRef: 1 },
-    why: "the local side of the $lookup in _findAllUserEntriesWithMetadata",
+    why: "no query — the $lookup that named these joins on works._id, and dedupe_works.js repoints by _id; see the comment above and #180",
   })),
   ...REVIEW_COLLECTIONS.map((collection) => ({
     collection,
     key: { entryRef: 1 },
     why: "getReview on every expanded row, findReviews in the export",
   })),
+  // Kept beside the compound index below for the reason the plain `userId` one
+  // is kept beside its compound: the compound serves this index's prefix, so
+  // this answers nothing that one cannot, but undeclaring it would leave it
+  // live in the database and no longer explained. It is also the narrower
+  // index, and discardHistory's delete on `entryRef` alone reads no other
+  // field, so it walks fewer bytes through this one.
   {
     collection: "entryRevisions",
     key: { entryRef: 1 },
-    why: "every history read, every draft read, every save; findDraft runs on every autosave, once every 2.5s while an edit form is open",
+    why: "every history read, every draft read, every save, and discardHistory when an entry is deleted",
+  },
+  // `findDraft` asks `{ entryRef, kind: 'draft', userId }` and is the hottest
+  // read in this collection — once every 2.5 seconds per open edit form. On the
+  // single-field index above, the seek lands on the entry and the server then
+  // filters the rest in memory: up to MAX_REVISIONS_PER_ENTRY (50) documents
+  // read to keep one, each carrying a whole snapshot including the note. With
+  // all three fields in the index it is one seek to the one document.
+  //
+  // `findRevisions` matches `{ entryRef, kind: 'revision' }`, which is this
+  // index's prefix, so it is served by the same index — and `kind` being second
+  // rather than last is what makes that true. `userId` is last because it is
+  // the field only findDraft adds.
+  {
+    collection: "entryRevisions",
+    key: { entryRef: 1, kind: 1, userId: 1 },
+    why: "findDraft on every autosave, once every 2.5s while an edit form is open; findRevisions on every history read is served by its prefix",
   },
   // `apiRefs` is an array, so this is a **multikey** index — one index entry
   // per element. That is correct and is not something to "fix": findCachedWork

--- a/src/db_maintenance/index_plan.test.js
+++ b/src/db_maintenance/index_plan.test.js
@@ -70,6 +70,7 @@ test("the list covers every field the issue names, and no field twice", () => {
     "gameReviews.entryRef_1",
     "bookReviews.entryRef_1",
     "entryRevisions.entryRef_1",
+    "entryRevisions.entryRef_1_kind_1_userId_1",
     "films.apiRefs_1",
     "tvShows.apiRefs_1",
     "games.apiRefs_1",
@@ -281,4 +282,86 @@ test("the compound index is created beside the plain one, not in place of it", (
     plan.create.map((index) => indexName(index.key)),
     ["userId_1_updatedDate_-1__id_1"]
   );
+});
+
+test("findDraft's three fields are all in one index, in an order findRevisions can share", () => {
+  // findDraft asks `{ entryRef, kind: 'draft', userId }` — the hottest read in
+  // the collection — and findRevisions asks `{ entryRef, kind: 'revision' }`.
+  // An index serves an equality match on a set of fields when they are a
+  // prefix of the key, so `kind` has to come before `userId` for the second
+  // query to be served by the first one's index.
+  const keys = DESIRED_INDEXES.filter(
+    (index) => index.collection === "entryRevisions"
+  ).map((index) => index.key);
+
+  const draft = keys.find(
+    (key) => JSON.stringify(key) === JSON.stringify({ entryRef: 1, kind: 1, userId: 1 })
+  );
+  assert.ok(draft, "entryRevisions has no index over entryRef, kind and userId");
+
+  const fields = Object.keys(draft);
+  assert.deepEqual(fields.slice(0, 2), ["entryRef", "kind"]);
+  assert.ok(
+    Object.values(draft).every((direction) => direction === 1),
+    "nothing here sorts on these, so every field is ascending"
+  );
+});
+
+test("the plain entryRef index is still declared alongside the compound one", () => {
+  // Same reason as the plain userId index above: the compound serves this
+  // one's prefix, but undeclaring it would leave it live in the database and
+  // no longer explained.
+  const names = DESIRED_INDEXES.filter(
+    (index) => index.collection === "entryRevisions"
+  ).map((index) => indexName(index.key));
+
+  assert.ok(names.includes("entryRef_1"));
+});
+
+test("the draft index is one to create against the database as #147 left it", () => {
+  // The 23 indexes applied on 2026-08-18 include `entryRevisions.entryRef_1`
+  // and nothing else on that collection, so the compound one is new work for
+  // `ensure_indexes.js` rather than something it would consider satisfied.
+  const plan = planIndexes(
+    DESIRED_INDEXES.filter((index) => index.collection === "entryRevisions"),
+    { entryRevisions: [existing("_id_", { _id: 1 }), existing("entryRef_1", { entryRef: 1 })] }
+  );
+
+  assert.deepEqual(plan.conflicting, []);
+  assert.deepEqual(
+    plan.create.map((index) => indexName(index.key)),
+    ["entryRef_1_kind_1_userId_1"]
+  );
+  assert.equal(plan.satisfied.length, 1);
+});
+
+test("every workRef index says it has no query, rather than naming one it cannot serve", () => {
+  // The $lookup these used to name joins `localField: 'workRef'` to
+  // `foreignField: '_id'`, and a $lookup uses the index on the foreign side —
+  // `works._id`. Nothing else filters on `workRef` either. They stay declared
+  // because dropping an index is a human's call and undeclaring one only hides
+  // it, so what the dry run prints has to be the honest version.
+  const workRefIndexes = DESIRED_INDEXES.filter(
+    (index) => JSON.stringify(index.key) === JSON.stringify({ workRef: 1 })
+  );
+
+  assert.deepEqual(
+    workRefIndexes.map((index) => index.collection),
+    ENTRY_COLLECTIONS
+  );
+  for (const index of workRefIndexes) {
+    assert.doesNotMatch(index.why, /\$lookup in _findAllUserEntriesWithMetadata/);
+    assert.match(index.why, /no query/);
+  }
+});
+
+test("nothing in toUserEntriesPipeline's $lookup wants a local index", () => {
+  // Reading the pipeline rather than restating it: if the join ever turns
+  // around — `workRef` on the foreign side of a lookup from `works` — these
+  // four indexes acquire a user and this test is the thing that fails.
+  const stages = toUserEntriesPipeline({ userId: "u1", workCollection: "films" });
+  const { $lookup } = stages.find((stage) => stage.$lookup);
+
+  assert.equal($lookup.localField, "workRef");
+  assert.equal($lookup.foreignField, "_id");
 });


### PR DESCRIPTION
Closes #180. `index_plan.js` asks that every index be able to name a query, because "an index nobody can name a query for is an index to delete". Two entries were not holding up their end of that. Both fixes are in the plan and its tests; nothing has been applied to the database.

## The four `workRef` indexes

Their `why` said "the local side of the `$lookup` in `_findAllUserEntriesWithMetadata`". A `$lookup` uses the index on the *foreign* side — `toUserEntriesPipeline` joins `localField: 'workRef'` to `foreignField: '_id'` on the works collection, so the index that serves the join is `works._id`, which MongoDB maintains itself. The local field is read off documents the `$match` and the `$sort` have already chosen; there is nothing left for an index on it to do. There is now a test that reads the `$lookup` out of the pipeline rather than restating it, so if the join ever turns around these four acquire a user and the test is what fails.

**One correction to the issue, which changes the conclusion.** #180 expected the honest `why` to be "the `updateMany` in `dedupe_works.js`", but that script does not query `workRef`: it repoints entries with `updateMany({ _id: { $in: plan.entriesToRepoint } }, ...)`, having grouped them by `workRef` in Node from a full `find()` (`work_dedupe_plan.js`). `audit_database.js` and `backfill_game_playtimes.js` read `workRef` the same way, in memory. Across the repo, `workRef` never appears in a filter. So the trade is not "four indexes for an occasional maintenance script" — it is four indexes maintained on every entry write with nothing at all reading them, and that is what the `why` and the comment now say.

**The decision is yours.** By this file's own rule these are indexes to drop, but dropping one is a human's call per CLAUDE.md, and nothing here drops anything — deleting the entry would only leave the indexes live in the database and no longer declared, which is the one state worse than either. They stay declared, honestly, until you decide. If you want them gone, that is a `dropIndex` by hand on four collections plus removing the entry here.

## `findDraft` matches three fields against a one-field index

`revisions.js` asks `{ entryRef, userId, kind: 'draft' }` and the only declared index was `{ entryRef: 1 }`, so the seek lands on the entry and the server filters the rest in memory — up to `MAX_REVISIONS_PER_ENTRY` (50) documents, each carrying a whole snapshot including the note — on what its own `why` calls the hottest read in the collection, once every 2.5 seconds per open edit form. This adds `{ entryRef: 1, kind: 1, userId: 1 }`, which makes it a single seek. `kind` is second rather than last so that `findRevisions`' `{ entryRef, kind: 'revision' }` is served by the index's prefix; a test asserts that ordering rather than just the presence of the three fields.

The plain `{ entryRef: 1 }` index stays beside the compound one for exactly the reason the plain `{ userId: 1 }` index stays beside its compound — it is the narrower index, and `discardHistory`'s delete on `entryRef` alone reads no other field — with a test mirroring the existing one.

## Applying it

Not done here, and it needs you. #147 confirms the 23 declared indexes are live as of 2026-08-18, so this new one is the twenty-fourth and `ensure_indexes.js` will report it as one to create. Per CLAUDE.md that is a fresh verified snapshot and then `--apply` — a human's approval, like the last one. The README's durable record is updated to say so: a dry run today prints `23 index(es) already exist, 1 would be created, 0 conflict`, and the paragraph says what it should read once the index is built.

`npm test` passes — 362 tests, 5 new.
