### PR TITLE
feat(api): upgrade jose to 6.x, now that esbuild inlines it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,24 @@ the API is simply fine — verified on a preview, where `require` of an
 ESM-only package returns cleanly on a runtime still reporting
 `features.require_module: false`.
 
+**`jose` is the first dependency to actually rely on that.** #144 held it
+back for years as the hard one, #170 took it as far as 4.x and recorded
+that `SignJWT` and `jwtVerify` there are already the API 5 and 6 want, and
+#168 tried 6 and was reverted for exactly the reason above. Nothing about
+the package has changed since: `node --no-experimental-require-module -e
+"require('jose')"` still throws `ERR_REQUIRE_ESM` on 6.x. Only the bundler
+underneath it changed, and #170's reading held, so the upgrade was
+packaging rather than a rewrite.
+
+What is worth knowing is that the tree is no longer single-version.
+`openid-client` 5 asks for `jose` ^4, so npm nests a copy under it and
+esbuild inlines both: the session token is signed and verified on 6, while
+login and callback go on reaching 4 through `openid-client`. That is fine
+— separate call graphs, and neither hands the other a key — and `npm ls
+jose` is where it shows up. It stops being true when `openid-client`
+reaches 6, which is a rewrite of that library's API and its own job
+(#182).
+
 **What still bites.** `external_node_modules` bypasses the bundler by
 design, so anything in that list is copied rather than inlined and the
 original rule applies to it unchanged. `mongodb` is there because it reaches

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.2.3",
         "html-minifier": "^4.0.0",
         "igdb-api-node": "^5.0.1",
-        "jose": "^4.15.9",
+        "jose": "^6.2.9",
         "mongodb": "^6.20.0",
         "neverthrow": "^4.3.1",
         "node-themoviedb": "^0.2.8",
@@ -1718,9 +1718,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -18202,6 +18202,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/openid-client/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -19948,9 +19957,9 @@
       "integrity": "sha512-ZFar/L4ngX7wZh2QX+Fiftmuf0igWJsrJtfizrovWifF1gAWkfmRa5Z1m0LQZbm0hKCHRDYhLRSLFrSqNe4EJA=="
     },
     "jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -31959,6 +31968,11 @@
         "oidc-token-hash": "^5.0.1"
       },
       "dependencies": {
+        "jose": {
+          "version": "4.15.9",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+          "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^17.2.3",
     "html-minifier": "^4.0.0",
     "igdb-api-node": "^5.0.1",
-    "jose": "^4.15.9",
+    "jose": "^6.2.9",
     "mongodb": "^6.20.0",
     "neverthrow": "^4.3.1",
     "node-themoviedb": "^0.2.8",


### PR DESCRIPTION
Takes `jose` from 4.15.9 to 6.2.9. It was the last package left on #144's list and the one that list called the hard one, and it has been stuck not on its API but on its packaging.

`jose` 5 and 6 are ESM-only. The functions runtime is started with `--no-experimental-require-module` — #185 read it off `process.execArgv` on the deployed runtime — so `require` of an ES module throws while the module is being read, before any handler runs, and every route 502s at once rather than one endpoint misbehaving. That is what happened to `uuid` 13 in #162, and it is why #168 was reverted. #190 set `node_bundler = "esbuild"`, which inlines dependencies at build time so the deployed function has no module boundary left for the runtime to refuse. This is the first dependency that actually relies on that, and it is a real test of it: `node --no-experimental-require-module -e "require('jose')"` still throws `ERR_REQUIRE_ESM` on 6.2.9, exactly as it did in #168. Nothing about the package changed — only the bundler underneath it.

**No source change**, which is what #170 predicted when it took `jose` to 4.x and recorded that `SignJWT` and `jwtVerify` there are already the API 5 and 6 want. I checked that rather than assumed it. `new SignJWT(payload).setProtectedHeader({ alg, typ }).sign(key)` and `jwtVerify(token, key, { algorithms })` are unchanged across 4, 5 and 6. The 5.0 breaks are `base64url.decode` returning `Uint8Array`, PBES2 needing explicit opt-in via `keyManagementAlgorithms`, `importJWK` no longer returning a `KeyObject` for `oct`, and JWE `zip` removed; the 6.0 breaks are `generateSecret`/`generateKeyPair`/`importJWK` and friends yielding `CryptoKey` instead of `KeyObject`, and Ed448, X448, secp256k1 and RSA1_5 dropped. None of them is on this path — both call sites build the key as a `Uint8Array` from `TextEncoder`, which stays supported for HS256 throughout, and neither imports a JWK or generates a key.

## What was verified

I did not want to find out on production whether esbuild really removes the boundary, so I bundled `src/api/routes/auth.js` with esbuild and loaded the artefact the way the runtime would:

| check | result |
| --- | --- |
| `require('jose')` under `--no-experimental-require-module` | `ERR_REQUIRE_ESM` — genuinely ESM-only |
| `require` of the esbuild artefact under the same flag | loads, `process.features.require_module` is `false` |
| `GET /auth/renew`, no cookie | `401 {"error":"Not logged in"}` |
| `GET /auth/renew`, token signed with another key | `401 {"error":"Session expired"}` |
| `GET /auth/renew`, valid token | `200`, re-issues `nf_jwt` |

`npm test` is 410 passing, 0 skipped — `auth_token.test.js` exercises the real `jose` and ran rather than skipping itself, including the cases for an expired token, a token signed with another key, and the one asserting the algorithm is ours to choose rather than the token's. The four controller tests that stub `jose` through `Module._load` still pass: the stub is unaffected because the source still says `require('jose')`, so `Module._load` intercepts the name before Node ever resolves the package. `node scripts/check_function_dependencies.js` passes, and so does the audit gate — 34 advisories over 8 packages, all known, none of them `jose`.

## The lockfile, and the one thing worth arguing with

Only `jose` moved. I regenerated the lockfile with `npm install --package-lock-only` and diffed it: the top-level bump, and one nested addition. Nothing else shifted — `zod` in particular is still 3.2.0.

That nested addition is the thing to look at. `openid-client` 5.1.10 asks for `jose` `^4.1.4`, so npm keeps a second copy under it and esbuild inlines both. The session token is signed and verified on 6 while login and callback go on reaching 4 through `openid-client`. Two copies of a crypto library in one bundle deserves a second look, and I think it is fine here: they are separate call graphs, neither hands the other a key, and the alternative is holding the API on 4 to preserve a tidiness that buys nothing. It stops being true when `openid-client` reaches 6, which is a rewrite of that library's API and its own job — listed in #182, which also notes that nothing in the suite covers the login flow, so that one needs a manual pass against a real Auth0 tenant.

The bundle is about 1.0mb for the auth route, both copies included.

## Not done here

`CLAUDE.md`'s ES-modules section said `jose` 6 "would have done it again", which stops being true with this branch, so it now records what actually happened and that the tree is no longer single-version. The deploy preview on this PR is the last check: `/api/auth/renew` should answer 401 without a cookie, which is the one place this can still fail.
