### PR TITLE
feat(ci): make the functions runtime visible to the repo, and assertable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
-  command = "npm run build"
+  # TEMPORARY, deleted with `scripts/probe_build_env.js` before this PR
+  # leaves draft: reports what the build can see of
+  # `AWS_LAMBDA_JS_RUNTIME` (#185, #190).
+  command = "npm run build && node scripts/probe_build_env.js"
   publish = "dist"
 
 [build.environment]

--- a/scripts/probe_build_env.js
+++ b/scripts/probe_build_env.js
@@ -1,0 +1,34 @@
+/**
+ * @file THROWAWAY, like `src/api/routes/runtime_probe.js`. Deleted before this
+ * PR leaves draft — see #185 and #190.
+ *
+ * The probe function reports what the *runtime* sees. This reports what the
+ * *build* sees, which is the other half of the question: a check can only fail
+ * a deploy over `AWS_LAMBDA_JS_RUNTIME` if the build is given it. UI variables
+ * are scoped, and a variable scoped to functions alone would be invisible here
+ * while still pinning the runtime.
+ *
+ * Netlify build logs are not readable from a laptop, so this writes its answer
+ * where the deploy will serve it: `_redirects` sends `/js/*` to itself with a
+ * forced rule, so a file under `dist/js` is one of the few things that comes
+ * back as itself rather than as the homepage's HTML.
+ *
+ * Named keys only — never the environment wholesale. `MONGODB_URL` and four
+ * API keys are in it.
+ */
+const fs = require('node:fs')
+const path = require('node:path')
+
+const REPORT = path.join('dist', 'js', 'build_env.json')
+
+const report = {
+  'process.version': process.version,
+  AWS_LAMBDA_JS_RUNTIME: process.env.AWS_LAMBDA_JS_RUNTIME ?? null,
+  NODE_VERSION: process.env.NODE_VERSION ?? null,
+  NETLIFY: process.env.NETLIFY ?? null,
+  CONTEXT: process.env.CONTEXT ?? null,
+}
+
+fs.mkdirSync(path.dirname(REPORT), { recursive: true })
+fs.writeFileSync(REPORT, `${JSON.stringify(report, null, 2)}\n`)
+console.log(`wrote ${REPORT}\n${JSON.stringify(report, null, 2)}`)

--- a/src/api/routes/runtime_probe.js
+++ b/src/api/routes/runtime_probe.js
@@ -1,0 +1,42 @@
+/**
+ * @file THROWAWAY. Delete before this PR leaves draft — see #185 and #190.
+ *
+ * #190 could say what the functions runtime *is* only by deploying something
+ * like this, and then deleted it, which leaves the repo exactly as unable to
+ * answer the question as it was before. This one asks the next question:
+ * whether the runtime follows `NODE_VERSION` from `netlify.toml` when
+ * `AWS_LAMBDA_JS_RUNTIME` is not set in the Netlify UI. Netlify's docs say it
+ * does, and a claim about this setting has already been misleading once.
+ *
+ * Read it at `<deploy-preview-url>/api/runtime_probe`.
+ *
+ * Deliberately depends on nothing else in this repo: a probe that 502s for an
+ * unrelated reason answers nothing.
+ */
+exports.handler = async (event, context) => ({
+  statusCode: 200,
+  headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  body: JSON.stringify({
+    // The answer. `AWS_EXECUTION_ENV` is the runtime AWS says it started —
+    // `AWS_Lambda_nodejs26.x` — and `process.version` is the Node inside it.
+    // Both, because the mapping between them is what is being tested.
+    version: process.version,
+    AWS_EXECUTION_ENV: process.env.AWS_EXECUTION_ENV ?? null,
+
+    // Whether the UI variable is still set, and whether it reaches the
+    // function at all. A null here while the runtime is still pinned would
+    // mean the deletion had not taken effect rather than that it had.
+    AWS_LAMBDA_JS_RUNTIME: process.env.AWS_LAMBDA_JS_RUNTIME ?? null,
+
+    // Whether `[build.environment]` in `netlify.toml` reaches the runtime as
+    // well as the build. If it does, the runtime can be asserted from inside
+    // a function; if it does not, only the build can compare the two.
+    NODE_VERSION: process.env.NODE_VERSION ?? null,
+
+    // #185's finding, cheap to re-read while we are here: AWS passes
+    // `--no-experimental-require-module` on the command line, so this stays
+    // false however new the runtime is.
+    'features.require_module': String(process.features.require_module),
+    execArgv: process.execArgv,
+  }, null, 2),
+})


### PR DESCRIPTION
**Draft: the experiment is still running.** This currently contains nothing but a throwaway probe. The check it exists to inform lands before it leaves draft, and the probe goes with it.

The problem, found in #185 and written down in #190: the Node version the deployed functions run on is set by `AWS_LAMBDA_JS_RUNTIME`, which Netlify reads only from its UI, CLI or API and deliberately ignores in `netlify.toml`. `NODE_VERSION = "22"` in `netlify.toml` and the two `node-version: 22` pins in CI are all about the build, and none of them about the runtime serving requests. The consequence was not theoretical — the API ran on `nodejs18.x`, deprecated by AWS in September 2025, for years, while every file in the repo said Node 22, and nothing in the repo could have said otherwise.

`src/api/routes/runtime_probe.js` reports `process.version`, `AWS_EXECUTION_ENV`, and whether `AWS_LAMBDA_JS_RUNTIME` and `NODE_VERSION` reach the function at all, at `<deploy-preview-url>/api/runtime_probe`. Netlify's docs say that with `AWS_LAMBDA_JS_RUNTIME` unset the functions runtime follows the build's Node version, and a claim about this setting has already been misleading once, so it gets measured rather than believed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
