### PR TITLE
fix(works): check a work's ref before an adapter interpolates it

### DIFF
--- a/src/api/controllers/works.js
+++ b/src/api/controllers/works.js
@@ -23,13 +23,15 @@ const workTypes = require('../utils/work_types')
  * four-requests-a-second ceiling. Every real caller is a logged-in user
  * filling in the entry form; what scripts and language models are meant to
  * read is `/api/export`, which touches none of this. See #174.
+ *
+ * The search term is whatever the user typed, so there is no shape to hold it
+ * to — only the decoding to survive.
  * @type {(event: Event) => Promise<Response>}
  */
-const searchForWork = (event) => toPromise(
+const searchForWork = (event) => respond(
   getUserId(event)
-    .andThen(() => withAdapter_('search', event))
-    .map(responses.ok)
-    .mapErr(responses.fromError)
+    .andThen(() => decodeSegment(getUrlSegments(event)[2]))
+    .andThen((query) => withAdapter_('search', event, query))
 )
 
 /**
@@ -39,7 +41,6 @@ const searchForWork = (event) => toPromise(
  */
 const retrieveWork = (event) => {
   const type = getUrlSegments(event)[1]
-  const apiRefId = getUrlSegments(event)[2]
 
   // Every prefix that names this work, tried in turn — not every prefix it
   // may carry, since the id in the url belongs to one API. The Google Books
@@ -47,28 +48,33 @@ const retrieveWork = (event) => {
   // some book documents are stored under that name, and both mean the ISBN.
   const apiNames = workTypes.byType(type)?.identityPrefixes
 
-  return toPromise(
-    // The token is checked before the type segment is, so that an anonymous
-    // caller is told the same thing whatever it asks for. This route spends
-    // the credentials `search` does — a game costs up to three IGDB round
-    // trips — and it also *writes*: a miss here creates the work document.
-    // Walking an API's ids anonymously therefore filled `films`, `tvShows`,
-    // `games` and `books` with works no entry points at, which is the junk
-    // `scripts/audit_database.js` reports and `dedupe_works.js` cleans up.
+  return respond(
+    // The token is checked before the url is, so that an anonymous caller is
+    // told the same thing whatever it asks for — the ref included. This route
+    // spends the credentials `search` does — a game costs up to three IGDB
+    // round trips — and it also *writes*: a miss here creates the work
+    // document. Walking an API's ids anonymously therefore filled `films`,
+    // `tvShows`, `games` and `books` with works no entry points at, which is
+    // the junk `scripts/audit_database.js` reports and `dedupe_works.js`
+    // cleans up.
     getUserId(event)
       .andThen(() => apiNames ? okAsync(apiNames) : errAsync(errors.notFound()))
       .andThen((names) =>
-        findCachedWork(typeToCollection(type), names.map((name) => `${name}__${apiRefId}`))
+        // Read once, and the one value used for both the lookup and the
+        // retrieve. The cache was searched for the raw segment while the
+        // adapter was handed the decoded one, so the two could be asking
+        // after different works.
+        parseRef(type, event).asyncAndThen((apiRefId) =>
+          findCachedWork(typeToCollection(type), names.map((name) => `${name}__${apiRefId}`))
+            .andThen(({ data, ref }) => data
+              ? okAsync(({
+                ...data,
+                internalRef: ref.id
+              }))
+              : createWork(event, apiRefId)
+            )
+        )
       )
-      .andThen(({ data, ref }) => data
-        ? okAsync(({
-          ...data,
-          internalRef: ref.id
-        }))
-        : createWork(event)
-      )
-      .map(responses.ok)
-      .mapErr(responses.fromError)
   )
 }
 
@@ -97,14 +103,60 @@ const findCachedWork = (collection, apiRefs) =>
   )
 
 
-/** @type {(action: keyof Adapter, event: Event) => ResultAsync<any, any>} */
-const withAdapter_ = (action, event) =>
+/** @type {(result: ResultAsync<any, Error>) => Promise<Response>} */
+const respond = (result) => toPromise(
+  result
+    .map(responses.ok)
+    .mapErr(responses.fromError)
+)
+
+/**
+ * The url segment, percent-decoded.
+ *
+ * `decodeURI` throws on a malformed escape — `decodeURI('%')` is a URIError —
+ * and neverthrow does not catch: `Ok.prototype.asyncAndThen` is `f(this.value)`
+ * with no try/catch anywhere in it. So the throw left this module
+ * synchronously, past every `mapErr(responses.fromError)` above, out of the
+ * handler, and Netlify answered `GET /api/works/search/films/%` with an empty
+ * 502. The same shape of bug as the `jwtVerify` one `getUserId` in ./utils.js
+ * describes, and it has the same fix: catch it where it is thrown. #175.
+ * @type {(segment: string) => Result<string, Error>}
+ */
+const decodeSegment = Result.fromThrowable(
+  decodeURI,
+  (err) => errors.req(err, 'that url could not be read'),
+)
+
+/**
+ * The ref a retrieve url names: decoded, and of the shape a ref of this type
+ * has. Anything else names no work we hold and none the API could give us, so
+ * it is a 404 rather than a query written half by the caller — the games
+ * adapter interpolates this into an apicalypse `where`, and the books adapter
+ * into a url carrying GOOGLE_API_KEY. See work_types.js. #175.
+ * @type {(type: string, event: Event) => Result<string, Error>}
+ */
+const parseRef = (type, event) =>
+  decodeSegment(getUrlSegments(event)[2])
+    .andThen((segment) => {
+      const ref = workTypes.parseRef(type, segment)
+      // The segment goes to the log and not into the body: publishing the
+      // caller's own text back to them is how it gets read as ours. #105.
+      return ref ? ok(ref) : err(errors.notFound(`not a ${type} ref: ${segment}`))
+    })
+
+/**
+ * The argument is passed in rather than read from the event here, because the
+ * two actions take different things — a search takes whatever was typed, a
+ * retrieve takes a ref that has been checked against its type.
+ * @type {(action: keyof Adapter, event: Event, argument: string) => ResultAsync<any, any>}
+ */
+const withAdapter_ = (action, event, argument) =>
   getAdapter(event)
     // TODO: make typechecker happy
-    .asyncAndThen((adapter) => adapter[action](decodeURI(getUrlSegments(event)[2])))
+    .asyncAndThen((adapter) => adapter[action](argument))
 
-const createWork = (event) =>
-  withAdapter_('retrieve', event)
+const createWork = (event, apiRefId) =>
+  withAdapter_('retrieve', event, apiRefId)
     .andThen((data) =>
       db.create_(typeToCollection(getUrlSegments(event)[1]), data)
     )

--- a/src/api/utils/work_types.js
+++ b/src/api/utils/work_types.js
@@ -29,6 +29,7 @@
  *   entryType: string,
  *   apiRefPrefixes: string[],
  *   identityPrefixes: string[],
+ *   refShape: 'id' | 'isbn',
  * }} WorkType
  */
 
@@ -41,6 +42,9 @@
  * of those that actually names the work, and so the only ones a lookup by
  * external id may use — they are not always the same list.
  *
+ * `refShape` names the shape of the id that follows the prefix, which is what
+ * `parseRef` checks a url segment against — see REF_SHAPES.
+ *
  * @type {WorkType[]}
  */
 const WORK_TYPES = [
@@ -52,6 +56,7 @@ const WORK_TYPES = [
     entryType: 'Film',
     apiRefPrefixes: ['tmdb'],
     identityPrefixes: ['tmdb'],
+    refShape: 'id',
   },
   {
     type: 'tv',
@@ -61,6 +66,7 @@ const WORK_TYPES = [
     entryType: 'TVShow',
     apiRefPrefixes: ['tmdb'],
     identityPrefixes: ['tmdb'],
+    refShape: 'id',
   },
   {
     type: 'games',
@@ -77,6 +83,7 @@ const WORK_TYPES = [
     // games share the placeholder `hltb__N/A`. Only igdb establishes identity,
     // so only igdb may be looked up by.
     identityPrefixes: ['igdb'],
+    refShape: 'id',
   },
   {
     type: 'books',
@@ -90,6 +97,7 @@ const WORK_TYPES = [
     apiRefPrefixes: ['ISBN', 'google'],
     // Both name the same ISBN, so either establishes identity.
     identityPrefixes: ['ISBN', 'google'],
+    refShape: 'isbn',
   },
 ]
 
@@ -111,14 +119,60 @@ const byType = (type) => BY_TYPE[type]
  */
 const byEntryCollection = (entryCollection) => BY_ENTRY_COLLECTION[entryCollection]
 
+/**
+ * The external id a `/works/retrieve/:type/:ref` segment names, or undefined
+ * if it names nothing a work of that type could be held under. An unknown type
+ * has no shape to check against, so it answers undefined as well — the same
+ * answer `byType` gives it, and `controllers/works.js` turns both into the 404
+ * it already answers an unknown type with.
+ *
+ * The segment is not decoration. The games adapter interpolates it into an
+ * apicalypse `where id = <ref>` clause and the books adapter into a Google
+ * Books query string carrying GOOGLE_API_KEY, so until #175 a caller wrote
+ * part of both. Checking the shape here, where the segment is read, is what
+ * saves three adapters from each deciding for themselves what a safe ref is.
+ *
+ * Returns the segment itself rather than a number: each accepted shape is
+ * already the canonical spelling, so there is nothing to normalise, and the
+ * adapters and the `<prefix>__<ref>` lookups all want a string.
+ *
+ * @type {(type: string, segment: string) => string | undefined}
+ */
+const parseRef = (type, segment) => {
+  const shape = REF_SHAPES[byType(type)?.refShape]
+  return shape?.test(segment) ? segment : undefined
+}
+
 module.exports = {
   WORK_TYPES,
   TYPES,
   byType,
   byEntryCollection,
+  parseRef,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * What an id of each shape looks like: as the two APIs write them, and as
+ * every one of the 3794 identity refs in the four works collections — 2034
+ * tmdb, 1128 igdb, 632 ISBN — is spelled.
+ *
+ * A trailing `$` would not be the end of it — `$` also matches before a final
+ * newline, and `%0A` in a url is a newline once `decodeURI` has had it, an
+ * `id = 1020\n...` being just the sort of segment this exists to refuse.
+ * `(?![\s\S])` is "and then nothing whatsoever".
+ */
+const REF_SHAPES = {
+  // A tmdb or igdb id. Leading zeros are refused rather than tolerated:
+  // neither API writes one, so `tmdb__007` could only be a cache miss that
+  // then asks tmdb for a work we would go on to cache a second time.
+  id: /^[1-9][0-9]*(?![\s\S])/,
+  // ISBN-13, or an ISBN-10 whose check digit may be an X. Unpunctuated and
+  // uppercase, because that is how Google Books writes the identifiers in the
+  // search results a ref is taken from, and so how every book is cached.
+  isbn: /^(?:[0-9]{9}[0-9X]|[0-9]{13})(?![\s\S])/,
+}
 
 /** @type {(field: keyof WorkType) => Record<string, WorkType>} */
 const indexBy = (field) =>

--- a/src/api/utils/work_types.test.js
+++ b/src/api/utils/work_types.test.js
@@ -1,7 +1,25 @@
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
 
-const { WORK_TYPES, TYPES, byType, byEntryCollection } = require('./work_types')
+const {
+  WORK_TYPES,
+  TYPES,
+  byType,
+  byEntryCollection,
+  parseRef,
+} = require('./work_types')
+
+/**
+ * Refs the works collections really hold: Inception, Breaking Bad, Grand Theft
+ * Auto V, The Passage, and an ISBN-10 whose check digit is an X — the one
+ * spelling of a book ref that is not all digits.
+ */
+const REAL_REFS = {
+  films: ['27205'],
+  tv: ['1396'],
+  games: ['1020'],
+  books: ['9780385669528', '404387801X'],
+}
 
 test('every type round-trips segment -> entry collection -> segment', () => {
   for (const type of TYPES) {
@@ -31,6 +49,7 @@ test('the four types the site has, under the collections it stores them in', () 
     entryType: 'TVShow',
     apiRefPrefixes: ['tmdb'],
     identityPrefixes: ['tmdb'],
+    refShape: 'id',
   })
 })
 
@@ -82,4 +101,82 @@ test('only the prefixes that name the work establish identity', () => {
       )
     }
   }
+})
+
+test('a ref the collections hold is accepted, and comes back as it went in', () => {
+  // Unchanged rather than parsed into a number: the lookups build
+  // `${prefix}__${ref}` out of it and the adapters send it on as it is.
+  for (const [type, refs] of Object.entries(REAL_REFS)) {
+    for (const ref of refs) {
+      assert.equal(parseRef(type, ref), ref, `${type} rejected its own ref ${ref}`)
+    }
+  }
+})
+
+test('every type can name a ref, so no type is unreachable', () => {
+  // A row whose refShape nothing answers to would 404 every retrieve of that
+  // type, which is what the `?.` in parseRef would otherwise do in silence.
+  for (const workType of WORK_TYPES) {
+    assert.ok(REAL_REFS[workType.type], `no sample ref for ${workType.type}`)
+    assert.ok(
+      parseRef(workType.type, REAL_REFS[workType.type][0]),
+      `${workType.type} accepts no ref at all`
+    )
+  }
+})
+
+test('an id is a positive integer and nothing else', () => {
+  for (const type of ['films', 'tv', 'games']) {
+    // What the igdb adapter would otherwise interpolate into `where id = ...`.
+    assert.equal(parseRef(type, '1020; drop'), undefined)
+    assert.equal(parseRef(type, '1020 | 1021'), undefined)
+    assert.equal(parseRef(type, '*'), undefined)
+    assert.equal(parseRef(type, 'id = 1020'), undefined)
+    // A `$` on its own would accept these two: it matches before a trailing
+    // newline as well as at the end, and `%0A` in the url is how a newline
+    // gets here.
+    assert.equal(parseRef(type, '1020\n'), undefined)
+    assert.equal(parseRef(type, '1020\nname = "x"'), undefined)
+
+    assert.equal(parseRef(type, ''), undefined)
+    assert.equal(parseRef(type, ' 1020'), undefined)
+    assert.equal(parseRef(type, '1020 '), undefined)
+    assert.equal(parseRef(type, '-1'), undefined)
+    assert.equal(parseRef(type, '1e3'), undefined)
+    assert.equal(parseRef(type, '10.20'), undefined)
+    // No id is zero and none is written with a leading zero, so accepting one
+    // would look a work up under a name nothing caches it under.
+    assert.equal(parseRef(type, '0'), undefined)
+    assert.equal(parseRef(type, '01020'), undefined)
+  }
+})
+
+test('a book ref is an ISBN, unpunctuated', () => {
+  // The Google Books adapter interpolates this into a url carrying
+  // GOOGLE_API_KEY, so an `&` here is query parameters of the caller's
+  // choosing on a request of ours.
+  assert.equal(parseRef('books', '9780385669528&key=theirs'), undefined)
+  assert.equal(parseRef('books', '9780385669528?maxResults=1'), undefined)
+
+  // Neither length is optional, and the check digit is the only letter.
+  assert.equal(parseRef('books', '978038566952'), undefined)
+  assert.equal(parseRef('books', '97803856695281'), undefined)
+  assert.equal(parseRef('books', 'X04387801X'), undefined)
+  // Lowercase is refused rather than upcased: every book is cached under the
+  // uppercase spelling Google Books hands out, so accepting the other one
+  // would miss the cache and store the same book a second time.
+  assert.equal(parseRef('books', '404387801x'), undefined)
+  // The same ISBN as The Passage's, but not the way anything holds it.
+  assert.equal(parseRef('books', '978-0-385-66952-8'), undefined)
+})
+
+test('a type with no refs of its own accepts nothing', () => {
+  // The 404 an unknown `:type` segment already gets, reached by the same route
+  // as a malformed ref rather than by a check of its own.
+  assert.equal(parseRef('albums', '1020'), undefined)
+  assert.equal(parseRef('', '1020'), undefined)
+  // Not a type — and, since both lookups go through an object, not a way to
+  // reach anything else either.
+  assert.equal(parseRef('constructor', '1020'), undefined)
+  assert.equal(parseRef('__proto__', '1020'), undefined)
 })


### PR DESCRIPTION
Closes #175.

`withAdapter_` took the third url segment, `decodeURI`d it and handed it to an adapter with nothing looked at on the way. This checks it where it is read, which is one rule rather than three fixes in three adapters.

**The 502.** `decodeURI('%')` throws a `URIError`, and neverthrow does not catch — `Ok.prototype.asyncAndThen` is `return f(this.value)` with no try/catch of its own. So the throw left the controller synchronously, past every `.mapErr(responses.fromError)`, out of the handler, and Netlify answered `GET /api/works/search/films/%` with an empty 502. `Result.fromThrowable` around the decode makes it a 400. It is the same shape of bug as the `jwtVerify` one `getUserId` in `controllers/utils.js` describes, and it has the same fix: catch where the throwing happens. I confirmed the before and the after by driving the real route handler with the adapters, the database and jose stubbed — before, the `URIError` comes back out of `handler`; after, a 400 with the adapter never called.

**The ref.** `work_types.js` already knew what each type's refs look like, so it is where the shape now lives: `parseRef(type, segment)` answers with the segment when it is one a work of that type could be held under, and undefined otherwise. A games, films or tv ref is a positive integer; a books ref is an ISBN-13 or an ISBN-10 whose check digit may be an X. Everything else is the 404 an unknown `:type` segment already gets, and the adapters are handed a value they can interpolate: the games adapter puts it in an apicalypse `where id = <ref>`, and the books adapter in a Google Books url that carries `GOOGLE_API_KEY` and does not encode it, so an `&` in the segment was query parameters of the caller's choosing on a request of ours.

The shapes are narrow deliberately, and I checked them against the data rather than guessing: all 1128 `igdb` refs, all 2034 `tmdb` refs and all 632 book refs in the works collections pass, so nothing that is reachable today stops being reachable. Leading zeros are refused because neither API writes one — `tmdb__007` could only be a cache miss that then caches the same work a second time — and a lowercase `x` check digit is refused for the same reason. Each pattern ends `(?![\s\S])` rather than `$`, because `$` also matches before a trailing newline and `%0A` in a url is a newline once `decodeURI` has had it.

**One value, read once.** `retrieveWork` built its cache lookup from the raw segment while the adapter got the decoded one, so the two could be asking after different works. Both now come from the parsed value.

**Order, after #189.** Both checks sit behind `getUserId`, so the gate #189 put on these two routes still answers first: an anonymous caller gets the same 401 whether its ref is malformed, well formed, or names a type that does not exist. Putting the decode ahead of the token would have made a 400 and a 404 into two more things an unauthenticated caller could learn about a url. The harness asserts that for all four cases.

`parseRef` returns `string | undefined` rather than a `Result`, which is the one place I departed from the issue. `work_types.js` is dependency-free on purpose — that is what lets `node --test` cover it with no install, which is how CI runs the suite — so requiring neverthrow there would cost more than the wrapping saves. `controllers/works.js` turns it into a `Result`, exactly as its callers already do for `byType`.

I also left the two adapters alone rather than adding `encodeURIComponent` to `books/google.js`'s `retrieve` alongside the check. The argument for adding it is that `search` in the same file already does it; the argument against, and why I didn't, is that it would put a second and differently-worded idea of a safe ref in a file that no longer decides the question. Happy to add it if you'd rather have the belt and the braces.

**Tests.** `work_types.test.js` gains the cases for `parseRef`: a real ref of each type out of the collections, every type accepting something (a row whose `refShape` nothing answers to would otherwise 404 that whole type in silence), the apicalypse and query-string segments this exists to refuse, the trailing-newline one, and the unknown type. `npm test` is 410 passing on the rebased branch with the dependencies installed and the same without them, and `routes/works.js` still loads under `--no-experimental-require-module`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
