### PR TITLE
fix(works): give works.test.js the token secret it needs

### DIFF
--- a/src/api/controllers/works.test.js
+++ b/src/api/controllers/works.test.js
@@ -42,6 +42,7 @@ const options = {
 const { okAsync } = dependenciesInstalled ? require('neverthrow') : {}
 
 process.env.MONGODB_URL = process.env.MONGODB_URL ?? 'mongodb://in-memory'
+process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? 'a-secret-for-the-tests'
 
 ///////////////////////////////////////////////////////////////////////////////
 // A Mongo small enough to keep in a variable, an auth check that takes the


### PR DESCRIPTION
Five of the eight tests in `src/api/controllers/works.test.js` fail with `Error: TOKEN_SECRET is not set` whenever the npm dependencies are installed. `getUserId` in `controllers/utils.js` calls `tokenSecret()`, which since #193 throws on a key with no bytes, and this file never set the variable. `auth_cookies.test.js` sets it, but `node --test` runs each file in its own process, so that assignment does not reach here.

The failures are "a token that does not verify is refused too", "a logged-in user still gets their search", "a logged-in retrieve of a cached work answers from the store", "a logged-in retrieve of an uncached work retrieves it and writes it", and "a logged-in request for an unknown type is a 404".

CI never saw it. The `test` job runs `npm test` with no install, so the file skips itself on its `dependenciesInstalled` guard, and the assertions added by #189 and #192 have therefore never executed there. Those five are the ones that check who reaches the adapter — that it was not called, that nothing was written — which is the part of #174 worth having a test for at all, so it matters that they run somewhere.

The fix is one line, set the way and in the place `MONGODB_URL` already is a line above, matching `auth_cookies.test.js:37`.

Verified on a local-disk copy with `npm ci`: the five fail with exactly that error when the line is removed, all 8 pass with it, and the full `npm test` is 447/447 with dependencies installed.

This does not change what CI runs — the file still skips itself there. Making CI actually run these would mean an installing test job, which is a separate question from whether the file is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
