### PR TITLE
fix(api): require a token to search and retrieve works

### DIFF
--- a/src/api/controllers/works.js
+++ b/src/api/controllers/works.js
@@ -3,19 +3,40 @@
 /** @typedef {import('../utils/external_api_adapters/types').Adapter} Adapter */
 /** @typedef {import('../utils/errors').Error} Error */
 const { toPromise } = require('../utils/general')
-const { getUrlSegments } = require('./utils')
-const { Result, ok, err, ResultAsync, okAsync } = require('neverthrow')
+const { getUrlSegments, getUserId } = require('./utils')
+const { Result, ok, err, ResultAsync, okAsync, errAsync } = require('neverthrow')
 const errors = require('../utils/errors')
 const responses = require('../utils/responses')
 const adapters = require('../utils/external_api_adapters')
 const db = require('../utils/db')
 const workTypes = require('../utils/work_types')
 
-/** @type {(event: Event) => Promise<Response>} */
-const searchForWork = (event) =>
-  withAdapter('search', event)
+/**
+ * GET /api/works/search/:type/:query
+ *
+ * Behind a token, alone among the reads on this site along with `retrieve`
+ * below — the lists are public and stay public. This one is not a read of our
+ * data: the adapter it reaches attaches `TMDB_API_KEY`,
+ * `TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET` or `GOOGLE_API_KEY` server-side,
+ * so open it is a free proxy to three metered third-party APIs with nobody to
+ * attribute a request to and nothing standing between a caller and IGDB's
+ * four-requests-a-second ceiling. Every real caller is a logged-in user
+ * filling in the entry form; what scripts and language models are meant to
+ * read is `/api/export`, which touches none of this. See #174.
+ * @type {(event: Event) => Promise<Response>}
+ */
+const searchForWork = (event) => toPromise(
+  getUserId(event)
+    .andThen(() => withAdapter_('search', event))
+    .map(responses.ok)
+    .mapErr(responses.fromError)
+)
 
-/** @type {(event: Event) => Promise<Response>} */
+/**
+ * GET /api/works/retrieve/:type/:ref
+ *
+ * @type {(event: Event) => Promise<Response>}
+ */
 const retrieveWork = (event) => {
   const type = getUrlSegments(event)[1]
   const apiRefId = getUrlSegments(event)[2]
@@ -26,10 +47,19 @@ const retrieveWork = (event) => {
   // some book documents are stored under that name, and both mean the ISBN.
   const apiNames = workTypes.byType(type)?.identityPrefixes
 
-  if (!apiNames) return Promise.resolve(responses.notFound())
-
   return toPromise(
-    findCachedWork(typeToCollection(type), apiNames.map((name) => `${name}__${apiRefId}`))
+    // The token is checked before the type segment is, so that an anonymous
+    // caller is told the same thing whatever it asks for. This route spends
+    // the credentials `search` does — a game costs up to three IGDB round
+    // trips — and it also *writes*: a miss here creates the work document.
+    // Walking an API's ids anonymously therefore filled `films`, `tvShows`,
+    // `games` and `books` with works no entry points at, which is the junk
+    // `scripts/audit_database.js` reports and `dedupe_works.js` cleans up.
+    getUserId(event)
+      .andThen(() => apiNames ? okAsync(apiNames) : errAsync(errors.notFound()))
+      .andThen((names) =>
+        findCachedWork(typeToCollection(type), names.map((name) => `${name}__${apiRefId}`))
+      )
       .andThen(({ data, ref }) => data
         ? okAsync(({
           ...data,
@@ -66,13 +96,6 @@ const findCachedWork = (collection, apiRefs) =>
     okAsync({})
   )
 
-
-/** @type {(action: keyof Adapter, event: Event) => Promise<Response>} */
-const withAdapter = (action, event) => toPromise(
-  withAdapter_(action, event)
-    .map(responses.ok)
-    .mapErr(responses.fromError)
-)
 
 /** @type {(action: keyof Adapter, event: Event) => ResultAsync<any, any>} */
 const withAdapter_ = (action, event) =>

--- a/src/api/controllers/works.test.js
+++ b/src/api/controllers/works.test.js
@@ -1,0 +1,237 @@
+/**
+ * @file Who may reach /api/works, driven through the real Netlify handler
+ * against an in-memory Mongo and a stubbed adapter.
+ *
+ * These two routes were open to anyone (#174), and what that cost is not
+ * visible in a status code: `search` spends TMDB, IGDB and Google Books
+ * credentials, and `retrieve` writes a work document on a cache miss. So the
+ * assertions are that the adapter was not called and that nothing was
+ * written, not merely that a 401 came back.
+ *
+ * The adapter is stubbed rather than mocked at the network: the real one
+ * builds its client at require time and throws without an API key, which is
+ * why nothing that requires it can be reached from `node --test` at all. That
+ * is also the honest boundary of this file — the question here is who gets to
+ * the adapter, not what it answers.
+ *
+ * Needs the dependencies (zod parses the work that gets written), so it
+ * **skips itself** when they aren't installed, which is how CI runs the
+ * suite.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const Module = require('module')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('neverthrow')
+    require('zod')
+    require('ts-pattern')
+    require('ramda')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+/** An adapter answers with a ResultAsync, so the stub below has to as well. */
+const { okAsync } = dependenciesInstalled ? require('neverthrow') : {}
+
+process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+
+///////////////////////////////////////////////////////////////////////////////
+// A Mongo small enough to keep in a variable, an auth check that takes the
+// token at its word, and an adapter that counts what reaches it.
+
+const store = {}
+
+/** Every call that got through to a third-party API, as `{ action, arg }`. */
+const adapterCalls = []
+
+/**
+ * Only the operator the queries in this module actually use. `apiRefs` is an
+ * array field asked about with a plain string, which Mongo matches against
+ * each element — a fake comparing the array itself would never find a cached
+ * work, and every test would silently take the write path.
+ */
+const matchesValue = (value, wanted) =>
+  Array.isArray(value) ? value.includes(wanted) : value === wanted
+
+const matches = (doc, filter = {}) =>
+  Object.entries(filter).every(([field, wanted]) =>
+    matchesValue(doc[field], wanted)
+  )
+
+const collectionOf = (name) => (store[name] = store[name] ?? [])
+
+const collection = (name) => ({
+  findOne: async (filter) =>
+    collectionOf(name).find((doc) => matches(doc, filter)) ?? null,
+  insertOne: async (doc) => (collectionOf(name).push(doc), { insertedId: doc._id }),
+})
+
+class MongoClient {
+  async connect() {}
+  db() {
+    return { databaseName: 'memo', collection }
+  }
+}
+
+/** What TMDB would answer with, reduced to what the films parser insists on. */
+const retrievedFilm = (ref) => ({
+  apiRefs: [`tmdb__${ref}`],
+  entryType: 'Film',
+  englishTranslatedTitle: 'Stalker',
+  releaseYear: 1979,
+})
+
+const stubAdapter = {
+  search: (query) => {
+    adapterCalls.push({ action: 'search', arg: query })
+    return okAsync([{ title: 'Stalker', ref: '1234' }])
+  },
+  retrieve: (ref) => {
+    adapterCalls.push({ action: 'retrieve', arg: ref })
+    return okAsync(retrievedFilm(ref))
+  },
+}
+
+const loadModule = Module._load
+Module._load = function (request, ...args) {
+  if (request === 'mongodb') return { MongoClient, ServerApiVersion: { v1: '1' } }
+  // jose verifies asynchronously from v4 on, and answers with the payload
+  // wrapped rather than the payload itself. A test's token is its user id,
+  // except `expired`: a token that fails verification rejects rather than
+  // throws, and this route has to answer 401 to that too. See #168.
+  if (request === 'jose') {
+    return {
+      jwtVerify: async (token) => token === 'expired'
+        ? Promise.reject(new Error('token expired'))
+        : { payload: { sub: token } },
+    }
+  }
+  // The real index builds a TMDB, an IGDB and a Google Books client at
+  // require time, each from a key this suite deliberately does not have.
+  if (request === '../utils/external_api_adapters') {
+    return { films: stubAdapter, tv: stubAdapter, games: stubAdapter, books: stubAdapter }
+  }
+  return loadModule.call(this, request, ...args)
+}
+
+const works = dependenciesInstalled ? require('../routes/works') : undefined
+
+///////////////////////////////////////////////////////////////////////////////
+
+const call = async (url, { as } = {}) => {
+  const response = await works.handler(
+    {
+      httpMethod: 'GET',
+      path: `/.netlify/functions/${url}`,
+      headers: as ? { authorization: `Bearer ${as}` } : {},
+      body: null,
+    },
+    {}
+  )
+  return {
+    statusCode: response.statusCode,
+    body: response.body ? JSON.parse(response.body) : undefined,
+  }
+}
+
+const seed = () => {
+  adapterCalls.length = 0
+  store.films = []
+}
+
+const seedCachedFilm = () => {
+  seed()
+  store.films = [{ _id: 'w1', ...retrievedFilm('1234') }]
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+test('a search without a token is refused before it spends an API call', options, async () => {
+  seed()
+
+  const { statusCode, body } = await call('works/search/films/stalker')
+
+  assert.equal(statusCode, 401)
+  assert.equal(body.error, 'UnauthorizedError')
+  assert.deepEqual(adapterCalls, [])
+})
+
+test('a retrieve without a token is refused and writes nothing', options, async () => {
+  seed()
+
+  const { statusCode } = await call('works/retrieve/films/1234')
+
+  assert.equal(statusCode, 401)
+  assert.deepEqual(adapterCalls, [])
+  // The point of the issue: walking an API's ids anonymously filled this
+  // collection with works no entry points at.
+  assert.deepEqual(store.films, [])
+})
+
+test('a token that does not verify is refused too', options, async () => {
+  seed()
+
+  const { statusCode } = await call('works/search/films/stalker', { as: 'expired' })
+
+  assert.equal(statusCode, 401)
+  assert.deepEqual(adapterCalls, [])
+})
+
+test('an anonymous caller is an unknown caller before it is an unknown type', options, async () => {
+  seed()
+
+  const { body } = await call('works/retrieve/operas/1234')
+
+  assert.equal(body.error, 'UnauthorizedError')
+})
+
+test('a logged-in user still gets their search', options, async () => {
+  seed()
+
+  const { statusCode, body } = await call('works/search/films/stalker', { as: 'u1' })
+
+  assert.equal(statusCode, 200)
+  assert.deepEqual(body, [{ title: 'Stalker', ref: '1234' }])
+  assert.deepEqual(adapterCalls, [{ action: 'search', arg: 'stalker' }])
+})
+
+test('a logged-in retrieve of a cached work answers from the store', options, async () => {
+  seedCachedFilm()
+
+  const { statusCode, body } = await call('works/retrieve/films/1234', { as: 'u1' })
+
+  assert.equal(statusCode, 200)
+  assert.equal(body.internalRef, 'w1')
+  assert.equal(body.englishTranslatedTitle, 'Stalker')
+  assert.deepEqual(adapterCalls, [])
+  assert.equal(store.films.length, 1)
+})
+
+test('a logged-in retrieve of an uncached work retrieves it and writes it', options, async () => {
+  seed()
+
+  const { statusCode, body } = await call('works/retrieve/films/1234', { as: 'u1' })
+
+  assert.equal(statusCode, 200)
+  assert.deepEqual(adapterCalls, [{ action: 'retrieve', arg: '1234' }])
+  assert.equal(store.films.length, 1)
+  assert.equal(store.films[0].englishTranslatedTitle, 'Stalker')
+  assert.equal(body.internalRef, store.films[0]._id)
+})
+
+test('a logged-in request for an unknown type is a 404', options, async () => {
+  seed()
+
+  const { statusCode } = await call('works/retrieve/operas/1234', { as: 'u1' })
+
+  assert.equal(statusCode, 404)
+  assert.deepEqual(adapterCalls, [])
+})


### PR DESCRIPTION
Closes #174.

`src/api/routes/works.js` never read the token, so `GET /api/works/search/:type/:query` and `GET /api/works/retrieve/:type/:ref` were open to anyone who could reach the site. Every other read here is unauthenticated and should be — the lists are public — but these two are not reads of our data. The adapters attach `TMDB_API_KEY`, `TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET` and `GOOGLE_API_KEY` server-side, which makes the endpoint a free proxy to three metered third-party APIs, unattributable and unlimited: a game `retrieve` is up to three IGDB round trips on its own, against a ceiling of four requests a second. And `retrieve` writes — `createWork` inserts a document into `films`, `tvShows`, `games` or `books` on every cache miss, so walking an API's ids anonymously fills a production collection with works nothing references, which is the junk `scripts/audit_database.js` reports as "works nothing references" and `dedupe_works.js` exists to clean up.

Both controllers now start at `getUserId(event)`, which is the cheapest of the three options the issue lists and the only one that closes the whole thing. It costs nothing anyone is using: the only callers are `searchWorks` and `retrieveWork` in `src/frontend/_includes/js/utils/netlify.js`, reached from the add/edit entry flow by a user who is by definition logged in, and both go through `Http.get`, which already attaches the bearer token when the `nf_jwt` cookie is there — confirmed rather than assumed, and nothing else in the repo calls either endpoint. The public read surface for scripts and language models is `/api/export`, which is separate and untouched. Rate limiting and caching `search` are still worth doing and are still open; neither is in here.

In `retrieve` the token is checked before the `:type` segment is looked at, so an anonymous caller is told the same thing whatever it asks for. A logged-in request for an unknown type still 404s, but now through `responses.fromError` like every other failure in the file, which means it comes back as `{ error: "NotFound", message: "not found" }` rather than as a bare bodiless 404. Nothing reads that body. `withAdapter` is gone — `searchForWork` was its only caller and now composes `withAdapter_` itself.

`works.test.js` is new and drives the real Netlify handler against an in-memory Mongo, in the shape `name.test.js` and `entries.test.js` established: a `jose` stub whose token is the user id, and the file skipping itself when the dependencies aren't installed. What it asserts about a refused request is that the adapter was never called and that the collection is still empty — the cost being guarded here is not visible in a status code, and a test that only read the 401 would pass against a version that spent the API call first. The adapter is stubbed at `require('../utils/external_api_adapters')` rather than at the network because the real one builds its TMDB, IGDB and Google Books clients at require time from keys the suite deliberately does not have, which is why nothing that reaches it has been testable until now.

Verified on a local copy of the repo (Drive can't hold a working `node_modules`): the full suite is 370 passing, and `node --no-experimental-require-module -e "require('./src/api/routes/works.js')"` still loads, which is the check that behaves the way the functions runtime does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
