### PR TITLE
feat: send a CSP and the rest of the security headers, and pin nf_jwt to SameSite=Lax

### DIFF
--- a/_headers
+++ b/_headers
@@ -40,3 +40,61 @@
 
 /css/*
   Cache-Control: public, max-age=31536000, immutable
+
+# Everything below is site-wide, and none of it was being sent at all: no CSP,
+# no `nosniff`, no referrer policy, no HSTS (#173). The reason to care is
+# `nf_jwt` — a 14-day HS256 token that is the whole session, and that
+# `Http.getToken` reads out of `document.cookie` because the API takes it as a
+# bearer header. Any script that runs on this page can read it and keep it for
+# a fortnight, so the cheapest real mitigation is to stop a script that isn't
+# ours from running in the first place.
+#
+# The policy is not trusting the two CDN hosts it names: every third-party url
+# in `layouts/base.njk` is pinned to an exact version and carries an
+# `integrity` hash, so what an origin allowlist adds is a rule about where a
+# script may come from at all, on top of bytes that are already checked.
+#
+# Report-only first, deliberately. Nothing here has ever run under a CSP, so
+# this policy is a hypothesis about what the page loads, and an enforcing
+# header would turn a wrong guess into a blank site. In this mode a violation
+# is a console message and nothing else, which is what makes it safe to read a
+# real page load — logged in, on a list, on the profile charts and in the
+# entry form — before switching the header name to `Content-Security-Policy`.
+#
+# `style-src` needs `'unsafe-inline'`: `components/index.js` appends a
+# `<style id="component-styles">` and every component writes its rules into it
+# at runtime, and litepicker and apexcharts inject their own on top of that.
+# `script-src` does not get it, which is the whole point of the exercise — the
+# scripts are eight pinned CDN files and one hashed same-origin bundle, every
+# one of them loaded by `src`. The known exception is the `onclick` that
+# `utils/columns.js` writes into each row's edit icon: an inline handler is a
+# `script-src` violation, so an owner viewing their own list is what
+# report-only is here to measure.
+#
+# `font-src` names cdnjs because Bootstrap's glyphicons and Font Awesome's
+# webfonts are fetched by those stylesheets relative to themselves; under
+# `default-src 'self'` alone they would be the first thing to break.
+#
+# `img-src` is the loose one: cover art urls are stored on the work documents
+# and come from whatever TMDB, IGDB or Google Books handed back, so an
+# allowlist would be a list of every provider the metadata scripts have ever
+# used. `https:` is honest about that, still rules out `http:`, and an image
+# is not what a token thief needs.
+#
+# There is no `report-uri`/`report-to`: nothing here collects them, and a
+# violation in the console is what this is for. Adding a collector means
+# sending someone else every url this site loads, which is its own decision.
+#
+# These rules sit in this file rather than `netlify.toml` for the same reason
+# the cache rules above do — see that note. Netlify applies every rule whose
+# path matches, so `/js/*` keeps its `immutable` and gains these as well; a
+# deploy preview is the place to confirm both, since neither a build nor a
+# test can. Comments are kept out of the rule block below for the same
+# reflex: this file's whole history is header rules silently not applying, and
+# an indented `#` is one more thing that would have to be right.
+
+/*
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; img-src 'self' https: data:; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains

--- a/_headers
+++ b/_headers
@@ -85,6 +85,20 @@
 # violation in the console is what this is for. Adding a collector means
 # sending someone else every url this site loads, which is its own decision.
 #
+# What a `/*` rule does not reach is `/api/*`. A deploy preview answers
+# `/api/export/films/nil` with none of these — the rules are applied to pages
+# and static assets, and a function's response headers are the function's own.
+# So `nosniff` covers the site and not the export endpoint, which is the one
+# place here that answers two content types off one path. Putting it there too
+# means `utils/responses.js`, and that is a separate change.
+#
+# `Strict-Transport-Security` is the one header a preview cannot confirm:
+# `*.netlify.app` carries Netlify's own `max-age=31536000; includeSubDomains;
+# preload` whatever this file says, so what comes back there is theirs rather
+# than ours. On nil.moe the default is a bare `max-age=31536000`, and this rule
+# replaces it the way the cache rules above replace theirs — worth a look at
+# production after the merge, since it is the only place it shows.
+#
 # These rules sit in this file rather than `netlify.toml` for the same reason
 # the cache rules above do — see that note. Netlify applies every rule whose
 # path matches, so `/js/*` keeps its `immutable` and gains these as well; a

--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -101,6 +101,25 @@ const generateNetlifyCookie = (netlifyToken) =>
     secure: !isRunningLocally,
     path: "/",
     maxAge: NETLIFY_JWT_EXPIRATION_SECONDS,
+    // Unlike the login cookie above, this one is only ever sent to us by our
+    // own pages: the API is same-origin and the frontend reads the cookie and
+    // repeats it as a bearer header anyway. So the widest thing SameSite has
+    // to allow is a top-level navigation back to the site, and Lax allows
+    // exactly that. It does not get in the way of the Auth0 callback either —
+    // SameSite decides when a cookie is *sent*, and setting one on that
+    // cross-site form_post is unaffected; the redirect that follows it is a
+    // same-site GET.
+    //
+    // Chrome already treats an unset SameSite as Lax, so on that browser this
+    // changes nothing and is written down instead of assumed. Elsewhere the
+    // default is still None, which is where it was worth something.
+    //
+    // Not `httpOnly`, which is the change this cookie actually wants and
+    // cannot have yet: `Http.getToken` reads it from `document.cookie` and
+    // `refreshTokenIfNecessary` parses its `exp` there, so hiding it means
+    // moving the API to the cookie `getNetlifyJWTFromEvent` already accepts.
+    // Its own issue, not this one (#173).
+    sameSite: "lax",
   })
 
 const generateNetlifyCookieFromAuth0Token = async (tokenData) =>

--- a/src/api/controllers/auth_cookie.test.js
+++ b/src/api/controllers/auth_cookie.test.js
@@ -7,6 +7,13 @@
  * through the same `generateNetlifyCookie`, needs nothing but a valid token,
  * and is therefore where the attributes can be asserted at all.
  *
+ * A deploy preview is not the fallback it looks like: Netlify sets `URL` to
+ * the site's primary url in every context, so a preview's `/api/auth/login`
+ * redirects with `redirect_uri=https://nil.moe/...` and Auth0 posts the
+ * callback to production. The login cookie was set on the preview's domain
+ * and is not sent there, so the flow fails on the preview whatever the branch
+ * says — which leaves this file and, after a merge, a real login.
+ *
  * The `httpOnly` assertion is inverted on purpose: it is deliberately absent,
  * because `Http.getToken` reads this cookie out of `document.cookie`. Turning
  * it on is a separate change that has to move the API to cookie-borne auth

--- a/src/api/controllers/auth_cookie.test.js
+++ b/src/api/controllers/auth_cookie.test.js
@@ -1,0 +1,104 @@
+/**
+ * @file The attributes the session cookie is set with, which nothing checked.
+ *
+ * `nf_jwt` is the whole session — a 14-day HS256 token — and #173 is about
+ * the attributes it was missing. The login flow that sets it runs through
+ * Auth0 and cannot be exercised here, but `handleRenew` mints the same cookie
+ * through the same `generateNetlifyCookie`, needs nothing but a valid token,
+ * and is therefore where the attributes can be asserted at all.
+ *
+ * The `httpOnly` assertion is inverted on purpose: it is deliberately absent,
+ * because `Http.getToken` reads this cookie out of `document.cookie`. Turning
+ * it on is a separate change that has to move the API to cookie-borne auth
+ * first, and this test is what makes that a decision rather than a surprise.
+ *
+ * It needs the dependencies, so it **skips itself** when they aren't
+ * installed — which is how CI runs the suite.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('jose')
+    require('cookie')
+    require('openid-client')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
+
+const jose = dependenciesInstalled ? require('jose') : undefined
+const { handleRenew, handleLogout } = dependenciesInstalled
+  ? require('./auth')
+  : {}
+
+const secret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
+
+/** A token shaped like the one `signNetlifyJWT` mints. */
+const sign = () => {
+  const iat = Math.floor(Date.now() / 1000)
+  return new jose.SignJWT({
+    exp: iat + 14 * 24 * 3600,
+    iat,
+    updated_at: iat,
+    aud: 'memo',
+    sub: 'auth0|nil',
+    app_metadata: { authorization: { roles: ['user'] } },
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(secret())
+}
+
+/** The attributes of a `Set-Cookie`, lowercased, without their values. */
+const attributesOf = (setCookie) =>
+  setCookie
+    .split(';')
+    .slice(1)
+    .map((part) => part.trim().split('=')[0].toLowerCase())
+
+const renewedCookie = async () => {
+  const response = await handleRenew({
+    headers: { authorization: `Bearer ${await sign()}` },
+  })
+  assert.equal(response.statusCode, 200)
+  return response.headers['Set-Cookie']
+}
+
+test('the session cookie is SameSite=Lax', options, async () => {
+  // Lax rather than Strict: the Auth0 callback answers with a redirect and the
+  // browser has to send the cookie on that top-level navigation. Lax rather
+  // than nothing: an unset SameSite is Lax on Chrome and None elsewhere, and
+  // None on a bearer token that never needs to travel cross-site is worth
+  // nothing to us and something to a forged request.
+  assert.match(await renewedCookie(), /;\s*SameSite=Lax/i)
+})
+
+test('the session cookie is Secure, site-wide, and not HttpOnly', options, async () => {
+  const cookie = await renewedCookie()
+  const attributes = attributesOf(cookie)
+
+  assert.equal(attributes.includes('secure'), true)
+  assert.match(cookie, /;\s*Path=\//i)
+  assert.match(cookie, /;\s*Max-Age=1209600/i)
+  // Not a wish list: the frontend reads this cookie from `document.cookie`, so
+  // `httpOnly` here would log everyone out. See the file comment.
+  assert.equal(attributes.includes('httponly'), false)
+})
+
+test('logging out clears the same cookie', options, async () => {
+  // Same name and path, or the browser keeps the one it has alongside it and
+  // the session outlives the logout.
+  const response = await handleLogout()
+  const cookie = response.headers['Set-Cookie']
+
+  assert.match(cookie, /^nf_jwt=;/)
+  assert.match(cookie, /;\s*Path=\//i)
+})


### PR DESCRIPTION
Closes #173.

The site sends no `Content-Security-Policy`, no `X-Content-Type-Options`, no `Referrer-Policy` and no `Strict-Transport-Security`, and `nf_jwt` — a 14-day HS256 token that is the whole session — is set without `SameSite`. This adds the four headers and pins the cookie to `SameSite=Lax`. `HttpOnly` is deliberately not here: `Http.getToken` reads the cookie out of `document.cookie` and `refreshTokenIfNecessary` parses its `exp` client-side, so switching it on means moving the API to the cookie `getNetlifyJWTFromEvent` already accepts, which is a separate change and its own issue.

The CSP ships as `Content-Security-Policy-Report-Only`. Nothing on this site has ever run under one, so the policy is a hypothesis about what a page loads rather than a description of it, and an enforcing header would turn a wrong guess into a blank site. In report-only mode a violation is a console message and nothing else, which is what makes it safe to watch real page loads before renaming the header.

```
default-src 'self';
script-src  'self' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net;
style-src   'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net;
img-src     'self' https: data:;
font-src    'self' https://cdnjs.cloudflare.com;
connect-src 'self';
frame-ancestors 'none'; base-uri 'none'; object-src 'none'
```

`script-src` has no `'unsafe-inline'`, which is the point of the exercise — every script is one of eight version-pinned, SRI-hashed CDN files or the one hashed same-origin bundle, all loaded by `src`. `style-src` does need it: `components/index.js` appends a `<style id="component-styles">` and every component writes its rules into it at runtime, with litepicker and apexcharts injecting their own on top. `font-src` names cdnjs because Bootstrap's glyphicons and Font Awesome's webfonts are fetched by those stylesheets relative to themselves, and under `default-src 'self'` alone they would be the first thing to break. `img-src` is the loose one on purpose: cover art urls are stored on the work documents as whatever TMDB, IGDB or Google Books handed back, so an allowlist would be a list of every provider the metadata scripts have ever used; `https:` is honest about that and still rules out `http:`. There is no `report-uri`/`report-to` — nothing here collects them, and adding a collector means sending a third party every url this site loads, which is its own decision.

**One violation is already expected and is not in the numbers below.** `utils/columns.js` writes `onclick="window.editEntry(...)"` into each row's edit icon — deliberately, because bootstrap-table destroys and rebuilds the node — and an inline handler is a `script-src` violation. That column only renders for the owner of a list, so an anonymous load does not reach it. It is the thing to fix before this becomes enforcing, not a reason to widen `script-src` now.

`SameSite=Lax` on the session cookie costs nothing today, and the reasoning is worth checking rather than taking on trust: the API is same-origin and the frontend repeats the cookie as a bearer header anyway, so the widest thing SameSite has to allow is a top-level navigation back to the site. The Auth0 callback is unaffected — SameSite decides when a cookie is *sent*, not whether one can be set on a cross-site `form_post` — and the 302 the callback answers with is a top-level GET to our own origin, which is exactly what Lax permits. Chrome has treated an unset SameSite as Lax for years, so on that browser this changes nothing and writes down what was being assumed; the browsers where the default is still None are where it buys something.

`auth_cookie.test.js` is new, and it exists because `handleRenew` is the only place the session cookie can be minted without Auth0 — same `generateNetlifyCookie`, same attributes. It pins `SameSite=Lax`, `Secure`, `Path`, `Max-Age`, and the *absence* of `httpOnly`, so that turning that on stays a decision rather than a surprise logout.

## What the deploy preview settled

Given this repo's history of header rules silently not applying, everything here was checked against https://deploy-preview-187--td-memo.netlify.app rather than reasoned about.

- **The four headers arrive** on `/` and on a client-routed `/films/nil`. Netlify's "Header rules" check passes.
- **`/js/*` and `/css/*` keep `immutable` and gain them too** — `Cache-Control: public,max-age=31536000,immutable` alongside the CSP on `bundle.<hash>.js` and `main.<hash>.css`. Netlify does apply every rule whose path matches.
- **`netlify-headers-parser`**, Netlify's own parser, reads the built `dist/_headers` with zero errors and three rules; the semicolons inside the CSP value do not break the parse. Comments are kept outside the rule block anyway.
- **A real page load violates nothing.** `/films/nil` renders 1518 images (1491 from themoviedb.org, the rest the local fallback), zero broken; `/profile/nil` draws 13 apexcharts SVGs; the component `<style>` fills with 3130 characters of injected CSS; and both cdnjs webfonts load. The only console violation on either page is Netlify's own deploy-preview drawer framing `app.netlify.com`, which does not exist in production.
- `npm test`: 365 pass, 0 fail, 0 skipped.

## What it could not settle, and why

**`/api/*` is not covered by any of this.** A function's response headers are its own, so `/api/export/films/nil` comes back with none of the four — `nosniff` reaches the site but not the one endpoint that answers two content types off one path. Putting it there means `utils/responses.js` and is left out of this change deliberately; say the word and it can be its own PR.

**`Strict-Transport-Security` cannot be checked on a preview at all.** `*.netlify.app` carries Netlify's own `max-age=31536000; includeSubDomains; preload` whatever this file says, so what comes back there is theirs, not ours. On nil.moe the current default is a bare `max-age=31536000`, and this rule should replace it the way the cache rules replace theirs — but only production can show that, so it is worth one `curl -I https://nil.moe/` after the merge. Related, and the line most worth arguing with: `includeSubDomains` commits *everything* under nil.moe to HTTPS, not just this site. It is what #173 asks for and there is no `preload`, which would be the hard-to-reverse one — but it is the clause to drop if another subdomain of that apex is not ready.

**The login flow has not been exercised end to end, and cannot be on a preview.** Netlify sets `URL` to the site's primary url in every deploy context, so the preview's `/api/auth/login` redirects with `redirect_uri=https://nil.moe/.netlify/functions/auth/callback` and Auth0 posts the callback to production — where the `auth0_login_cookie` the preview just set was never stored. Logging in from the preview therefore fails on any branch and proves nothing about this one. What is checked instead: the exact `Set-Cookie` string this code produces, asserted in the new test, and `/api/auth/login` still answering a 302 to Auth0 with its own cookie unchanged at `HttpOnly; Secure; SameSite=None`. What remains is one manual login on nil.moe after the merge, confirming the session survives the Auth0 round-trip and that `nf_jwt` comes back carrying `SameSite=Lax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
