### PR TITLE
fix(db_maintenance): drop the two entry fields no reader uses

### DIFF
--- a/src/api/utils/db/queries.js
+++ b/src/api/utils/db/queries.js
@@ -42,11 +42,15 @@ const toUserEntriesPipeline = ({ userId, workCollection, limit }) => [
       as: 'work',
     },
   },
-  // Nobody reads either of these from a list, and they are not small:
+  // Nobody reads any of these from a list, and they are not small:
   // `review` is the whole note, which the reviews endpoint serves when a row
-  // is actually opened, and `userId` is an auth0 id repeated once per entry
-  // for anyone who asks for the list.
-  { $project: { review: 0, userId: 0 } },
+  // is actually opened; `userId` is an auth0 id repeated once per entry for
+  // anyone who asks for the list; and `commonMetadata` is a stale copy of the
+  // work that the `$lookup` above has just fetched the live version of — the
+  // caller overwrites it with `work.data` on the way out, so every byte of it
+  // crossed the wire to be thrown away. 1.2 MB of that on a four-list profile
+  // load. See #176.
+  { $project: { review: 0, userId: 0, commonMetadata: 0 } },
 ]
 
 /**

--- a/src/api/utils/db/queries.test.js
+++ b/src/api/utils/db/queries.test.js
@@ -70,7 +70,19 @@ test('the join names the work collection it was given', () => {
 })
 
 test('a list carries neither the notes nor the owner it does not render', () => {
-  assert.deepEqual(stage(filmsOf('u1'), '$project'), { review: 0, userId: 0 })
+  assert.deepEqual(stage(filmsOf('u1'), '$project'), {
+    review: 0,
+    userId: 0,
+    commonMetadata: 0,
+  })
+})
+
+test('the stale copy of the work is dropped, not sent alongside the fresh one', () => {
+  // `commonMetadata` on the document is a pre-migration snapshot of the work
+  // the `$lookup` has just fetched, and the caller overwrites it with
+  // `work.data`. Unprojected it was 1.2 MB read out of Atlas per profile load
+  // to be thrown away in Node. See #176.
+  assert.equal(stage(filmsOf('u1'), '$project').commonMetadata, 0)
 })
 
 test('the pipeline is built fresh, so a caller cannot mutate the next one', () => {

--- a/src/db_maintenance/README.md
+++ b/src/db_maintenance/README.md
@@ -17,7 +17,8 @@ The scripts, and the section below that explains each:
 | `backfill_work_metadata.js` | Re-runs the API adapters over cached works, filling gaps and refreshing stale metadata. | `--apply` |
 | `backfill_game_playtimes.js` | Fills in games with no playtime, from IGDB's `/game_time_to_beats`. | `--apply` |
 | `dedupe_works.js` | Merges works that duplicate each other, repoints the entries and deletes the leftovers. | `--apply` |
-| `prune_orphan_reviews.js` | Deletes reviews whose entry no longer exists, and so which nothing can reach. The one script here that writes outside the work collections. | `--apply` |
+| `prune_orphan_reviews.js` | Deletes reviews whose entry no longer exists, and so which nothing can reach. | `--apply` |
+| `strip_dead_entry_fields.js` | Unsets `review` and `commonMetadata` from entry documents — a duplicated note and a stale copy of the work, neither of which any reader uses. | `--apply` |
 
 Everything marked `--apply` is a **dry run without it**, and takes a backup of
 each collection it writes to first — except `ensure_indexes.js`, which writes
@@ -25,6 +26,12 @@ no documents at all. The two backfills touch the **work** collections only, so
 the overrides a user set by hand, which live on the entry documents, are out
 of reach by construction; `dedupe_works.js` is the one that also writes to the
 entry collections, repointing `workRef` at the document it merged into.
+
+Two scripts write outside the work collections, and both say so in their own
+section below: `prune_orphan_reviews.js` deletes review documents nothing can
+reach, and `strip_dead_entry_fields.js` unsets two named dead fields from
+entry documents. Neither can reach an override, and neither creates or
+deletes an entry.
 
 The commands below are written from this folder, as
 `node scripts/audit_database.js`, but nothing depends on that. The `.env` and
@@ -303,6 +310,81 @@ the work and the entry collection are backed up before anything is written.
 Run it before a full `scripts/backfill_work_metadata.js`, so you aren't
 paying for an API call per duplicate.
 
+## Dead fields on entry documents
+
+Two fields on an entry document are written and never read back:
+
+- **`review`** — a second copy of the note. The note's home is the `*Reviews`
+  collections, which is where `getReview`, the export and the history all read
+  it from, and `toUserEntriesPipeline` projects the entry's copy away
+  specifically so it cannot reach a response.
+- **`commonMetadata`** — a snapshot of the work document the entry points at,
+  taken before the `$lookup` existed. `getUserEntries` sets
+  `commonMetadata: work.data` from the lookup *after* spreading the entry, so
+  the stored value is overwritten on every read. These are not merely
+  redundant, they are stale: they disagree with the `works` collections they
+  mirror.
+
+Measured over `snapshot-2026-08-19T02-51-54-658Z`, the two came to **3.21 MB
+of the entry collections' 4.32 MB** — 1.9 MB of duplicated note across 1034
+entries, and 1.2 MB of stale metadata across 3267 (762 of them literally
+`null`). See #176.
+
+`scripts/strip_dead_entry_fields.js` `$unset`s them. It is a **dry run unless
+you pass `--apply`**, and it dumps each entry collection before writing to it.
+
+```
+node scripts/strip_dead_entry_fields.js
+node scripts/strip_dead_entry_fields.js --fields=commonMetadata
+node scripts/strip_dead_entry_fields.js --apply
+```
+
+Flags: `--only=films,tv,games,books`, `--fields=review,commonMetadata`,
+`--json=path`, `--backup-dir=path`.
+
+**Before it drops a note it proves the other copy is there.** Every entry
+carrying a `review` must have a review document under its `_id` holding the
+same text, verbatim — not merely a review document, the same text. An entry
+that fails is printed and left entirely alone, `commonMetadata` included: a
+document we cannot account for is not one to write to. The check is equality
+rather than existence for a second reason, too. `toSnapshot` takes
+`reviewText ?? entryData.review`, so a revision falls back to the entry's copy
+when the review document has no text, and verbatim equality is exactly the
+condition under which that fallback cannot change its answer.
+
+It is the second script here that writes outside the work collections, and the
+only one that writes to `*Entries`. What bounds it:
+
+- It `$unset`s those two named fields and nothing else. `overrides`, `status`,
+  `score`, the dates and `workRef` are unreachable from it, and an `$unset`
+  can neither create, delete nor repoint a document.
+- It never touches `updatedDate`. A write that bumped it would reorder every
+  list on the site — a visible change to data nobody asked to change.
+- It re-reads the collection afterwards and reports the entry count and what
+  still carries each field, so a run that did something other than what it
+  planned says so rather than exiting quietly.
+
+**Applied to production on 2026-08-19 (UTC)**, against snapshot
+`snapshot-2026-08-19T17-25-19-670Z` — verified first against live
+`countDocuments()` and the manifest's own SHA-256s, all 14 collections
+agreeing. The dry run matched every one of the 1034 notes to its review
+document verbatim and refused none, and found 3267 stale metadata objects
+(762 `null`). Applying removed both. The four entry collections went from
+**4,320,256 bytes to 1,119,513** — 74% gone, and within 5 KB of what #176
+predicted.
+
+Afterwards: entry counts unchanged in all four collections (1527 / 548 / 1089
+/ 660), the audit reports zero dangling `workRef`s and zero unreachable
+reviews, the `*Reviews` collections are unchanged document for document, and
+all 1034 notes were re-read from them verbatim.
+
+The write side is a separate fix: the form's `readForm` sends
+`commonMetadata: null` and `review` on every save, and the update path used to
+store the request body wholesale. #171 (PR #183) validates a PATCH body
+against what an entry may hold instead, which is what stops these coming back.
+Until that lands, a run of this clears the backlog rather than settling the
+question, and an entry edited through the form afterwards carries them again.
+
 ## Backing up the database, with history
 
 `scripts/backup_database.js` writes a **snapshot**: a timestamped directory
@@ -374,9 +456,10 @@ Useful flags: `--dir=path`, `--from=name|path`, `--only=a,b`, `--prune`,
 ## Tests
 
 The parts that decide what to write (`work_metadata_merge.js`,
-`game_playtime_plan.js`), what to delete (`work_dedupe_plan.js`), which
-snapshots a retention policy keeps (`backup_plan.js`) and which indexes are
-missing (`index_plan.js`) are pure and dependency-free, and are covered by
+`game_playtime_plan.js`), what to delete (`work_dedupe_plan.js`,
+`orphan_review_plan.js`, `dead_entry_fields_plan.js`), which snapshots a
+retention policy keeps (`backup_plan.js`) and which indexes are missing
+(`index_plan.js`) are pure and dependency-free, and are covered by
 `node --test`:
 
 ```

--- a/src/db_maintenance/dead_entry_fields_plan.js
+++ b/src/db_maintenance/dead_entry_fields_plan.js
@@ -1,0 +1,217 @@
+/**
+ * @file Decides which entry documents may have their dead fields removed, and
+ * which must be left alone.
+ *
+ * Two fields on an entry document are read by nothing:
+ *
+ * - **`review`** — the note's home is the `*Reviews` collections, which is
+ *   where `getReview`, the export and the history all read it from. The copy
+ *   on the entry is written by the update path and served to no one:
+ *   `toUserEntriesPipeline` in ../api/utils/db/queries.js projects it away
+ *   specifically so it cannot reach a response.
+ * - **`commonMetadata`** — a pre-migration snapshot of the work document the
+ *   entry points at. `getUserEntries` in ../api/controllers/entries.js sets
+ *   `commonMetadata: work.data` from the `$lookup` *after* spreading the
+ *   entry, so the stored value is overwritten on every read whether or not
+ *   the entry has a `workRef` at all. The 23 hand-typed entries that point at
+ *   no work are no exception: they render from `overrides` over the empty
+ *   stand-in, which is what they already do today.
+ *
+ * So `commonMetadata` may go on sight. `review` may not — not because
+ * anything reads it, but because dropping 1034 notes on the *assumption* that
+ * the other copy is there is not the same as knowing it is. This module's
+ * real job is that check, and its answer for an entry it cannot verify is to
+ * leave the whole document alone.
+ *
+ * There is one place `entry.review` is still read: `toSnapshot` in
+ * ../api/utils/revision_history.js takes `reviewText ?? entryData.review`, so
+ * a revision falls back to the entry's copy when the review document has no
+ * text. Verbatim equality is exactly the condition under which that fallback
+ * cannot change its answer — which is the other reason the check is equality
+ * and not merely existence.
+ *
+ * Pure and dependency-free: scripts/strip_dead_entry_fields.js unsets fields
+ * based on what this returns, so the decision is unit tested
+ * (./dead_entry_fields_plan.test.js) rather than discovered in production.
+ */
+
+/** The fields on an entry document that no reader uses. */
+const DEAD_FIELDS = ["review", "commonMetadata"];
+
+/**
+ * Which entries may have which of `fields` unset, and which may not.
+ *
+ * `blocked` is the important return value, and it means the same thing here
+ * as in ./orphan_review_plan.js: a collection read that quietly came back
+ * empty. Planning `review` removals against no reviews at all would call
+ * every entry a mismatch — which is safe, since a mismatch is refused, but it
+ * is safe by accident and reads in the output as a database full of divergent
+ * notes. The combination is never legitimate, so it is refused by name and
+ * the caller is expected to stop.
+ *
+ * An entry whose stored note cannot be matched, verbatim, to a review
+ * document is skipped **entirely** — `commonMetadata` included. The two
+ * fields are unrelated, but the reason to skip is not: a document we do not
+ * understand is not one to write to.
+ *
+ * @typedef {{ _id: any, reason: string, entryChars: number, storedChars: number | undefined }} Mismatch
+ * @type {(entries: any[], reviews: any[], fields?: string[]) => {
+ *   blocked: string | undefined,
+ *   review: { ids: any[], jsonChars: number },
+ *   commonMetadata: { ids: any[], nulls: number, objects: number, jsonChars: number },
+ *   mismatches: Mismatch[],
+ *   totals: {
+ *     entries: number,
+ *     carryingReview: number,
+ *     carryingCommonMetadata: number,
+ *     skipped: number,
+ *   },
+ * }}
+ */
+const planDeadFieldRemoval = (entries, reviews, fields = DEAD_FIELDS) => {
+  if (!Array.isArray(entries) || !Array.isArray(reviews)) {
+    return {
+      ...emptyPlan(),
+      blocked: "entries and reviews must both be arrays",
+    };
+  }
+
+  const wanted = new Set(fields);
+  const unknown = [...wanted].filter((field) => !DEAD_FIELDS.includes(field));
+  if (unknown.length > 0) {
+    return { ...emptyPlan(), blocked: `not a dead field: ${unknown.join(", ")}` };
+  }
+
+  const carryingReview = entries.filter(carriesReview);
+
+  if (carryingReview.length > 0 && reviews.length === 0) {
+    return {
+      ...emptyPlan(),
+      blocked:
+        `${carryingReview.length} entry(s) carry a note but the reviews ` +
+        `collection came back empty — refusing to call every one of them a ` +
+        `mismatch. This is what a failed collection read looks like.`,
+    };
+  }
+
+  const storedTexts = toTextsByEntry(reviews);
+  const plan = emptyPlan();
+  plan.totals.entries = entries.length;
+  plan.totals.carryingReview = carryingReview.length;
+  plan.totals.carryingCommonMetadata =
+    entries.filter(carriesCommonMetadata).length;
+
+  for (const entry of entries) {
+    if (carriesReview(entry)) {
+      const mismatch = toMismatch(entry, storedTexts.get(toRefKey(entry._id)));
+      if (mismatch) {
+        plan.mismatches.push(mismatch);
+        plan.totals.skipped += 1;
+        continue;
+      }
+      if (wanted.has("review")) {
+        plan.review.ids.push(entry._id);
+        plan.review.jsonChars += jsonChars(entry.review);
+      }
+    }
+
+    if (carriesCommonMetadata(entry) && wanted.has("commonMetadata")) {
+      plan.commonMetadata.ids.push(entry._id);
+      plan.commonMetadata.jsonChars += jsonChars(entry.commonMetadata);
+      if (entry.commonMetadata === null) plan.commonMetadata.nulls += 1;
+      else plan.commonMetadata.objects += 1;
+    }
+  }
+
+  return plan;
+};
+
+module.exports = {
+  DEAD_FIELDS,
+  planDeadFieldRemoval,
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Why this entry's note cannot be dropped, or `undefined` if it can.
+ *
+ * The test is that some review document filed under this entry holds the
+ * *same value*, not merely that one exists. An empty note counts: an entry
+ * storing `""` beside a review document storing `""` is verified, and one
+ * storing `""` beside a review document with no `text` field at all is not.
+ * `undefined` and `""` read the same on a page and differently in
+ * `toSnapshot`, which drops an undefined field from a revision instead of
+ * recording it as empty.
+ *
+ * @type {(entry: any, storedTexts: unknown[] | undefined) => Mismatch | undefined}
+ */
+const toMismatch = (entry, storedTexts) => {
+  const texts = storedTexts ?? [];
+  if (texts.length === 0) {
+    return {
+      _id: entry._id,
+      reason: "no review document",
+      entryChars: textLength(entry.review),
+      storedChars: undefined,
+    };
+  }
+  if (texts.some((text) => text === entry.review)) return undefined;
+
+  return {
+    _id: entry._id,
+    reason: "review document holds different text",
+    entryChars: textLength(entry.review),
+    // The longest of them: what getting a mismatch wrong costs is the text
+    // that would go, so the number worth printing is the most there is on the
+    // other side.
+    storedChars: Math.max(...texts.map(textLength)),
+  };
+};
+
+/**
+ * The notes filed under each entry, keyed the way an `_id` compares. An entry
+ * has one review document in practice, but nothing in the schema says so, and
+ * a plan that assumed it would silently compare against whichever of a pair
+ * the driver happened to return first.
+ */
+const toTextsByEntry = (reviews) =>
+  reviews.reduce((byEntry, review) => {
+    const key = toRefKey(review?.entryRef);
+    if (key === undefined) return byEntry;
+    return byEntry.set(key, [...(byEntry.get(key) ?? []), review?.text]);
+  }, new Map());
+
+/**
+ * Presence, not truthiness. A field holding `null` or `""` is still a field
+ * being stored, read out of Atlas and sent, and is exactly as dead as one
+ * holding a kilobyte — 762 of the stored `commonMetadata` are literally
+ * `null`.
+ */
+const carriesReview = (entry) =>
+  entry !== null && typeof entry === "object" && "review" in entry;
+
+const carriesCommonMetadata = (entry) =>
+  entry !== null && typeof entry === "object" && "commonMetadata" in entry;
+
+/** `undefined` and `null` are not ids, and must not compare equal as strings. */
+const toRefKey = (id) =>
+  id === undefined || id === null ? undefined : String(id);
+
+/** What the field costs to store, near enough to size a run by. */
+const jsonChars = (value) => (JSON.stringify(value) ?? "").length;
+
+const textLength = (text) => (typeof text === "string" ? text.length : 0);
+
+const emptyPlan = () => ({
+  blocked: undefined,
+  review: { ids: [], jsonChars: 0 },
+  commonMetadata: { ids: [], nulls: 0, objects: 0, jsonChars: 0 },
+  mismatches: [],
+  totals: {
+    entries: 0,
+    carryingReview: 0,
+    carryingCommonMetadata: 0,
+    skipped: 0,
+  },
+});

--- a/src/db_maintenance/dead_entry_fields_plan.test.js
+++ b/src/db_maintenance/dead_entry_fields_plan.test.js
@@ -1,0 +1,253 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { planDeadFieldRemoval, DEAD_FIELDS } = require("./dead_entry_fields_plan");
+
+const entry = (id, fields = {}) => ({ _id: id, userId: "u1", ...fields });
+const review = (entryRef, text) => ({
+  _id: `r-${entryRef}`,
+  entryRef,
+  ...(text === undefined ? {} : { text }),
+});
+
+const ids = (plan, field) => plan[field].ids;
+
+test("a note that is verbatim in the reviews collection may be dropped", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "the note" })],
+    [review("e1", "the note")]
+  );
+
+  assert.equal(plan.blocked, undefined);
+  assert.deepEqual(ids(plan, "review"), ["e1"]);
+  assert.deepEqual(plan.mismatches, []);
+});
+
+test("a note the reviews collection does not have is refused, and so is the rest of that entry", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "somebody's writing", commonMetadata: { title: "x" } })],
+    [review("other", "unrelated")]
+  );
+
+  // Both fields, not just the note: a document we cannot account for is not
+  // one to write to.
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.deepEqual(ids(plan, "commonMetadata"), []);
+  assert.equal(plan.totals.skipped, 1);
+  assert.equal(plan.mismatches.length, 1);
+  assert.equal(plan.mismatches[0].reason, "no review document");
+  assert.equal(plan.mismatches[0].entryChars, "somebody's writing".length);
+});
+
+test("a note that differs from the stored one is refused, and reported with both sizes", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "the fuller draft" })],
+    [review("e1", "a draft")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.equal(plan.mismatches[0].reason, "review document holds different text");
+  assert.equal(plan.mismatches[0].entryChars, "the fuller draft".length);
+  assert.equal(plan.mismatches[0].storedChars, "a draft".length);
+});
+
+test("verification is equality, not existence — a near-miss is a mismatch", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "the note" })],
+    [review("e1", "the note ")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.equal(plan.mismatches.length, 1);
+});
+
+test("an entry with two review documents is verified by whichever one matches", () => {
+  // Nothing in the schema says an entry has one review, and picking the first
+  // would refuse an entry whose note is sitting right there in the second.
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "the note" })],
+    [review("e1", "an older copy"), review("e1", "the note")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), ["e1"]);
+});
+
+test("an empty note is verified against an empty stored one", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "" })],
+    [review("e1", "")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), ["e1"]);
+});
+
+test("an empty note beside a review document with no text at all is refused", () => {
+  // They read the same on a page and differently in `toSnapshot`, which drops
+  // an undefined field from a revision rather than recording it as empty.
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "" })],
+    [review("e1", undefined)]
+  );
+
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.equal(plan.mismatches[0].reason, "review document holds different text");
+});
+
+test("commonMetadata needs no verification — nothing reads it, so it always goes", () => {
+  const plan = planDeadFieldRemoval(
+    [
+      entry("e1", { commonMetadata: { englishTranslatedTitle: "stale" } }),
+      entry("e2", { commonMetadata: null }),
+      entry("e3"),
+    ],
+    []
+  );
+
+  assert.equal(plan.blocked, undefined);
+  assert.deepEqual(ids(plan, "commonMetadata"), ["e1", "e2"]);
+  assert.equal(plan.commonMetadata.objects, 1);
+  assert.equal(plan.commonMetadata.nulls, 1);
+});
+
+test("a hand-typed entry with no workRef is no exception", () => {
+  // The read path overwrites `commonMetadata` with the `$lookup` result
+  // whether or not the lookup found anything, so these 23 render from
+  // `overrides` over the empty stand-in either way.
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { commonMetadata: { title: "typed in by hand" }, overrides: { title: "t" } })],
+    []
+  );
+
+  assert.deepEqual(ids(plan, "commonMetadata"), ["e1"]);
+});
+
+test("presence and not truthiness: a field holding null is still a field being stored", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: null, commonMetadata: null })],
+    [review("e1", null)]
+  );
+
+  assert.deepEqual(ids(plan, "review"), ["e1"]);
+  assert.deepEqual(ids(plan, "commonMetadata"), ["e1"]);
+});
+
+test("an entry carrying neither field is left out of the plan entirely", () => {
+  const plan = planDeadFieldRemoval([entry("e1"), entry("e2")], []);
+
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.deepEqual(ids(plan, "commonMetadata"), []);
+  assert.equal(plan.totals.entries, 2);
+  assert.equal(plan.totals.carryingReview, 0);
+  assert.equal(plan.totals.carryingCommonMetadata, 0);
+});
+
+test("notes but no reviews at all is refused rather than planned", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "a note", commonMetadata: null })],
+    []
+  );
+
+  assert.match(plan.blocked, /failed collection read/);
+  assert.deepEqual(ids(plan, "review"), []);
+  // Nothing is planned when the read is in doubt, not even the safe half.
+  assert.deepEqual(ids(plan, "commonMetadata"), []);
+});
+
+test("no reviews and no notes is not a failure, just nothing to verify", () => {
+  const plan = planDeadFieldRemoval([entry("e1", { commonMetadata: null })], []);
+
+  assert.equal(plan.blocked, undefined);
+  assert.deepEqual(ids(plan, "commonMetadata"), ["e1"]);
+});
+
+test("a review filed under no entry at all never verifies one by accident", () => {
+  // Without this an entry whose `_id` stringifies to "undefined" would be
+  // matched by a review carrying no `entryRef`.
+  const plan = planDeadFieldRemoval(
+    [entry("undefined", { review: "a note" })],
+    [review(undefined, "a note"), review(null, "a note")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), []);
+  assert.equal(plan.mismatches[0].reason, "no review document");
+});
+
+test("an id compares as an id, whatever type it arrives as", () => {
+  // Fauna-era ids are numeric strings in some documents and numbers in
+  // others; comparing them raw would refuse a perfectly verified note.
+  const plan = planDeadFieldRemoval(
+    [entry(1234, { review: "a note" })],
+    [review("1234", "a note")]
+  );
+
+  assert.deepEqual(ids(plan, "review"), [1234]);
+});
+
+test("--fields restricts what is planned without changing what is verified", () => {
+  const entries = [
+    entry("e1", { review: "the note", commonMetadata: null }),
+    entry("e2", { review: "unverifiable", commonMetadata: null }),
+  ];
+  const reviews = [review("e1", "the note")];
+
+  const metadataOnly = planDeadFieldRemoval(entries, reviews, ["commonMetadata"]);
+
+  assert.deepEqual(ids(metadataOnly, "review"), []);
+  // e2 is still skipped whole: the note it carries is still unaccounted for.
+  assert.deepEqual(ids(metadataOnly, "commonMetadata"), ["e1"]);
+  assert.equal(metadataOnly.mismatches.length, 1);
+
+  const notesOnly = planDeadFieldRemoval(entries, reviews, ["review"]);
+
+  assert.deepEqual(ids(notesOnly, "review"), ["e1"]);
+  assert.deepEqual(ids(notesOnly, "commonMetadata"), []);
+});
+
+test("a field that is not one of the dead ones is refused, not quietly unset", () => {
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { overrides: { title: "x" } })],
+    [],
+    ["overrides"]
+  );
+
+  assert.match(plan.blocked, /not a dead field: overrides/);
+});
+
+test("anything other than two arrays is refused", () => {
+  assert.match(planDeadFieldRemoval(undefined, []).blocked, /must both be arrays/);
+  assert.match(planDeadFieldRemoval([], undefined).blocked, /must both be arrays/);
+});
+
+test("the plan is built fresh, so one call cannot leak into the next", () => {
+  const first = planDeadFieldRemoval([entry("e1", { commonMetadata: null })], []);
+  first.review.ids.push("not from here");
+  first.mismatches.push("nor this");
+
+  const second = planDeadFieldRemoval([entry("e2", { commonMetadata: null })], []);
+
+  assert.deepEqual(ids(second, "review"), []);
+  assert.deepEqual(second.mismatches, []);
+  assert.deepEqual(ids(second, "commonMetadata"), ["e2"]);
+});
+
+test("a blocked plan is built fresh too", () => {
+  const first = planDeadFieldRemoval(undefined, []);
+  first.review.ids.push("not from here");
+
+  assert.deepEqual(ids(planDeadFieldRemoval(undefined, []), "review"), []);
+});
+
+test("the sizes reported are the sizes of what would go", () => {
+  const stale = { englishTranslatedTitle: "a stale copy of the work" };
+  const plan = planDeadFieldRemoval(
+    [entry("e1", { review: "note", commonMetadata: stale })],
+    [review("e1", "note")]
+  );
+
+  assert.equal(plan.review.jsonChars, JSON.stringify("note").length);
+  assert.equal(plan.commonMetadata.jsonChars, JSON.stringify(stale).length);
+});
+
+test("the dead fields are the two the API does not read", () => {
+  assert.deepEqual(DEAD_FIELDS, ["review", "commonMetadata"]);
+});

--- a/src/db_maintenance/scripts/strip_dead_entry_fields.js
+++ b/src/db_maintenance/scripts/strip_dead_entry_fields.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * @file Removes the two fields on an entry document that nothing reads.
+ *
+ * `review` is a second copy of the note whose home is the `*Reviews`
+ * collections, and `commonMetadata` is a pre-migration snapshot of the work
+ * the entry points at, which the read path overwrites from the `$lookup` on
+ * every request. Together they are 3.21 MB of the entry collections' 4.32 MB
+ * — the stale copies disagree with the `works` collections they mirror, and
+ * the notes are read out of Atlas on every list load to be projected away.
+ * See #176 for the measurements and ../dead_entry_fields_plan.js for why each
+ * one is safe to drop.
+ *
+ * This is the second script here that writes outside the work collections,
+ * and unlike ../scripts/prune_orphan_reviews.js it writes to `*Entries`
+ * directly. That is the rule in ../../../CLAUDE.md bent as far as it goes, so
+ * it is bent narrowly:
+ *
+ * - It only ever `$unset`s those two named fields. `overrides`, `status`,
+ *   `score`, the dates and `workRef` are unreachable from here, and the
+ *   `$unset` cannot create, delete or repoint a document.
+ * - It never touches `updatedDate`. A write that bumped it would reorder
+ *   every list in the site, which is a visible change to data nobody asked to
+ *   change.
+ * - **It verifies before it drops a note.** Every entry carrying a `review`
+ *   must have a review document holding the same text, verbatim; an entry
+ *   that fails is reported and left entirely alone, both fields. 1034 notes
+ *   is not something to drop on the assumption the other copy is there.
+ *
+ * The write side that refills these is #171 / PR #183, which validates a
+ * PATCH body instead of storing it wholesale. Until that lands, saving an
+ * entry through the form writes both fields back onto it, so a run of this
+ * clears the backlog rather than settling the question.
+ *
+ * Environment (../.env): MONGODB_URL. No API keys needed.
+ *
+ * Usage:
+ *   node scripts/strip_dead_entry_fields.js
+ *   node scripts/strip_dead_entry_fields.js --only=games
+ *   node scripts/strip_dead_entry_fields.js --fields=commonMetadata
+ *   node scripts/strip_dead_entry_fields.js --apply
+ *
+ * Flags:
+ *   --apply             actually unset (default: dry run)
+ *   --only=a,b          restrict to these types (films, tv, games, books)
+ *   --fields=a,b        restrict to these fields (review, commonMetadata)
+ *   --json=path         write a machine-readable report
+ *   --backup-dir=path   where to put the pre-run backups (default ../backups)
+ */
+require("../env");
+const fs = require("fs");
+const path = require("path");
+const { MongoClient, ServerApiVersion } = require("mongodb");
+const {
+  COLLECTIONS,
+  selectCollections,
+  parseArgs,
+} = require("../work_collections");
+const {
+  DEAD_FIELDS,
+  planDeadFieldRemoval,
+} = require("../dead_entry_fields_plan");
+
+const args = parseArgs(process.argv);
+
+const options = {
+  apply: args.apply === true,
+  fields: args.fields === undefined ? DEAD_FIELDS : String(args.fields).split(","),
+  backupDir: String(args["backup-dir"] ?? path.join(__dirname, "..", "backups")),
+};
+
+let client;
+
+const main = async () => {
+  const selected = selectCollections(args.only);
+  if (selected.length === 0) {
+    console.error(
+      `--only=${args.only} matched nothing. Valid types: ${COLLECTIONS.map(
+        (c) => c.type
+      ).join(", ")}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    options.apply
+      ? "APPLY MODE: dead fields will be unset from entry documents."
+      : "DRY RUN: nothing will be written. Re-run with --apply to commit."
+  );
+  console.log(`Fields: ${options.fields.join(", ")}`);
+
+  client = new MongoClient(process.env.MONGODB_URL, {
+    serverApi: ServerApiVersion.v1,
+  });
+  await client.connect();
+  const db = client.db("memo");
+
+  const report = {};
+  let blocked = false;
+  for (const collection of selected) {
+    const result = await stripCollection(db, collection);
+    report[collection.type] = result;
+    if (result.blocked) blocked = true;
+  }
+
+  summarise(report);
+
+  if (blocked) {
+    console.error(
+      "\nOne or more collections were refused. Nothing was written for those. " +
+        "This means the reviews collection came back empty beside entries that " +
+        "carry notes, which is what a failed read looks like — check the " +
+        "connection before re-running."
+    );
+    process.exitCode = 1;
+  }
+
+  if (args.json) {
+    fs.writeFileSync(String(args.json), JSON.stringify(report, null, 2));
+    console.log(`Full report written to ${args.json}`);
+  }
+
+  await client.close();
+};
+
+const stripCollection = async (db, collection) => {
+  console.log(`\n=== ${collection.entries} ===`);
+
+  const entries = await db.collection(collection.entries).find().toArray();
+  const reviews = await db.collection(collection.reviews).find().toArray();
+
+  const plan = planDeadFieldRemoval(entries, reviews, options.fields);
+
+  if (plan.blocked) {
+    console.error(`  REFUSED: ${plan.blocked}`);
+    return { blocked: plan.blocked };
+  }
+
+  console.log(
+    `  ${plan.totals.entries} entries, ` +
+      `${plan.totals.carryingReview} carrying a note, ` +
+      `${plan.totals.carryingCommonMetadata} carrying stale metadata`
+  );
+  console.log(
+    `  verified and unsettable: ` +
+      `review on ${plan.review.ids.length} (${toKb(plan.review.jsonChars)}), ` +
+      `commonMetadata on ${plan.commonMetadata.ids.length} ` +
+      `(${plan.commonMetadata.nulls} null, ${plan.commonMetadata.objects} stale ` +
+      `objects, ${toKb(plan.commonMetadata.jsonChars)})`
+  );
+
+  if (plan.mismatches.length > 0) {
+    // The lengths, never the text: this is somebody's writing, and a terminal
+    // log is not where it should turn up. Anything listed here is left alone.
+    console.error(
+      `\n  ${plan.mismatches.length} entry(s) REFUSED — the note on the entry ` +
+        `is not verbatim in ${collection.reviews}. Nothing at all was unset ` +
+        `from these:`
+    );
+    for (const mismatch of plan.mismatches) {
+      console.error(
+        `      ${mismatch._id}: ${mismatch.reason} ` +
+          `(entry ${mismatch.entryChars} chars, ` +
+          `stored ${mismatch.storedChars ?? "-"} chars)`
+      );
+    }
+    console.error(
+      `  Read these through the app before deciding. Re-running does not ` +
+        `change the answer: the check is equality, so a note only becomes ` +
+        `droppable once the two copies genuinely agree.\n`
+    );
+  }
+
+  const base = {
+    entries: plan.totals.entries,
+    review: plan.review.ids.length,
+    commonMetadata: plan.commonMetadata.ids.length,
+    reviewChars: plan.review.jsonChars,
+    commonMetadataChars: plan.commonMetadata.jsonChars,
+    mismatches: plan.mismatches,
+    skipped: plan.totals.skipped,
+  };
+
+  const nothingToDo =
+    plan.review.ids.length === 0 && plan.commonMetadata.ids.length === 0;
+  if (!options.apply || nothingToDo) {
+    return { ...base, unset: { review: 0, commonMetadata: 0 } };
+  }
+
+  backup(collection.entries, entries);
+
+  // Two `updateMany`s rather than a bulk write of per-document `$unset`s: the
+  // fields are unset from different sets of entries, but within each set the
+  // operation is identical, so this is the whole job in two round trips.
+  //
+  // `$unset` and not `$set: { field: null }` — a null is still a field being
+  // stored and read out, which is what 762 of these already were. And no
+  // `updatedDate`: bumping it would reorder every list on the site.
+  const unset = {
+    review: await unsetField(db, collection, "review", plan.review.ids),
+    commonMetadata: await unsetField(
+      db,
+      collection,
+      "commonMetadata",
+      plan.commonMetadata.ids
+    ),
+  };
+
+  const remaining = await countRemaining(db, collection, plan);
+  console.log(
+    `  after: ${remaining.entries} entries (was ${plan.totals.entries}), ` +
+      `${remaining.review} still carrying a note, ` +
+      `${remaining.commonMetadata} still carrying stale metadata`
+  );
+
+  if (remaining.entries !== plan.totals.entries) {
+    console.error(
+      `  ENTRY COUNT CHANGED: ${plan.totals.entries} -> ${remaining.entries}. ` +
+        `Restore from the snapshot taken before this run.`
+    );
+    process.exitCode = 1;
+  }
+
+  return { ...base, unset, remaining };
+};
+
+/** @type {(db: any, collection: any, field: string, ids: any[]) => Promise<number>} */
+const unsetField = async (db, collection, field, ids) => {
+  if (ids.length === 0) return 0;
+
+  const result = await db
+    .collection(collection.entries)
+    .updateMany({ _id: { $in: ids } }, { $unset: { [field]: "" } });
+
+  console.log(`  unset ${field} from ${result.modifiedCount} entry(s)`);
+  if (result.modifiedCount !== ids.length) {
+    console.error(
+      `  expected ${ids.length}, modified ${result.modifiedCount} — ` +
+        `something else is writing to ${collection.entries}.`
+    );
+    process.exitCode = 1;
+  }
+  return result.modifiedCount;
+};
+
+/**
+ * What is left, asked of the database rather than inferred from the plan. The
+ * entries a mismatch spared still carry theirs, so this is expected to be
+ * non-zero exactly when something was refused.
+ */
+const countRemaining = async (db, collection, plan) => {
+  const entriesCollection = db.collection(collection.entries);
+  return {
+    entries: await entriesCollection.countDocuments(),
+    review: await entriesCollection.countDocuments({ review: { $exists: true } }),
+    commonMetadata: await entriesCollection.countDocuments({
+      commonMetadata: { $exists: true },
+    }),
+    expectedRefused: plan.totals.skipped,
+  };
+};
+
+const summarise = (report) => {
+  const totals = Object.values(report).reduce(
+    (sum, r) => ({
+      review: sum.review + (r.review ?? 0),
+      commonMetadata: sum.commonMetadata + (r.commonMetadata ?? 0),
+      chars: sum.chars + (r.reviewChars ?? 0) + (r.commonMetadataChars ?? 0),
+      skipped: sum.skipped + (r.skipped ?? 0),
+    }),
+    { review: 0, commonMetadata: 0, chars: 0, skipped: 0 }
+  );
+
+  console.log(
+    `\n${totals.review} note(s) and ${totals.commonMetadata} stale metadata ` +
+      `object(s) ${options.apply ? "removed" : "would be removed"}, ` +
+      `${toKb(totals.chars)} in all.`
+  );
+  if (totals.skipped > 0) {
+    console.log(
+      `${totals.skipped} entry(s) were left untouched because their note ` +
+        `could not be verified. See the per-collection output above.`
+    );
+  }
+};
+
+const backup = (collectionName, documents) => {
+  fs.mkdirSync(options.backupDir, { recursive: true });
+  const file = path.join(
+    options.backupDir,
+    `${collectionName}_${new Date().toISOString().replace(/:/g, "-")}.json`
+  );
+  fs.writeFileSync(file, JSON.stringify(documents, null, 2));
+  console.log(`  backed up ${documents.length} document(s) to ${file}`);
+};
+
+const toKb = (chars) => `${(chars / 1024).toFixed(1)} KB`;
+
+main().catch(async (e) => {
+  console.error(e);
+  process.exitCode = 1;
+  await client?.close();
+});


### PR DESCRIPTION
Closes #176. Two fields on an entry document are written and never read back, and between them they were 3.21 MB of the entry collections' 4.32 MB. `review` duplicates the note whose home is the `*Reviews` collections — where `getReview`, the export and the history all read it from. `commonMetadata` is a copy of the work taken before the `$lookup` existed, and `getUserEntries` sets `commonMetadata: work.data` from that lookup *after* spreading the entry, so the stored value is overwritten on every read. They are not merely redundant, they are stale: they disagree with the `works` they mirror.

This is the stored data plus the one read that was still paying for it. The write side is #171 / PR #183.

## The read

`commonMetadata` was missing from `toUserEntriesPipeline`'s `$project` even though `review` was in it, so 1.2 MB of superseded objects crossed the wire from Atlas on a full four-list profile load, to be overwritten in Node the moment it arrived. That one line is correct regardless of what happens to the stored data, which is why it stands on its own rather than depending on the script below having run.

## The script

`scripts/strip_dead_entry_fields.js` `$unset`s both, a dry run unless given `--apply`, with the planning half in a pure dependency-free `dead_entry_fields_plan.js` and its own tests — the same split as `work_dedupe_plan.js` and `orphan_review_plan.js`, so what gets written is decided somewhere `node --test` can reach without a database.

It is the second script in the folder to write outside the work collections and the only one that writes to `*Entries`, so it is bounded deliberately. It unsets those two named fields and nothing else — `overrides`, `status`, `score`, the dates and `workRef` are unreachable from it, and an `$unset` can neither create, delete nor repoint a document. It never touches `updatedDate`, since a write that bumped it would reorder every list on the site: a visible change to data nobody asked to change. And it re-reads the collection afterwards, reporting the entry count and what still carries each field, so a run that did something other than what it planned says so rather than exiting quietly.

## Verifying before dropping 1034 notes

Dropping a thousand notes on the assumption that the other copy is there is not the same as knowing it is, so the script proves it first: every entry carrying a `review` must have a review document under its `_id` holding that text **verbatim** — not merely a review document, the same text. An entry that fails is printed with the two lengths (never the text; it is somebody's writing and a terminal log is not where it belongs) and left entirely alone, `commonMetadata` included. The fields are unrelated but the reason to skip is not: a document we cannot account for is not one to write to.

The check is equality rather than existence for a second reason, and this one is the interesting half. `toSnapshot` in `revision_history.js` takes `reviewText ?? entryData.review`, so a revision genuinely does fall back to the entry's copy when the review document has no text — `entry.review` is not quite as dead as it looks. Verbatim equality is exactly the condition under which that fallback cannot change its answer.

There is also a `blocked` guard, the same one `orphan_review_plan.js` carries and for the same reason: entries that carry notes beside a reviews collection that came back empty is what a failed read looks like from inside the plan, and it would otherwise be reported as a database full of divergent notes. That combination is refused by name, and nothing is planned for that collection — not even the safe half.

## Applied

Against snapshot `snapshot-2026-08-19T17-25-19-670Z`, taken immediately before and verified first against live `countDocuments()` and the manifest's own SHA-256s, all 14 collections agreeing. The dry run matched every one of the 1034 notes to its review document and refused none, and found 3267 stale metadata objects, 762 of them literally `null`.

| | before | after |
| --- | --- | --- |
| `filmEntries` | 1,100,891 | 394,800 |
| `gameEntries` | 2,280,728 | 371,548 |
| `bookEntries` | 532,464 | 167,979 |
| `tvShowEntries` | 406,173 | 185,186 |
| **total** | **4,320,256** | **1,119,513** |

74% gone, within 5 KB of what #176 predicted. Afterwards: entry counts unchanged in all four collections (1527 / 548 / 1089 / 660), the audit reports zero dangling `workRef`s and zero unreachable reviews, the 23 entries with no linked work are all still there, the `*Reviews` collections are unchanged document for document, and all 1034 notes were re-read from them verbatim. A restore would put any of it back — `restore_backup.js` writes with `replaceOne` from the full snapshot document, so an unset field comes straight back.

## Worth arguing with

Refusing a mismatched entry's `commonMetadata` as well as its `review` couples two unrelated fields. I took "refuse to touch those entries" at its word, and it cost nothing here — there were no mismatches — but the alternative is defensible.

`--fields=` exists so the safe half can be applied without the note half. Nothing needed it this time.

Until #183 lands, `readForm` still sends both fields on every save, so an entry edited through the form carries them again. This run clears the backlog rather than settling the question.
