### PR TITLE
fix(auth): bound how long a session may slide, and refuse a key with no bytes

### DIFF
--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -3,6 +3,12 @@
 const { Issuer, generators } = require("openid-client")
 const { SignJWT, jwtVerify } = require("jose")
 const cookie = require("cookie")
+const {
+  VERIFY_OPTIONS,
+  isWithinAbsoluteLifetime,
+  sessionStartedAt,
+  tokenSecret,
+} = require("../utils/session_token")
 
 const NETLIFY_JWT_EXPIRATION_SECONDS = 14 * 24 * 3600
 // cookie's maxAge is in seconds
@@ -10,15 +16,6 @@ const LOGIN_COOKIE_MAX_AGE = 30 * 60
 const AUTH0_LOGIN_COOKIE_NAME = "auth0_login_cookie"
 const NETLIFY_COOKIE_NAME = "nf_jwt"
 const isRunningLocally = process.env.NETLIFY_DEV === "true"
-
-/* HS256 signs with bytes, not with a string, and the secret is read at call
-   time rather than at import time so a function that never touches a token
-   does not care whether TOKEN_SECRET is set. */
-const tokenSecret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
-
-/* Naming the algorithm on the way in is what stops a caller choosing it for
-   us by sending a token whose header says something else. */
-const VERIFY_OPTIONS = { algorithms: ["HS256"] }
 
 const getOpenIDClient = async () => {
   const issuer = await Issuer.discover(`https://${process.env.AUTH0_DOMAIN}`)
@@ -30,13 +27,17 @@ const getOpenIDClient = async () => {
 }
 
 //Refer to Netlify Documentation for token formatting - https://docs.netlify.com/visitor-access/role-based-access-control/#external-providers
-const signNetlifyJWT = async ({ aud, sub, roles }) => {
+const signNetlifyJWT = async ({ aud, sub, roles, startedAt }) => {
   const iat = Math.floor(Date.now() / 1000)
   const exp = Math.floor(iat + NETLIFY_JWT_EXPIRATION_SECONDS)
   const tokenPayload = {
     exp,
     iat,
     updated_at: iat,
+    /* A login starts the session here; a renewal passes the original forward
+       untouched, which is the only thing that keeps the sliding window from
+       sliding for ever. See ../utils/session_token.js. */
+    session_started_at: startedAt ?? iat,
     aud,
     sub,
     app_metadata: {
@@ -202,10 +203,23 @@ const handleCallback = async (event) => {
   }
 }
 
+/* Clears the cookie and says so. The frontend keeps using the token it has for
+   the request in flight, and the cleared cookie is what stops it asking
+   again. */
+const sessionOver = () => ({
+  statusCode: 401,
+  headers: {
+    "Cache-Control": "no-store",
+    "Set-Cookie": generateLogoutCookie(),
+  },
+  body: JSON.stringify({ error: "Session expired" }),
+})
+
 /* Re-issues the nf_jwt cookie with a fresh expiry so that an active session
    slides forward instead of hard-expiring NETLIFY_JWT_EXPIRATION_SECONDS after
    login. The frontend calls this once the current token is past halfway
-   through its lifetime. */
+   through its lifetime, and MAX_SESSION_SECONDS is how far forward it may go
+   in total. */
 const handleRenew = async (event) => {
   const currentToken = getNetlifyJWTFromEvent(event)
   if (!currentToken) {
@@ -216,26 +230,35 @@ const handleRenew = async (event) => {
     }
   }
 
+  /* Read before the try, so that an unset TOKEN_SECRET throws out of here
+     rather than being caught below and dressed up as an ordinary expired
+     session. The server being misconfigured is not the user's fault to fix. */
+  const secret = tokenSecret()
+
   let claims
   try {
     /* A token still inside its renewal window verifies fine, so a failure here
        means the session is genuinely over and the user has to log in again. */
-    claims = (await jwtVerify(currentToken, tokenSecret(), VERIFY_OPTIONS)).payload
+    claims = (await jwtVerify(currentToken, secret, VERIFY_OPTIONS)).payload
   } catch (err) {
-    return {
-      statusCode: 401,
-      headers: {
-        "Cache-Control": "no-store",
-        "Set-Cookie": generateLogoutCookie(),
-      },
-      body: JSON.stringify({ error: "Session expired" }),
-    }
+    return sessionOver()
+  }
+
+  /* The bound the sliding window was missing. Renewal asks nothing of Auth0
+     and mints from the presented token's own claims, so without a cap a token
+     stolen once was renewable indefinitely and a user disabled in Auth0 kept a
+     working session for as long as anything went on renewing it. Reaching the
+     cap looks exactly like an expired session from out here, which is both
+     true and none of a stranger's business. */
+  if (!isWithinAbsoluteLifetime(claims, Math.floor(Date.now() / 1000))) {
+    return sessionOver()
   }
 
   const renewedToken = await signNetlifyJWT({
     aud: claims.aud,
     sub: claims.sub,
     roles: claims.app_metadata?.authorization?.roles,
+    startedAt: sessionStartedAt(claims),
   })
 
   return {

--- a/src/api/controllers/auth_token.test.js
+++ b/src/api/controllers/auth_token.test.js
@@ -7,8 +7,14 @@
  * that failed to verify rather than answer `Err`, which reached the caller
  * as a 502, and an expired session is the ordinary way to arrive there.
  *
- * It needs the dependencies, so it **skips itself** when they aren't
- * installed — which is how CI runs the suite.
+ * It covers the whole life of one now — `handleCallback` minting it,
+ * `handleRenew` re-issuing it and `getUserId` reading it — because the rule
+ * this file is mostly about, that a session may slide but not for ever, is
+ * only true if all three agree on it.
+ *
+ * Most of it needs the dependencies, so those tests **skip themselves** when
+ * they aren't installed, which is how CI runs the suite. The rules in
+ * `utils/session_token.js` need nothing, so those tests always run.
  */
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
@@ -18,6 +24,9 @@ const dependenciesInstalled = (() => {
     require('jose')
     require('neverthrow')
     require('ramda')
+    // `controllers/auth.js` reaches these two, and its handlers are tested here.
+    require('cookie')
+    require('openid-client')
     return true
   } catch (error) {
     return false
@@ -31,18 +40,68 @@ const options = {
 process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
 process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
 
+process.env.URL = 'https://memo.test'
+process.env.AUTH0_TOKEN_NAMESPACE = 'https://memo.test'
+
+/* The only stand-in in the file, and it stands in for Auth0 rather than for
+   anything about the token: `handleCallback` is where a session's start is
+   minted rather than carried forward, so it is worth reaching, and the only
+   thing between here and it is a discovery request and a code exchange. The
+   token that comes out the other end is verified below by the real jose,
+   exactly as a request to the API would verify it. */
+const auth0Claims = {
+  aud: 'a-client-id',
+  sub: 'auth0|somebody',
+  'https://memo.test/roles': ['user'],
+}
+
+if (dependenciesInstalled) {
+  const Module = require('module')
+  const loadModule = Module._load
+  Module._load = function (request, ...args) {
+    if (request !== 'openid-client') {
+      return loadModule.apply(this, [request, ...args])
+    }
+    class Client {
+      callbackParams() {
+        return {}
+      }
+      async callback() {
+        return { claims: () => auth0Claims }
+      }
+    }
+    return {
+      generators: { nonce: () => 'a-nonce' },
+      Issuer: { discover: async () => ({ Client }) },
+    }
+  }
+}
+
 const jose = dependenciesInstalled ? require('jose') : undefined
+const cookie = dependenciesInstalled ? require('cookie') : undefined
 const { getUserId } = dependenciesInstalled ? require('./utils') : {}
+const { handleRenew, handleCallback } = dependenciesInstalled ? require('./auth') : {}
+
+/* The rules themselves are dependency-free, which is the point of the module. */
+const sessionToken = require('../utils/session_token')
 
 const secret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
+const now = () => Math.floor(Date.now() / 1000)
 
-/** A token shaped like the one `signNetlifyJWT` mints. */
-const sign = ({ sub = 'auth0|somebody', exp, key = secret() } = {}) => {
-  const iat = Math.floor(Date.now() / 1000)
+/**
+ * A token shaped like the one `signNetlifyJWT` mints. `sessionStartedAt` is
+ * left out unless asked for, so the default is a token from before that claim
+ * existed.
+ */
+const sign = ({ sub = 'auth0|somebody', exp, sessionStartedAt, key = secret() } = {}) => {
+  const iat = now()
   return new jose.SignJWT({
     exp: exp ?? iat + 14 * 24 * 3600,
     iat,
     updated_at: iat,
+    ...(sessionStartedAt === undefined
+      ? {}
+      : { session_started_at: sessionStartedAt }),
     aud: 'memo',
     sub,
     app_metadata: { authorization: { roles: ['user'] } },
@@ -54,6 +113,24 @@ const sign = ({ sub = 'auth0|somebody', exp, key = secret() } = {}) => {
 const asEvent = (token) => ({
   headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
 })
+
+const claimsOf = async (token) =>
+  (await jose.jwtVerify(token, secret(), { algorithms: ['HS256'] })).payload
+
+/** Runs `fn` with TOKEN_SECRET set to `value`, or unset when it is undefined. */
+const withSecret = async (value, fn) => {
+  const previous = process.env.TOKEN_SECRET
+  if (value === undefined) {
+    delete process.env.TOKEN_SECRET
+  } else {
+    process.env.TOKEN_SECRET = value
+  }
+  try {
+    return await fn()
+  } finally {
+    process.env.TOKEN_SECRET = previous
+  }
+}
 
 test('a valid token answers with its subject', options, async () => {
   const result = await getUserId(asEvent(await sign({ sub: 'auth0|nil' })))
@@ -113,4 +190,191 @@ test('nothing the token said reaches the caller', options, async () => {
     JSON.stringify(expired._unsafeUnwrapErr()).includes('auth0|private-id'),
     false,
   )
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The secret it is all signed with
+
+test('a TOKEN_SECRET that is not set is refused, not encoded to nothing', async () => {
+  // `TextEncoder.prototype.encode` defaults its argument to '', so an unset
+  // secret was never a missing key here — it was a zero-length one, and HS256
+  // over an empty key signs and verifies consistently enough that nothing
+  // looks wrong from outside while any `sub` at all can be forged.
+  assert.equal(new TextEncoder().encode(undefined).length, 0)
+
+  await withSecret(undefined, () => {
+    assert.throws(() => sessionToken.tokenSecret(), /TOKEN_SECRET/)
+  })
+  await withSecret('', () => {
+    assert.throws(() => sessionToken.tokenSecret(), /TOKEN_SECRET/)
+  })
+
+  assert.ok(sessionToken.tokenSecret().length > 0)
+})
+
+test('a token handled with no TOKEN_SECRET is a fault, not an unauthorized request', options, async () => {
+  // A 401 would send the user off to log in again over something logging in
+  // cannot fix, and would be indistinguishable from an expired session.
+  const token = await sign()
+
+  await withSecret(undefined, async () => {
+    await assert.rejects(async () => getUserId(asEvent(token)), /TOKEN_SECRET/)
+    await assert.rejects(() => handleRenew(asEvent(token)), /TOKEN_SECRET/)
+  })
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// The absolute session lifetime
+
+test('a session may slide, but not past the cap', () => {
+  const cap = sessionToken.MAX_SESSION_SECONDS
+  const at = (startedAt) => ({ session_started_at: startedAt, iat: now() })
+
+  assert.equal(sessionToken.isWithinAbsoluteLifetime(at(now()), now()), true)
+  assert.equal(
+    sessionToken.isWithinAbsoluteLifetime(at(now() - cap + 60), now()),
+    true,
+  )
+  assert.equal(
+    sessionToken.isWithinAbsoluteLifetime(at(now() - cap), now()),
+    false,
+  )
+})
+
+test('a token from before the claim existed is read as starting when it was minted', () => {
+  // The lenient reading, and the one that does not sign everybody out on
+  // deploy. It stops being reachable once every live token has been renewed.
+  const cap = sessionToken.MAX_SESSION_SECONDS
+
+  assert.equal(sessionToken.sessionStartedAt({ iat: 1000 }), 1000)
+  assert.equal(
+    sessionToken.sessionStartedAt({ session_started_at: 7, iat: 1000 }),
+    7,
+  )
+  assert.equal(
+    sessionToken.isWithinAbsoluteLifetime({ iat: now() - 3600 }, now()),
+    true,
+  )
+  assert.equal(
+    sessionToken.isWithinAbsoluteLifetime({ iat: now() - cap }, now()),
+    false,
+  )
+  // Claims saying nothing about when they were issued are not ours to slide.
+  assert.equal(sessionToken.isWithinAbsoluteLifetime({}, now()), false)
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// Renewal
+
+test('renewal slides the expiry forward but not the session start', options, async () => {
+  const startedAt = now() - 40 * 24 * 3600
+  const response = await handleRenew(
+    asEvent(await sign({ sessionStartedAt: startedAt })),
+  )
+
+  assert.equal(response.statusCode, 200)
+  const claims = await claimsOf(JSON.parse(response.body).token)
+  assert.equal(claims.sub, 'auth0|somebody')
+  assert.deepEqual(claims.app_metadata.authorization.roles, ['user'])
+  // The window moved; the thing that bounds it did not.
+  assert.ok(claims.exp > now() + 13 * 24 * 3600)
+  assert.equal(claims.session_started_at, startedAt)
+})
+
+test('a session past the cap is not renewed again', options, async () => {
+  // The token presented is in perfectly good order and has a fortnight left to
+  // run - it is the session behind it that has gone on long enough.
+  const response = await handleRenew(asEvent(await sign({
+    sessionStartedAt: now() - sessionToken.MAX_SESSION_SECONDS - 1,
+  })))
+
+  assert.equal(response.statusCode, 401)
+  // The cleared cookie is what stops the frontend asking again every request.
+  assert.match(response.headers['Set-Cookie'], /nf_jwt=;/)
+})
+
+test('a token from before the claim existed renews, and carries a start from then on', options, async () => {
+  const response = await handleRenew(asEvent(await sign()))
+
+  assert.equal(response.statusCode, 200)
+  const claims = await claimsOf(JSON.parse(response.body).token)
+  assert.ok(Math.abs(claims.session_started_at - now()) < 60)
+})
+
+test('renewal needs a token of ours to renew', options, async (t) => {
+  const otherKey = new TextEncoder().encode('not the secret we sign with')
+
+  const cases = {
+    'no token at all': undefined,
+    'not a JWT': 'nonsense',
+    'signed with another key': await sign({ key: otherKey }),
+    'expired an hour ago': await sign({ exp: now() - 3600 }),
+  }
+
+  for (const [name, token] of Object.entries(cases)) {
+    await t.test(name, async () => {
+      assert.equal((await handleRenew(asEvent(token))).statusCode, 401)
+    })
+  }
+})
+
+///////////////////////////////////////////////////////////////////////////////
+// Login
+
+test('logging in mints the session start the cap is measured from', options, async () => {
+  // Everything else only ever carries this claim forward, so a login that did
+  // not write it would leave every session falling back to the `iat` of
+  // whichever token happened to be in hand - which is reset on every renewal,
+  // and is the whole bug back again with a claim in the payload to hide it.
+  const state = Buffer.from(
+    JSON.stringify({ route: '/films/nil', nonce: 'a-nonce' }),
+  ).toString('base64')
+
+  const response = await handleCallback({
+    headers: {
+      host: 'memo.test',
+      cookie: cookie.serialize(
+        'auth0_login_cookie',
+        JSON.stringify({ nonce: 'a-nonce', state }),
+      ),
+    },
+    body: '',
+  })
+
+  assert.equal(response.statusCode, 302)
+  assert.equal(response.headers.Location, '/films/nil')
+
+  const [netlifyCookie] = response.multiValueHeaders['Set-Cookie']
+  const claims = await claimsOf(cookie.parse(netlifyCookie).nf_jwt)
+
+  assert.equal(claims.sub, 'auth0|somebody')
+  assert.deepEqual(claims.app_metadata.authorization.roles, ['user'])
+  assert.equal(claims.session_started_at, claims.iat)
+  assert.ok(Math.abs(claims.session_started_at - now()) < 60)
+})
+
+test('a login and the renewals after it share one session start', options, async () => {
+  // The cap is only a cap if this holds: two renewals, and the start is still
+  // the one the login wrote.
+  const state = Buffer.from(JSON.stringify({ route: '/' })).toString('base64')
+  const login = await handleCallback({
+    headers: {
+      host: 'memo.test',
+      cookie: cookie.serialize(
+        'auth0_login_cookie',
+        JSON.stringify({ nonce: 'a-nonce', state }),
+      ),
+    },
+    body: '',
+  })
+
+  let token = cookie.parse(login.multiValueHeaders['Set-Cookie'][0]).nf_jwt
+  const startedAt = (await claimsOf(token)).session_started_at
+
+  for (let i = 0; i < 2; i++) {
+    const renewal = await handleRenew(asEvent(token))
+    assert.equal(renewal.statusCode, 200)
+    token = JSON.parse(renewal.body).token
+    assert.equal((await claimsOf(token)).session_started_at, startedAt)
+  }
 })

--- a/src/api/controllers/entries.test.js
+++ b/src/api/controllers/entries.test.js
@@ -32,6 +32,9 @@ const options = {
 }
 
 process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+/* The jose below takes every token at its word, but `getUserId` asks for the
+   signing key before it gets there, and a key of no bytes is refused now. */
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
 
 ///////////////////////////////////////////////////////////////////////////////
 // A Mongo small enough to keep in a variable, with a transaction that is a

--- a/src/api/controllers/name.test.js
+++ b/src/api/controllers/name.test.js
@@ -28,6 +28,9 @@ const options = {
 }
 
 process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+/* The jose below takes every token at its word, but `getUserId` asks for the
+   signing key before it gets there, and a key of no bytes is refused now. */
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
 
 ///////////////////////////////////////////////////////////////////////////////
 // A Mongo small enough to keep in a variable, and an auth check that takes

--- a/src/api/controllers/revisions.test.js
+++ b/src/api/controllers/revisions.test.js
@@ -28,6 +28,9 @@ const options = {
 }
 
 process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+/* The jose below takes every token at its word, but `getUserId` asks for the
+   signing key before it gets there, and a key of no bytes is refused now. */
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
 
 ///////////////////////////////////////////////////////////////////////////////
 // A Mongo small enough to keep in a variable, and an auth check that takes

--- a/src/api/controllers/utils.js
+++ b/src/api/controllers/utils.js
@@ -9,13 +9,7 @@ const workTypes = require('../utils/work_types')
 const { validateExists } = require('../utils/general')
 const { identity } = require('ramda')
 const { jwtVerify } = require("jose")
-
-/* HS256 verifies against bytes, not a string, and the secret is read at call
-   time so that importing this module does not require it to be set. Naming
-   the algorithm is what stops a caller picking one for us in the token's own
-   header. */
-const tokenSecret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)
-const VERIFY_OPTIONS = { algorithms: ['HS256'] }
+const { tokenSecret, VERIFY_OPTIONS } = require('../utils/session_token')
 
 /**
  * The `sub` of the bearer token, or an unauthorized error.
@@ -33,6 +27,11 @@ const VERIFY_OPTIONS = { algorithms: ['HS256'] }
  * log in again. `ResultAsync.fromPromise` catches the rejection, so a bad
  * token, a tampered one and an expired one are all 401 now. See #139 for the
  * same shape of bug one layer down.
+ *
+ * A missing `TOKEN_SECRET` deliberately does not land here. `tokenSecret`
+ * throws on one, out of this function and out of the handler, because a
+ * server with no signing key is a fault of ours and a 401 would tell the user
+ * to go and log in again over something logging in cannot fix.
  *
  * @type {(event: Event) => ResultAsync<string, Error>}
  */

--- a/src/api/utils/session_token.js
+++ b/src/api/utils/session_token.js
@@ -1,0 +1,103 @@
+/**
+ * @file The rules the `nf_jwt` session token is judged by: the key it is
+ * signed and verified with, the terms it is verified on, and the bound on how
+ * long one session may go on sliding.
+ *
+ * `controllers/auth.js` mints and renews the token, `controllers/utils.js`
+ * reads the one on an incoming request, and the first two of those had a copy
+ * each. A token is only as good as the weakest place it is checked, so they
+ * are checked in one place now.
+ *
+ * Nothing is required here on purpose: the suite runs with no install, and
+ * these are the parts of the token worth testing without one.
+ */
+
+/**
+ * How long a session may go on renewing itself before Auth0 has to see the
+ * user again.
+ *
+ * The renewal path is the only place this is enforced, so the token in hand
+ * when a session reaches the cap goes on working until its own `exp` — the
+ * true bound is this plus at most one renewal interval. Clamping that last
+ * token's `exp` down to the cap would leave it permanently past the halfway
+ * mark at which the frontend renews, which is a renewal request per request
+ * for the tail of every session; the untidy bound is much the cheaper of the
+ * two.
+ *
+ * Ninety days rather than thirty because #81 was people being signed out too
+ * often and this is a site with a handful of users. The point of the number
+ * is that there is one at all — it is a one-line argument to have.
+ */
+const MAX_SESSION_SECONDS = 90 * 24 * 3600
+
+/* Naming the algorithm on the way in is what stops a caller choosing it for
+   us by sending a token whose header says something else. */
+const VERIFY_OPTIONS = { algorithms: ['HS256'] }
+
+/**
+ * The bytes HS256 signs and verifies with.
+ *
+ * An unset `TOKEN_SECRET` used to pass through here without a word.
+ * `TextEncoder.prototype.encode` defaults its argument to `''` when it is
+ * `undefined`, so what came back was not a weak key but a **zero-length**
+ * one, and HS256 over an empty key signs and verifies perfectly
+ * consistently: nothing looks wrong from the outside while anyone who guesses
+ * that is the situation can mint a token for any `sub` they like.
+ *
+ * Still read at call time rather than at import time, so a function that
+ * never touches a token does not care whether the variable is set. That was
+ * always an argument for checking here rather than for not checking at all.
+ *
+ * @type {() => Uint8Array}
+ */
+const tokenSecret = () => {
+  const secret = new TextEncoder().encode(process.env.TOKEN_SECRET)
+  if (secret.length === 0) {
+    throw new Error('TOKEN_SECRET is not set')
+  }
+  return secret
+}
+
+/**
+ * When the session behind a token began, in seconds.
+ *
+ * `session_started_at` is written at login and carried forward untouched by
+ * every renewal, which is the whole of the mechanism: `iat` says when this
+ * token was minted, and on a token that has been renewed for a year that is
+ * a few days ago.
+ *
+ * Falling back to `iat` is the lenient reading of a token minted before the
+ * claim existed. It grants such a session one more full cap from wherever it
+ * happens to be rather than cutting it short; treating the absence as an
+ * expired session instead would log every signed-in user out on deploy, for
+ * a bound that was not being enforced when their session started. The
+ * fallback stops being reachable a fortnight after that deploy — every token
+ * minted since carries the claim, and the ones that do not have expired on
+ * their own by then.
+ *
+ * @type {(claims: any) => number | undefined}
+ */
+const sessionStartedAt = (claims) =>
+  claims?.session_started_at ?? claims?.iat
+
+/**
+ * Whether the session behind these claims may be renewed again.
+ *
+ * Claims saying nothing at all about when they were issued are not renewed:
+ * `signNetlifyJWT` writes both, so a token without either is not one of ours
+ * to slide forward.
+ *
+ * @type {(claims: any, nowSeconds: number) => boolean}
+ */
+const isWithinAbsoluteLifetime = (claims, nowSeconds) => {
+  const startedAt = sessionStartedAt(claims)
+  return startedAt !== undefined && nowSeconds - startedAt < MAX_SESSION_SECONDS
+}
+
+module.exports = {
+  MAX_SESSION_SECONDS,
+  VERIFY_OPTIONS,
+  tokenSecret,
+  sessionStartedAt,
+  isWithinAbsoluteLifetime,
+}


### PR DESCRIPTION
Closes #177.

A session now carries the time it began, and stops sliding ninety days after it. `signNetlifyJWT` writes `session_started_at` at login, every renewal passes the one it was given straight back through rather than resetting it, and `handleRenew` refuses a token whose session has passed `MAX_SESSION_SECONDS` — 401, cookie cleared, indistinguishable from an ordinary expired session to whoever asked. That is the whole of the fix: no Auth0 round trip, no session store, nothing to revoke against.

Ninety rather than thirty because #81 was people being signed out too often and this is a site with a handful of users. The number is a one-line argument to have, which is the point of it being one line.

**Where it is enforced, and what that leaves.** Only on the renewal path, so the token in hand when a session reaches the cap goes on working until its own `exp` and the true bound is the cap plus at most one renewal interval. The obvious tightening — clamp that last token's `exp` down to the cap — is worse than it looks: it mints a token already past the halfway mark at which the frontend renews, so every request for the tail of the session fires a renewal. The untidy bound is much the cheaper of the two. The frontend needs no change either way: a refused renewal clears `nf_jwt`, and `refreshTokenIfNecessary` does nothing without that cookie, so the request in flight finishes on the token it already had and nothing asks again.

**Tokens already issued.** They have no `session_started_at`, and `sessionStartedAt` falls back to the token's own `iat`. That is deliberately the lenient reading — `iat` is when the token was last renewed rather than when its session began, so an existing session gets one more full cap from wherever it happens to be. The alternative, reading the absence as an expired session, signs every logged-in user out on deploy over a bound that was not being enforced when their session started. The fallback stops being reachable a fortnight after the deploy: every token minted since carries the claim, and the ones that do not have expired on their own by then.

**The secret.** `const tokenSecret = () => new TextEncoder().encode(process.env.TOKEN_SECRET)` was not producing a weak key when `TOKEN_SECRET` was unset — `TextEncoder.prototype.encode` defaults its argument to `''`, so it was producing a **zero-length** one, and HS256 over an empty key signs and verifies consistently enough that nothing looks wrong from outside while anyone who guesses the situation can mint a token for any `sub` they like. It throws on an empty secret now. Reading it at call time stays exactly as it was — the comment defending that was an argument for checking at use rather than for not checking at all. `handleRenew` reads it *before* the `try` that wraps verification, so a server with no signing key is not reported to the user as an expired session, which is a thing logging in again would not fix.

**One copy of each rule.** The secret and `VERIFY_OPTIONS` had a copy in `controllers/auth.js` and another in `controllers/utils.js`. A token is only as good as the weakest place it is checked, so those and the new lifetime rule are in `utils/session_token.js`, which requires nothing — the suite runs with no install, and the parts of a token worth testing without one now are.

The `algorithms: ['HS256']` item in the issue body was already done by #168 and is untouched here.

### Tests

`auth_token.test.js` covers the whole life of a token now rather than just `getUserId` reading one: `handleCallback` minting the session start, `handleRenew` sliding the expiry without moving that start, a session refused past the cap, a claim-less token renewing once and carrying a start from then on, and both `TOKEN_SECRET` holes. The rules in `session_token.js` are dependency-free, so those four run in CI without an install; the rest skip themselves as the file already did.

Reaching `handleCallback` means standing in for Auth0 — a discovery request and a code exchange, stubbed through `Module._load` the way the other controller tests stub their dependencies. `jose` stays real, so the token that comes out of a login is verified exactly as a request to the API verifies it. That is worth having: login is the only place a session start is minted rather than carried forward, and a login that quietly failed to write the claim would leave every session falling back to an `iat` that is reset on every renewal — the original bug back again, with a claim in the payload to hide it.

`entries.test.js`, `name.test.js` and `revisions.test.js` gained a `TOKEN_SECRET` beside the `MONGODB_URL` they already set. Their `jose` is a stand-in that takes every token at its word, but `getUserId` asks for the key before it gets there, and an empty one is refused now.

376 pass with the dependencies installed, 315 pass and 52 skip without them, and every route still loads under `--no-experimental-require-module`.

### Not done

**The login and callback flow has not been exercised by hand against a real Auth0 tenant.** `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID` and `TOKEN_SECRET` live in Netlify's environment and are not reachable from here, so the stub above is as close as this branch got. Worth ten minutes on a deploy preview before merge: log in, confirm the `nf_jwt` payload carries `session_started_at` equal to its `iat`, then confirm a renewal returns the same `session_started_at` with a later `exp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
