### PR TITLE
fix(api): upgrade cookie to 0.7.2 and clear cookies with 0, not a Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@11ty/eleventy": "^3.1.2",
         "@netlify/functions": "^2.5.1",
         "axios": "^1.13.1",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.2",
         "dotenv": "^17.2.3",
         "html-minifier": "^4.0.0",
         "igdb-api-node": "^5.0.1",
@@ -804,9 +804,10 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -19400,9 +19401,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
     "cross-env": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@11ty/eleventy": "^3.1.2",
     "@netlify/functions": "^2.5.1",
     "axios": "^1.13.1",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.2",
     "dotenv": "^17.2.3",
     "html-minifier": "^4.0.0",
     "igdb-api-node": "^5.0.1",

--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -78,12 +78,19 @@ const generateEncodedStateString = (route) => {
   return stateBuffer.toString("base64")
 }
 
+/* Both of these clear a cookie, which is `Max-Age=0`. They said `new Date(0)`
+   before, and reached the same header only because `serialize` coerces what it
+   is handed to a number and the epoch is 0 — `maxAge` is a count of seconds,
+   not a date, so any other Date would have been read as its epoch milliseconds
+   and set an expiry tens of thousands of years out instead of clearing
+   anything. `cookie` 1.x rejects a Date outright, so the coercion was also the
+   thing standing between here and the next upgrade. */
 const generateAuth0LoginResetCookie = () => {
   return cookie.serialize(AUTH0_LOGIN_COOKIE_NAME, "", {
     secure: !isRunningLocally,
     httpOnly: true,
     path: "/",
-    maxAge: new Date(0),
+    maxAge: 0,
   })
 }
 
@@ -91,7 +98,7 @@ const generateLogoutCookie = () => {
   return cookie.serialize(NETLIFY_COOKIE_NAME, "", {
     secure: !isRunningLocally,
     path: "/",
-    maxAge: new Date(0),
+    maxAge: 0,
     httpOnly: true,
   })
 }

--- a/src/api/controllers/auth_cookies.test.js
+++ b/src/api/controllers/auth_cookies.test.js
@@ -1,0 +1,122 @@
+/**
+ * @file The cookies the auth routes set, against the real `cookie`.
+ *
+ * `serialize` is the only thing between these options and a `Set-Cookie`
+ * header, and every one of its rules is a runtime rule — there is no type to
+ * catch an option it will not accept, and the header it produces is never read
+ * back by anything in this repo. So a `cookie` upgrade that tightened a rule
+ * would land silently: the tests would stay green, the build would pass, and
+ * the first sign of it would be a 502 on `/api/auth/logout` or, worse, a
+ * clearing cookie that quietly expires in fifty thousand years.
+ *
+ * That is not hypothetical. `maxAge` used to be `new Date(0)` here, which
+ * worked by coercion; `cookie` 1.x rejects it outright.
+ *
+ * It needs the dependencies, so it **skips itself** when they aren't
+ * installed — which is how CI runs the suite.
+ */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+
+const dependenciesInstalled = (() => {
+  try {
+    require('cookie')
+    require('jose')
+    require('openid-client')
+    require('ts-pattern')
+    return true
+  } catch (error) {
+    return false
+  }
+})()
+
+const options = {
+  skip: dependenciesInstalled ? false : 'run `npm install` to run these',
+}
+
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
+
+const cookie = dependenciesInstalled ? require('cookie') : undefined
+const jose = dependenciesInstalled ? require('jose') : undefined
+const { handleLogout, handleRenew } = dependenciesInstalled
+  ? require('./auth')
+  : {}
+
+const NETLIFY_COOKIE_NAME = 'nf_jwt'
+
+/** The attributes of a `Set-Cookie`, by name, alongside `cookie.parse`. */
+const attributesOf = (setCookie) =>
+  new Map(
+    setCookie
+      .split(';')
+      .slice(1)
+      .map((part) => {
+        const [key, ...rest] = part.trim().split('=')
+        return [key.toLowerCase(), rest.join('=')]
+      })
+  )
+
+/** A token shaped like the one `signNetlifyJWT` mints. */
+const sign = ({ key = new TextEncoder().encode(process.env.TOKEN_SECRET) } = {}) => {
+  const iat = Math.floor(Date.now() / 1000)
+  return new jose.SignJWT({
+    exp: iat + 14 * 24 * 3600,
+    iat,
+    updated_at: iat,
+    aud: 'memo',
+    sub: 'auth0|nil',
+    app_metadata: { authorization: { roles: ['user'] } },
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(key)
+}
+
+test('logging out clears the session cookie', options, async () => {
+  const { headers } = await handleLogout()
+  const setCookie = headers['Set-Cookie']
+
+  // `Max-Age=0` is the whole point: an empty value alone leaves a cookie the
+  // browser keeps sending. Anything other than 0 here is a session that does
+  // not end.
+  assert.equal(cookie.parse(setCookie)[NETLIFY_COOKIE_NAME], '')
+  assert.equal(attributesOf(setCookie).get('max-age'), '0')
+  assert.equal(attributesOf(setCookie).has('httponly'), true)
+  assert.equal(attributesOf(setCookie).has('secure'), true)
+  assert.equal(attributesOf(setCookie).get('path'), '/')
+})
+
+test('a session past saving is cleared the same way', options, async () => {
+  // The 401 branch of renew. It clears rather than merely refusing, so that a
+  // token the server will never accept again stops being sent.
+  const stale = await sign({ key: new TextEncoder().encode('another secret') })
+  const { statusCode, headers } = await handleRenew({
+    headers: { authorization: `Bearer ${stale}` },
+  })
+
+  assert.equal(statusCode, 401)
+  assert.equal(cookie.parse(headers['Set-Cookie'])[NETLIFY_COOKIE_NAME], '')
+  assert.equal(attributesOf(headers['Set-Cookie']).get('max-age'), '0')
+})
+
+test('a renewed token survives the round trip through a cookie', options, async () => {
+  // A JWT is dots and base64url, all of which `serialize` allows unencoded —
+  // but that is `cookie`'s judgement, not ours, and this is the assertion that
+  // notices if it ever stops being true. The renewed cookie is also the one
+  // whose `maxAge` is a real duration, so it pins the units as well: seconds,
+  // not milliseconds.
+  const { statusCode, headers, body } = await handleRenew({
+    headers: { authorization: `Bearer ${await sign()}` },
+  })
+  const setCookie = headers['Set-Cookie']
+
+  assert.equal(statusCode, 200)
+  assert.equal(cookie.parse(setCookie)[NETLIFY_COOKIE_NAME], JSON.parse(body).token)
+  assert.equal(attributesOf(setCookie).get('max-age'), String(14 * 24 * 3600))
+})
+
+test('no token at all is refused without a cookie to clear', options, async () => {
+  const { statusCode, headers } = await handleRenew({ headers: {} })
+
+  assert.equal(statusCode, 401)
+  assert.equal(headers['Set-Cookie'], undefined)
+})


### PR DESCRIPTION
First of the packages in #182, and the one that issue says to do on its own: `cookie` 0.5.0 → 0.7.2, closing GHSA-pxg6-pf52-xh8x / CVE-2024-47764.

The bug is in `serialize`. 0.5.0 checked the cookie name, the path and the domain against a single regexp for RFC 7230's `field-content`, which is the wrong grammar for all three and admits characters none of them allows — so a value reaching one of those options unchecked could close the attribute and append fields of its own. 0.7.0 replaced it with the four RFC 6265 productions that actually apply, one each for name, value, domain and path.

Nothing in `controllers/auth.js` passes user input into any of those options today: the two cookie names are module constants, the path is always `"/"`, and no domain is set. So this is not a live hole here so much as the only advisory in the tree that sits on the authentication path — `auth.js` serializes every cookie the site sets, `nf_jwt` included, and the version under it should not be the one with the open advisory.

## Why 0.7.2 and not 1.x or 2.x

`cookie` 2.x is ES modules only. Per `CLAUDE.md` and #162, the functions runtime cannot `require` one, and the throw happens while the module is being read — so every route 502s at once, not just the auth ones. `--no-experimental-require-module` confirms it:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../cookie/dist/index.js
```

1.x is requireable, but it rejects a `Date` for `maxAge` — which is the other half of this change, and the reason 1.x becomes available afterwards. 0.7.2 is the end of the 0.x line, still CommonJS, and carries the fix.

## `maxAge: new Date(0)`

Both cookies that end a session — the Auth0 login cookie in `generateAuth0LoginResetCookie`, the `nf_jwt` cookie in `generateLogoutCookie` — asked for `maxAge: new Date(0)`. That reached `Max-Age=0`, but only by coercion: `maxAge` is a count of seconds, not a date, and the epoch happens to convert to `0`. Any other `Date` would have been read as its epoch milliseconds and set an expiry tens of thousands of years out — the idiom only ever worked for the single value it was used with, and it works in 0.7.2 for the same accidental reason it worked in 0.5.0 (`Math.floor` where there used to be `- 0`). They now say `0`.

## The test

`serialize` is the only thing between those options and a `Set-Cookie` header, every one of its rules is enforced at runtime, and nothing in this repo read such a header back — so a future upgrade that tightened a rule would have been green here and a 502 on `/api/auth/logout` in production. `auth_cookies.test.js` closes that: it asserts `Max-Age=0` on both clearing paths, the fortnight in seconds on the renewed cookie, and that a JWT survives `serialize` → `parse` unchanged. It uses the real `cookie` and skips itself when dependencies aren't installed, the same way `auth_token.test.js` does, so the no-install `test` job is unaffected.

Checked against `cookie` 1.1.1 as well: the two clearing tests fail on the old `new Date(0)` code (`TypeError: option maxAge is invalid`) and pass on this one.

## Verified

`npm test` 366 pass / 0 fail (was 362; four are new), `node --check` over every tracked `.js`, `require` of all ten routes under `--no-experimental-require-module`, and `npm run build`. The lockfile diff is `cookie` and nothing else — `netlify-cli`'s own nested `cookie` 0.5.0 is a devDependency and untouched.

## Not in this PR

The rest of #182's table, and the triage of what's actually behind GitHub's 118 Dependabot alerts. The short version: 83 of the 118 are `netlify-cli`'s dev tree, including the only critical one; 5 more are build-time only; 30 are against packages a route actually loads, and 23 of those 30 are one nested `axios` 0.21.4 that `apicalypse` pins, which no change to our own `package.json` can reach. #195 adds the CI step; the full triage follows on #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

