### PR TITLE
chore(ci): stop installing the Netlify CLI to build the site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+# A branch that gets three pushes in a minute had three full runs going at
+# once, and the two the reviewer will never look at were still holding runners
+# the third one needed. Cancelling is right for a pull request, where only the
+# head commit's answer is ever read, and wrong for main, where every commit's
+# result is the record of whether that commit was good — hence the condition
+# rather than a plain `true`.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -23,8 +33,13 @@ jobs:
 
       # Cheap guard against a typo in the files the tests don't reach —
       # the Netlify functions and the frontend globals.
+      #
+      # One `node --check` per file is one process per file, and there are 154
+      # of them — the spawning, not the parsing, is the cost. `-P4` runs a few
+      # at a time; `-n1` stays because `node --check` reads a single file, and
+      # xargs still fails the step if any one of them exits non-zero.
       - name: Syntax check every JS file
-        run: git ls-files '*.js' | xargs -n1 node --check
+        run: git ls-files '*.js' | xargs -n1 -P4 node --check
 
   # The job above checks the inputs; this one checks what ships. `node --check`
   # reads each tracked file on its own, and `bundle.test.js` reconstructs the
@@ -50,7 +65,18 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      # `--omit=dev` because the devDependencies are almost the whole install:
+      # 1319 of the 1575 packages in the lockfile are `netlify-cli` and its
+      # tree, which is here so that `npx netlify dev` works on a laptop and
+      # which nothing in CI or on Netlify ever runs. Installing all of it took
+      # longer than every check in this file put together.
+      #
+      # What makes that safe is that `cross-env` is a `dependency`: `npm run
+      # build` calls it, so it is needed wherever the site is built rather than
+      # only where it is developed. Moving it back under devDependencies would
+      # break this job and the Netlify build with it, which is the one thing to
+      # watch if these lists are ever tidied.
+      - run: npm ci --omit=dev
 
       # The functions are CommonJS, and the runtime they get cannot `require`
       # an ES module. Node 22 can — `require(esm)` works from 22.12 — so the

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,17 @@
   # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
   NODE_VERSION = "22"
 
+  # Netlify installs devDependencies too, so its build was carrying the same
+  # 1319 packages of `netlify-cli` that CI was — a deploy preview reinstalling
+  # the Netlify CLI on Netlify. Nothing the build runs comes from that list:
+  # `npm run build` needs `cross-env` and Eleventy, and `cross-env` is a
+  # `dependency` for exactly this reason.
+  #
+  # Unlike the CI flag this one cannot be checked from a laptop; the deploy
+  # preview on the pull request that adds it is the test. If it ever stops
+  # being honoured the build gets slower, not wrong.
+  NPM_FLAGS = "--omit=dev"
+
 # There is deliberately no `[[headers]]` block here. #157 declared
 # `Cache-Control` for `/js/*` and `/css/*` this way and it never applied:
 # production kept answering the hashed bundle `public,max-age=0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@netlify/functions": "^2.5.1",
         "axios": "^1.13.1",
         "cookie": "^0.7.2",
+        "cross-env": "^7.0.3",
         "dotenv": "^17.2.3",
         "html-minifier": "^4.0.0",
         "igdb-api-node": "^5.0.1",
@@ -29,7 +30,6 @@
       },
       "devDependencies": {
         "@types/igdb-api-node": "^5.0.0",
-        "cross-env": "5.2.0",
         "netlify-cli": "^17.16.1",
         "typescript": "^4.5.0-dev.20210930"
       }
@@ -813,45 +813,35 @@
       }
     },
     "node_modules/cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "^7.0.1"
       },
       "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       },
       "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1712,20 +1702,11 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/iso-639-1": {
       "version": "3.1.6",
@@ -18096,12 +18077,6 @@
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-4.3.1.tgz",
       "integrity": "sha512-+vxjSaiDWjAj6kR6KKW0YDuV6O4UCNWGAO8m8ITjFKPWcTmU1GVnL+J5TAUTKpPnUAHCKDxXpOHVaERid223Ww=="
     },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "node_modules/no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -18275,12 +18250,12 @@
       }
     },
     "node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/picomatch": {
@@ -18555,24 +18530,24 @@
       "license": "ISC"
     },
     "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
       "dependencies": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -18778,15 +18753,18 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {
@@ -19406,34 +19384,21 @@
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
     "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "debug": {
@@ -19972,17 +19937,10 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "iso-639-1": {
       "version": "3.1.6",
@@ -31911,12 +31869,6 @@
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-4.3.1.tgz",
       "integrity": "sha512-+vxjSaiDWjAj6kR6KKW0YDuV6O4UCNWGAO8m8ITjFKPWcTmU1GVnL+J5TAUTKpPnUAHCKDxXpOHVaERid223Ww=="
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -32046,10 +31998,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "picomatch": {
       "version": "4.0.5",
@@ -32230,19 +32181,17 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "slash": {
       "version": "3.0.0",
@@ -32376,10 +32325,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@netlify/functions": "^2.5.1",
     "axios": "^1.13.1",
     "cookie": "^0.7.2",
+    "cross-env": "^7.0.3",
     "dotenv": "^17.2.3",
     "html-minifier": "^4.0.0",
     "igdb-api-node": "^5.0.1",
@@ -35,7 +36,6 @@
   },
   "devDependencies": {
     "@types/igdb-api-node": "^5.0.0",
-    "cross-env": "5.2.0",
     "netlify-cli": "^17.16.1",
     "typescript": "^4.5.0-dev.20210930"
   }


### PR DESCRIPTION
`npm ci` was 23 seconds of the build job's 35, and 1319 of the 1575 packages in the lockfile are `netlify-cli` and its tree. It is a devDependency so that `npx netlify dev` works on a laptop, and nothing in CI or in the Netlify build ever runs it — a deploy preview was reinstalling the Netlify CLI on Netlify. On local disk the same install goes from 54s to 2.7s without those packages. #195 reached the same conclusion from the other direction: 83 of the 118 advisories on this repo are that tree, which is why its gate already audits `--omit=dev`.

The fix is `--omit=dev` rather than dropping the dependency, because the README documents `npx netlify login`, `link` and `dev`, and those should keep working from a plain `npm install`. What makes it safe is moving `cross-env` from `devDependencies` to `dependencies`, where it belonged anyway: `npm run build` calls it, so it is needed wherever the site is *built*, not only where it is developed. That is the one thing to watch if these lists are ever tidied — put it back under devDependencies and both this job and the Netlify build break.

That move is also why `cross-env` goes from a pinned `5.2.0` to `^7.0.3`, which is not incidental tidying. Once it ships, it is inside the tree #195's gate audits, and 5.2.0 fails that gate — `cross-spawn` <6.0.6 and `semver` 5.7.1 are both high-severity ReDoS. 7.0.3 takes `cross-spawn` `^7.0.1`, which resolves to a clean 7.0.6 and drops the `semver` edge entirely; the gate then reports the same eight known packages it reports on main. 10.x is `"type": "module"`, so 7 is the last CommonJS line, the way `jose` stays on 4. `cross-env` is only ever invoked as a script binary and never `require`d, so the functions-runtime rule does not strictly bite here — but there is no reason to be the first to find out.

Two smaller things while here. The syntax check spawned one process per file across 154 files, so 4.0s of process spawning to do 154 parses; `-P4` takes it to 1.7s, and `-n1` stays because `node --check` reads a single file and xargs still fails the step on any non-zero exit. And a `concurrency` group, so a branch pushed three times in a minute stops holding runners for the two answers nobody will read — cancelling on `pull_request` only, since on main each commit's result is the record of whether that commit was good.

### Result

`build` 29–38s → **18s** (including #195's new audit step), `test` 11–12s → **12s**.

### What this does not fix

The checks spinner on the PR page is mostly not this. Measured across 80 jobs, runner allocation is 3s median and 8s at worst, and nothing was queuing. Netlify is the long pole now and runs in parallel regardless. The `NPM_FLAGS` line may help there, but this PR's own builds changed the lockfile and so ran against a cold cache — the first fair read is the next PR that touches nothing.

### Checking it

Rehearsed on local disk against a prod-only install, per the npm-and-Drive rule in `CLAUDE.md`: 405 tests pass, all 154 tracked files parse, all ten routes load under `--no-experimental-require-module`, the build writes every asset it references, `_redirects` and `_headers` ship, the bundle parses, and `check_audit.js` exits 0 with nothing new.

The `NPM_FLAGS` line in `netlify.toml` is the one thing that cannot be checked from a laptop — this PR's own deploy preview is the test. The failure mode is mild: if Netlify ever stops honouring it, the build gets slower, not wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
