### PR TITLE
fix(frontend): end the waits that never end, and empty the row registry

### DIFF
--- a/src/frontend/_includes/js/components/list/add_edit_entry/draft.js
+++ b/src/frontend/_includes/js/components/list/add_edit_entry/draft.js
@@ -139,10 +139,7 @@ Components.List.DraftNotice = DraftNotice
  * entirely and that must not disable autosaving the rest of the form.
  */
 const whenCommentsAreLoaded = () =>
-  Promise.race([
-    waitForEl('#add-entry-fields textarea'),
-    new Promise((resolve) => setTimeout(resolve, COMMENTS_WAIT_MS)),
-  ])
+  waitForEl('#add-entry-fields textarea', { timeout: COMMENTS_WAIT_MS })
 
 const offerExistingDraft = ({ id, type, data, saved }) => {
   getDraft(type, data.dbRef)

--- a/src/frontend/_includes/js/components/list/index.js
+++ b/src/frontend/_includes/js/components/list/index.js
@@ -1,6 +1,7 @@
 const { initComponent, Error404, WithRemoteData } = Components
 const { getUserIdFromName, getUserName, getEntries } = Netlify
 const { getNameFromUrl, getEntryTypeFromUrl } = Http
+const { waitForEl } = Utils
 const { List } = Components.List
 const { typeToTitle } = Conversions
 
@@ -41,24 +42,23 @@ const ListPage = () => initComponent({
     const urlAnchor = window.location.hash.substring(1)
 
     // Wait for the anchor element to actually be rendered, then unfold
-    // the review and jump to the element
+    // the review and jump to the element. The fragment is whatever was in the
+    // url, so it may well name a row that is not on this page — a deleted
+    // entry, a link to somebody else's list, a typo — and the wait has to end
+    // either way rather than watch the document for a row that is not coming.
+    //
+    // `CSS.escape` because that same fragment goes into a selector here: an
+    // id is free to contain characters that mean something to a selector
+    // parser, and an unescaped one throws instead of matching nothing.
     if (urlAnchor) {
-      const observer = new MutationObserver((mutations, obs) => {
-        const element = document.getElementById(urlAnchor)
-        if (element) {
-          $(`#${urlAnchor}`).parent().prev().find('i').trigger('click')
+      waitForEl(`#${CSS.escape(urlAnchor)}`).then((element) => {
+        if (!element) return
 
-          // jump to the element, hacky as fuck
-          location.hash = '#__nothing'
-          location.hash = '#' + urlAnchor
-          obs.disconnect()
-          return
-        }
-      })
+        $(element).parent().prev().find('i').trigger('click')
 
-      observer.observe(document, {
-        childList: true,
-        subtree: true
+        // jump to the element, hacky as fuck
+        location.hash = '#__nothing'
+        location.hash = '#' + urlAnchor
       })
     }
   }

--- a/src/frontend/_includes/js/components/list/list.js
+++ b/src/frontend/_includes/js/components/list/list.js
@@ -1,4 +1,4 @@
-const { html, css, escapeHtml } = Utils
+const { html, css, escapeHtml, waitForEl } = Utils
 const { col, initTable, detailFormatter, allColumns, statuses, entryTypeToFullColumns, editColumn, filmStatuses } = Tables
 const { typeToTitle, statusToTitle } = Conversions
 const { initComponent, WithRemoteData, appendContent, Nothing } = Components
@@ -44,38 +44,47 @@ const List = ({ username, entryType, entries, isOwner }) => initComponent({
     </div>
   `,
   initializer: () => {
-    // Show helpful image next to the first open-review-icon
-    // in the DOM
-    
+    // Emptied here, before the tables below fill it, so that what a render
+    // leaves behind is its own rows rather than those plus every row of every
+    // list drawn before it.
+    Rows.byRef = {}
+
+    // One handler for the page rather than one per sublist: the button hands
+    // over a `dbRef` and the registry it is looked up in is shared, so what
+    // each table used to install was this same closure, and only the last of
+    // them survived.
+    window.editEntry = (dbRef) => {
+      appendContent('body', Modal_({
+        title: "Edit an entry",
+        content: EntryForm(entryType, Rows.byRef[dbRef]),
+        showCloseConfirmationDialog: () => window.hasUnsavedChange === true
+      }))
+    }
+
+    // Show helpful image next to the first open-review-icon in the DOM. A
+    // list with no rows in it never grows one, which is what the wait gives
+    // up on: a hint nobody can be shown is not worth watching the document
+    // for as long as the page is open.
     if (Netlify.isLoggedIn()) {
       return
     }
 
-    const observer = new MutationObserver((mutations, obs) => {
-      const el = document.querySelector('a.detail-icon')
-      const helperImg = document.querySelector('#click-to-see-comments')
-      if (el && !helperImg) {
-        obs.disconnect()
-        setTimeout(() => {
-          $(el)
-            .parent()
-            .parent()
-            .parent()
-            .parent()
-            .parent()
-            .parent()
-            .parent()
-            .before(html`
-              <div id="click-to-see-comments">Click here to<br>read comments! <i class="fas fa-location-arrow" style="opacity:.7;"></i></div>
-            `)
-        }, 200)
-        return
-      }
-    })
+    waitForEl('a.detail-icon').then((el) => {
+      if (!el || document.querySelector('#click-to-see-comments')) return
 
-    observer.observe(document, {
-      childList: true,
-      subtree: true
+      setTimeout(() => {
+        $(el)
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .before(html`
+            <div id="click-to-see-comments">Click here to<br>read comments! <i class="fas fa-location-arrow" style="opacity:.7;"></i></div>
+          `)
+      }, 200)
     })
   },
   style: () => css`
@@ -229,7 +238,7 @@ const SubList = (status, entryType, isOwner, data) => initComponent({
 const initFullTable = (selector, data, entryType, isOwner, status) => {
   // The edit button names its row rather than carrying a copy of it, so
   // rows are kept here for it to name. `dbRef` is unique across the page, so
-  // one registry serves every table on it.
+  // one registry serves every table on it, and `List` empties it per render.
   data.forEach((row) => { Rows.byRef[row.dbRef] = row })
 
   initTable(selector, data, {
@@ -246,13 +255,6 @@ const initFullTable = (selector, data, entryType, isOwner, status) => {
       ...(isOwner ? [Columns.edit()] : []),
     ]
   })
-  window.editEntry = (dbRef) => {
-    appendContent('body', Modal_({
-      title: "Edit an entry",
-      content: EntryForm(entryType, Rows.byRef[dbRef]),
-      showCloseConfirmationDialog: () => window.hasUnsavedChange === true
-    }))
-  }
 }
 
 const toStats = (entries, entryType) => {

--- a/src/frontend/_includes/js/utils/general.js
+++ b/src/frontend/_includes/js/utils/general.js
@@ -16,20 +16,46 @@ const css = noOpTagFunction
 
 const noOp = () => undefined
 
-const waitForEl = (selector) => new Promise((resolve) => {
-  if (document.querySelector(selector)) {
-    return resolve(document.querySelector(selector))
-  }
+/**
+ * Long enough for anything the page is already fetching to arrive, short
+ * enough that a wait for something that is never coming ends.
+ */
+const WAIT_FOR_EL_TIMEOUT_MS = 10000
 
-  const observer = new MutationObserver((mutations) => {
-    if (document.querySelector(selector)) {
-      resolve(document.querySelector(selector))
+/**
+ * The element once it is on the page, or `undefined` if it has not arrived
+ * within `timeout`.
+ *
+ * The timeout is the point. Every caller here is waiting for something a
+ * failed request, an empty list or a stale url can leave out of the page
+ * entirely, and a wait that only ends on a match is a `querySelector` over
+ * the whole document on every mutation for the life of the page — on a page
+ * that redraws its tables on every column toggle, sort and search — plus a
+ * promise that never settles and whatever the caller was holding for it.
+ *
+ * So callers have to handle `undefined`, and in exchange they never have to
+ * bound the wait themselves.
+ * @type {(selector: string, options?: { timeout?: number }) => Promise<Element | undefined>}
+ */
+const waitForEl = (selector, { timeout = WAIT_FOR_EL_TIMEOUT_MS } = {}) =>
+  new Promise((resolve) => {
+    const existing = document.querySelector(selector)
+    if (existing) return resolve(existing)
+
+    let timer
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector(selector)
+      if (el) settle(el)
+    })
+    const settle = (el) => {
+      clearTimeout(timer)
       observer.disconnect()
+      resolve(el)
     }
-  })
 
-  observer.observe(document.body, { childList: true, subtree: true })
-})
+    timer = setTimeout(() => settle(undefined), timeout)
+    observer.observe(document.body, { childList: true, subtree: true })
+  })
 
 /**
  * "3 hours ago" reads faster than a date when something just happened, which

--- a/src/frontend/_includes/js/utils/general.test.js
+++ b/src/frontend/_includes/js/utils/general.test.js
@@ -93,3 +93,88 @@ test('a missing url is missing, not a link to nowhere', () => {
   assert.equal(toSafeUrl(null), undefined)
   assert.equal(toSafeUrl(''), undefined)
 })
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * `waitForEl` is the one thing in this file that touches the DOM, so it gets a
+ * context with just enough of one: a `document` that answers `querySelector`
+ * from a variable the test sets, and a `MutationObserver` that keeps hold of
+ * its callback — so a test can say when the page changed — and records whether
+ * it is still watching.
+ *
+ * The same source, evaluated into a context of its own rather than into this
+ * one: the tests above want Node's real globals and this one wants a page.
+ */
+const withFakeDom = () => {
+  const page = { el: null, observing: false, notify: () => {} }
+
+  const context = vm.createContext({
+    document: {
+      body: {},
+      querySelector: () => page.el,
+    },
+    MutationObserver: class {
+      constructor(callback) { page.notify = callback }
+      observe() { page.observing = true }
+      disconnect() { page.observing = false }
+    },
+    setTimeout,
+    clearTimeout,
+  })
+
+  const { waitForEl } = vm.runInContext(
+    `(() => {\n${source}\n;return Utils\n})()`,
+    context
+  )
+
+  /** Put the element on the page, and tell the observer the page changed. */
+  page.render = (el) => {
+    page.el = el
+    page.notify()
+  }
+
+  return { page, waitForEl }
+}
+
+test('an element already on the page is handed over without a wait', async () => {
+  const { page, waitForEl } = withFakeDom()
+  page.el = 'the icon'
+
+  assert.equal(await waitForEl('a.detail-icon', { timeout: 50 }), 'the icon')
+  assert.equal(page.observing, false)
+})
+
+test('an element that arrives ends the wait and the watching', async () => {
+  const { page, waitForEl } = withFakeDom()
+  const waiting = waitForEl('a.detail-icon', { timeout: 50 })
+
+  page.render('the icon')
+
+  assert.equal(await waiting, 'the icon')
+  assert.equal(page.observing, false)
+})
+
+test('a page that changes into something else is still waited on', async () => {
+  const { page, waitForEl } = withFakeDom()
+  const waiting = waitForEl('a.detail-icon', { timeout: 50 })
+
+  page.notify()
+  assert.equal(page.observing, true)
+
+  page.render('the icon')
+  assert.equal(await waiting, 'the icon')
+})
+
+test('an element that never arrives gives up rather than watching forever', async () => {
+  // The bug the timeout is here for: a logged-out visitor on a list with no
+  // rows in it never produces an `a.detail-icon`, and the wait for one used to
+  // run a `querySelector` over the whole document on every mutation for the
+  // life of the page, holding a promise that never settled.
+  const { page, waitForEl } = withFakeDom()
+  const started = Date.now()
+
+  assert.equal(await waitForEl('a.detail-icon', { timeout: 30 }), undefined)
+  assert.ok(Date.now() - started >= 20)
+  assert.equal(page.observing, false)
+})


### PR DESCRIPTION
Closes #181.

`waitForEl` now takes a timeout — 10 seconds by default, which is long enough for anything the page is already fetching to arrive — and when it expires it disconnects the observer and resolves `undefined`. Callers have to handle `undefined`, and in exchange none of them has to bound the wait itself. That is the whole fix: the two hand-rolled observers in the list page were the same code with the same bug, so both are now calls to `waitForEl`, and `whenCommentsAreLoaded` in `draft.js`, which raced it against a 5-second timeout of its own to work around exactly this, is a single call passing that same 5 seconds as the timeout.

What the leak cost: an observer on `document` with `{ childList: true, subtree: true }` whose callback is a document-wide `querySelector`, running on every mutation for as long as the page is open. Nobody sees it today, and a list page redraws four bootstrap-tables on every column toggle, sort and search, so there is no shortage of mutations to run it on. The pages where it never ended are the ones where the thing being waited for is never coming: a logged-out visitor on a list with no rows in it (an empty sublist, a list that is all `Planned`, a failed `/api/entries`) never grows an `a.detail-icon`, and a `#fragment` naming a deleted entry, someone else's list or a typo never resolves to an element.

The anchor jump picked up one other thing on the way: the fragment now goes through `CSS.escape` before it is used as a selector. It used to reach the element with `getElementById` and then build a jQuery selector out of the raw fragment; `querySelector` is stricter than that, and an id free to contain a `.` or a `:` would throw rather than match nothing. The trigger and the scroll now use the element `waitForEl` handed back.

`Rows.byRef` is emptied in the list page's initializer, before the tables that fill it run. It holds a copy of every row so the edit button can name its row rather than serialise one into the markup, and nothing ever cleared it, so what it held was every row of every list drawn since the page loaded rather than the rows currently on it.

`window.editEntry` moves out of `initFullTable` and up to the same place. It was assigned once per sublist — four to eight times per page — to the same closure over the same shared registry, so every assignment but the last was doing nothing, and the code read as though each table installed a handler of its own when the lookup was global all along.

The new tests in `general.test.js` load `general.js` into a context with just enough of a DOM to drive it: a `document` whose `querySelector` answers from a variable, and a `MutationObserver` that keeps its callback so a test can say when the page changed and records whether it is still watching. They cover the element being there already, arriving later, a mutation that is not the one being waited for, and the case this is all about — an element that never arrives, which now resolves `undefined` with the observer disconnected.

`npm test` (366 pass) and `npm run build` both green, and the built bundle parses.
